### PR TITLE
Add guardian setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ cd .\devbox
 
 If `.env` contains both `CLOUDFLARED_PUBLIC_HOSTNAME` and `CLOUDFLARED_TUNNEL_TOKEN`, `-Public` uses the named Cloudflare tunnel and keeps the MCP URL stable on your domain.
 
+If you want the stack to stay available across logon and recover from basic runtime failures, install the guardian with `.\scripts\Install-ChatGptDevboxGuardian.ps1` for local mode or `.\scripts\Install-ChatGptDevboxGuardian.ps1 -Public -OAuth` for the public OAuth path. Setup and status commands are in [docs/GUARDIAN.md](./docs/GUARDIAN.md).
+
 ## ChatGPT connector values
 
 After startup:

--- a/docs/GUARDIAN.md
+++ b/docs/GUARDIAN.md
@@ -1,0 +1,63 @@
+# Guardian Setup
+
+The guardian keeps the MCP stack available on a Windows workstation by installing two scheduled tasks and a background watcher. It is designed to restart the stack when Docker, the MCP process, or the optional public tunnel becomes unhealthy, while staying idle after an intentional stop.
+
+## Install
+
+Bootstrap the repo first and make sure `.env` reflects the mode you want to keep alive.
+
+Local-only setup:
+
+```powershell
+.\scripts\Install-ChatGptDevboxGuardian.ps1
+```
+
+Public ChatGPT connector with OAuth:
+
+```powershell
+.\scripts\Install-ChatGptDevboxGuardian.ps1 -Public -OAuth
+```
+
+The install script creates these scheduled tasks:
+
+- `ChatGptDevboxGuardian-Logon`
+- `ChatGptDevboxGuardian-KeepAlive`
+
+It also writes guardian state under `run\guardian\` plus `run\guardian.settings.json` and `run\guardian.desired-state.json`. Those files stay local and are already ignored by Git.
+
+## Verify
+
+Use the status helper after install:
+
+```powershell
+.\scripts\Get-ChatGptDevboxGuardianStatus.ps1
+```
+
+Check for these signals:
+
+- both scheduled tasks exist and show `LastTaskResult` `0`
+- `guardian.pid` and `heartbeat.json` exist
+- `state.json` reports `IsHealthy` as `true`
+- `guardian.log` does not show repeated repair failures
+
+## How It Behaves
+
+- `Start-ChatGptDevboxMcp.ps1` writes `ShouldRun=true`, updates guardian settings, and starts the stack normally
+- `Stop-ChatGptDevboxMcp.ps1` writes `ShouldRun=false`, so the guardian stays installed but does not immediately revive an intentionally stopped stack
+- when the desired state is `true`, the watcher checks Docker, the devbox container, the MCP process, local `/healthz`, and public `/healthz` when `-Public` is enabled
+- after repeated unhealthy checks, it reruns `Start-ChatGptDevboxMcp.ps1` with the stored `Public` and `OAuth` mode
+
+Repair output is written to `run\guardian\guardian.log`, `run\guardian\ensure.log`, and timestamped files under `run\guardian\repairs\`.
+
+## Update Or Remove
+
+Re-run the install command any time you want to refresh the scheduled tasks or switch between local and public/OAuth mode.
+
+If you want to remove the guardian completely, unregister both scheduled tasks:
+
+```powershell
+Unregister-ScheduledTask -TaskName 'ChatGptDevboxGuardian-Logon' -Confirm:$false
+Unregister-ScheduledTask -TaskName 'ChatGptDevboxGuardian-KeepAlive' -Confirm:$false
+```
+
+You can leave `run\guardian\` in place for logs, or delete it manually after removing the tasks if you no longer need the repair history.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation guide for a guardian component that maintains the MCP stack availability across user logon and recovers from runtime failures.
  * Documented two installation modes: local-only and public OAuth configurations.
  * Included setup instructions, verification procedures, and operational guidance for status checks, updates, and removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->