### PR TITLE
Add stdin-backed large file write tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,6 @@ See [docs/REPRODUCE.md](./docs/REPRODUCE.md) for a full copy-to-another-machine 
 - `windows_host_exec` is high risk because it gives ChatGPT PowerShell access to the Windows host.
 - `windows_host_run_program` is limited by `HOST_PROGRAM_ALLOWLIST`.
 - Do not commit `.env`, `.env.runtime`, `run/`, `workspace/`, or other live runtime state.
+
+
+It also includes `devbox_write_large_file`, a stdin-backed file writer intended for large generated source files and other payloads that are awkward to pass through shell-sized command strings.

--- a/README.md
+++ b/README.md
@@ -145,3 +145,4 @@ See [docs/REPRODUCE.md](./docs/REPRODUCE.md) for a full copy-to-another-machine 
 
 
 It also includes `devbox_write_large_file`, a stdin-backed file writer intended for large generated source files and other payloads that are awkward to pass through shell-sized command strings.
+It also includes `devbox_read_large_file`, a chunked reader with byte-offset support for inspecting later sections of large logs and generated files.

--- a/src/docker-runtime.js
+++ b/src/docker-runtime.js
@@ -269,6 +269,28 @@ export const writeFileInDevbox = async ({ path, content, append = false, createD
   });
 };
 
+export const writeLargeFileInDevbox = async ({ path, content, append = false, createDirs = true }) => {
+  const script = [
+    "import os, sys",
+    "path = sys.argv[1]",
+    "append = sys.argv[2] == '1'",
+    "create_dirs = sys.argv[3] == '1'",
+    "parent = os.path.dirname(path)",
+    "if create_dirs and parent:",
+    "    os.makedirs(parent, exist_ok=True)",
+    "mode = 'ab' if append else 'wb'",
+    "with open(path, mode) as f:",
+    "    f.write(sys.stdin.buffer.read())",
+  ].join("\n");
+
+  return runProgramInDevbox({
+    program: "python3",
+    args: ["-c", script, path, append ? "1" : "0", createDirs ? "1" : "0"],
+    input: content,
+    timeoutMs: 120000,
+  });
+};
+
 export const searchFilesInDevbox = async ({
   pattern,
   path = config.devboxWorkspacePath,

--- a/src/docker-runtime.js
+++ b/src/docker-runtime.js
@@ -258,6 +258,27 @@ export const readFileInDevbox = async ({ path, maxBytes = 65536 }) =>
     timeoutMs: 30000,
   });
 
+export const readLargeFileInDevbox = async ({ path, offsetBytes = 0, maxBytes = 262144 }) => {
+  const script = [
+    "import os, sys",
+    "path = sys.argv[1]",
+    "offset = int(sys.argv[2])",
+    "max_bytes = int(sys.argv[3])",
+    "if not os.path.isfile(path):",
+    "    print('Not a regular file.', file=sys.stderr)",
+    "    raise SystemExit(1)",
+    "with open(path, 'rb') as f:",
+    "    f.seek(max(0, offset))",
+    "    sys.stdout.buffer.write(f.read(max(1, max_bytes)))",
+  ].join("\n");
+
+  return runProgramInDevbox({
+    program: "python3",
+    args: ["-c", script, path, String(Math.max(0, offsetBytes)), String(Math.max(1, maxBytes))],
+    timeoutMs: 120000,
+  });
+};
+
 export const writeFileInDevbox = async ({ path, content, append = false, createDirs = true }) => {
   const encoded = Buffer.from(content, "utf8").toString("base64");
   const op = append ? ">>" : ">";

--- a/src/server.js
+++ b/src/server.js
@@ -22,6 +22,7 @@ import {
   syncGithubAuthToDevbox,
   stopDevbox,
   writeFileInDevbox,
+  writeLargeFileInDevbox,
 } from "./docker-runtime.js";
 import {
   HostCommandError,
@@ -509,6 +510,35 @@ const buildServer = () => {
         return fromProcessResult(summary, result);
       } catch (error) {
         return errorResult(error, `Failed to write ${path} in the Docker devbox.`);
+      }
+    },
+  );
+
+
+  server.registerTool(
+    "devbox_write_large_file",
+    safeActionTool(
+      {
+        title: "Write Large Docker Devbox File",
+        description: "Use this when you need to create or overwrite a large text file inside the Docker devbox workspace using stdin-backed transfer instead of a shell-sized command line.",
+        inputSchema: {
+          path: z.string().min(1).describe("File path inside the Docker devbox."),
+          content: z.string().describe("UTF-8 file contents to write."),
+          append: z.boolean().default(false).describe("Append to the file instead of overwriting it."),
+          create_dirs: z.boolean().default(true).describe("Create parent directories if they do not exist."),
+        },
+        outputSchema,
+      },
+      "Writing large Docker devbox file",
+      "Large Docker devbox file written",
+    ),
+    async ({ path, content, append, create_dirs: createDirs }) => {
+      try {
+        const result = await writeLargeFileInDevbox({ path, content, append, createDirs });
+        const summary = append ? `Appended large text payload to ${path} in the Docker devbox.` : `Wrote large text payload to ${path} in the Docker devbox.`;
+        return fromProcessResult(summary, result);
+      } catch (error) {
+        return errorResult(error, `Failed to write large text payload to ${path} in the Docker devbox.`);
       }
     },
   );

--- a/src/server.js
+++ b/src/server.js
@@ -16,6 +16,7 @@ import {
   getDevboxVersions,
   listFilesInDevbox,
   readFileInDevbox,
+  readLargeFileInDevbox,
   recreateDevbox,
   restartDevbox,
   searchFilesInDevbox,
@@ -482,6 +483,32 @@ const buildServer = () => {
         return fromProcessResult(`Read ${path} from the Docker devbox.`, result);
       } catch (error) {
         return errorResult(error, `Failed to read ${path} from the Docker devbox.`);
+      }
+    },
+  );
+
+  server.registerTool(
+    "devbox_read_large_file",
+    safeReadOnlyTool(
+      {
+        title: "Read Large Docker Devbox File Chunk",
+        description: "Use this when you need a specific byte range from a larger file inside the Docker devbox, such as log tails or a later section of a generated source file.",
+        inputSchema: {
+          path: z.string().min(1).describe("File path inside the Docker devbox."),
+          offset_bytes: z.number().int().min(0).default(0).describe("Starting byte offset within the file."),
+          max_bytes: z.number().int().min(1).max(2000000).default(262144).describe("Maximum bytes to return from that offset."),
+        },
+        outputSchema,
+      },
+      "Reading large Docker devbox file chunk",
+      "Large Docker devbox file chunk read",
+    ),
+    async ({ path, offset_bytes: offsetBytes, max_bytes: maxBytes }) => {
+      try {
+        const result = await readLargeFileInDevbox({ path, offsetBytes, maxBytes });
+        return fromProcessResult(`Read ${path} from byte ${offsetBytes} in the Docker devbox.`, result);
+      } catch (error) {
+        return errorResult(error, `Failed to read ${path} from byte ${offsetBytes} in the Docker devbox.`);
       }
     },
   );


### PR DESCRIPTION
This adds a dedicated `devbox_write_large_file` MCP tool for larger generated source files and other payloads that are awkward to pass through a shell-sized command string.

What changed:
- add `writeLargeFileInDevbox()` in `src/docker-runtime.js`
- register `devbox_write_large_file` in `src/server.js`
- document the new stdin-backed writer in `README.md`

Why:
- the existing `devbox_write_file` path serializes file contents into a shell command, which is fine for small writes but brittle for much larger payloads
- the new tool streams content over stdin into a small Python writer inside the devbox, avoiding shell command length/quoting limits

Validation performed:
- module import check for `src/docker-runtime.js`
- module import check for `src/server.js` under `MCP_AUTH_MODE=none`
- host-side smoke invocation returned successfully, but I did not get a clean repo-local end-to-end readback under all config-default combinations, so that specific validation remains lighter than I would like


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a large-file read tool supporting offset-based, chunked reads (configurable offset and max bytes) and a large-file write tool supporting stdin-backed uploads, append mode, and optional parent-directory creation.

* **Documentation**
  * Updated Security notes to document both large-file read and write tools, their parameters, and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->