### PR TITLE
Fix large file tools with exact base64 chunking and verified writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,5 +144,5 @@ See [docs/REPRODUCE.md](./docs/REPRODUCE.md) for a full copy-to-another-machine 
 - Do not commit `.env`, `.env.runtime`, `run/`, `workspace/`, or other live runtime state.
 
 
-It also includes `devbox_write_large_file`, a stdin-backed file writer intended for large generated source files and other payloads that are awkward to pass through shell-sized command strings.
-It also includes `devbox_read_large_file`, a chunked reader with byte-offset support for inspecting later sections of large logs and generated files.
+It also includes `devbox_write_large_file`, a base64-backed large file writer that verifies the exact bytes written so agents can mirror payloads without corruption.
+It also includes `devbox_read_large_file`, a base64 chunk reader with real byte offsets, chunk metadata, and paging support for later sections of large logs and generated files.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "git+https://github.com/adybag14-cyber/devbox.git"
   },
   "scripts": {
-    "start": "node src/server.js"
+    "start": "node src/server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.28.0",

--- a/src/docker-runtime.js
+++ b/src/docker-runtime.js
@@ -35,6 +35,18 @@ const runDocker = async (args, options = {}) => {
   }
 };
 
+const parseStructuredStdout = (result, fallbackMessage) => {
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new DockerCommandError(fallbackMessage, {
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    });
+  }
+};
+
 export const getDevboxInfo = async () => {
   try {
     const result = await runDocker([
@@ -259,24 +271,13 @@ export const readFileInDevbox = async ({ path, maxBytes = 65536 }) =>
   });
 
 export const readLargeFileInDevbox = async ({ path, offsetBytes = 0, maxBytes = 262144 }) => {
-  const script = [
-    "import os, sys",
-    "path = sys.argv[1]",
-    "offset = int(sys.argv[2])",
-    "max_bytes = int(sys.argv[3])",
-    "if not os.path.isfile(path):",
-    "    print('Not a regular file.', file=sys.stderr)",
-    "    raise SystemExit(1)",
-    "with open(path, 'rb') as f:",
-    "    f.seek(max(0, offset))",
-    "    sys.stdout.buffer.write(f.read(max(1, max_bytes)))",
-  ].join("\n");
-
-  return runProgramInDevbox({
-    program: "python3",
-    args: ["-c", script, path, String(Math.max(0, offsetBytes)), String(Math.max(1, maxBytes))],
+  const result = await runProgramInDevbox({
+    program: "node",
+    args: ["src/large-file-cli.js", "read", path, String(Math.max(0, offsetBytes)), String(Math.max(1, maxBytes))],
     timeoutMs: 120000,
   });
+
+  return parseStructuredStdout(result, `Large file read for ${path} returned invalid JSON.`);
 };
 
 export const writeFileInDevbox = async ({ path, content, append = false, createDirs = true }) => {
@@ -290,26 +291,21 @@ export const writeFileInDevbox = async ({ path, content, append = false, createD
   });
 };
 
-export const writeLargeFileInDevbox = async ({ path, content, append = false, createDirs = true }) => {
-  const script = [
-    "import os, sys",
-    "path = sys.argv[1]",
-    "append = sys.argv[2] == '1'",
-    "create_dirs = sys.argv[3] == '1'",
-    "parent = os.path.dirname(path)",
-    "if create_dirs and parent:",
-    "    os.makedirs(parent, exist_ok=True)",
-    "mode = 'ab' if append else 'wb'",
-    "with open(path, mode) as f:",
-    "    f.write(sys.stdin.buffer.read())",
-  ].join("\n");
-
-  return runProgramInDevbox({
-    program: "python3",
-    args: ["-c", script, path, append ? "1" : "0", createDirs ? "1" : "0"],
-    input: content,
+export const writeLargeFileInDevbox = async ({
+  path,
+  contentBase64,
+  append = false,
+  createDirs = true,
+  expectedSha256 = null,
+}) => {
+  const result = await runProgramInDevbox({
+    program: "node",
+    args: ["src/large-file-cli.js", "write", path, append ? "1" : "0", createDirs ? "1" : "0", expectedSha256 ?? ""],
+    input: contentBase64,
     timeoutMs: 120000,
   });
+
+  return parseStructuredStdout(result, `Large file write for ${path} returned invalid JSON.`);
 };
 
 export const searchFilesInDevbox = async ({

--- a/src/large-file-cli.js
+++ b/src/large-file-cli.js
@@ -1,0 +1,253 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdir, open, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const sha256Buffer = (value) => createHash("sha256").update(value).digest("hex");
+
+export const hashFileSha256 = async (filePath) =>
+  new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(filePath);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+
+export const decodeBase64Payload = (value) => {
+  const normalized = String(value ?? "").replace(/\s+/g, "");
+  if (normalized.length === 0) {
+    return Buffer.alloc(0);
+  }
+
+  if (normalized.length % 4 !== 0 || /[^A-Za-z0-9+/=]/.test(normalized)) {
+    throw new Error("Invalid base64 payload.");
+  }
+
+  const decoded = Buffer.from(normalized, "base64");
+  if (decoded.toString("base64") !== normalized) {
+    throw new Error("Invalid base64 payload.");
+  }
+
+  return decoded;
+};
+
+export const encodeUtf8Base64 = (value) => Buffer.from(String(value), "utf8").toString("base64");
+
+export const normalizeLargeWritePayload = ({ content, contentBase64 }) => {
+  const hasText = content !== undefined;
+  const hasBase64 = contentBase64 !== undefined;
+
+  if (hasText && hasBase64) {
+    throw new Error("Provide either content or content_base64, not both.");
+  }
+
+  if (!hasText && !hasBase64) {
+    throw new Error("Either content or content_base64 is required.");
+  }
+
+  return hasBase64 ? String(contentBase64) : encodeUtf8Base64(content);
+};
+
+export const summarizeLargeReadData = (data) => ({
+  path: data.path,
+  file_size: data.file_size,
+  offset_bytes_requested: data.offset_bytes_requested,
+  offset_bytes: data.offset_bytes,
+  bytes_requested: data.bytes_requested,
+  bytes_returned: data.bytes_returned,
+  next_offset_bytes: data.next_offset_bytes,
+  eof: data.eof,
+  content_sha256: data.content_sha256,
+  content_base64_chars: data.content_base64.length,
+});
+
+export const summarizeLargeWriteData = (data) => ({
+  path: data.path,
+  append: data.append,
+  previous_file_size: data.previous_file_size,
+  final_file_size: data.final_file_size,
+  bytes_written: data.bytes_written,
+  content_sha256: data.content_sha256,
+  verification_mode: data.verification_mode,
+  verified: data.verified,
+  expected_sha256_verified: data.expected_sha256_verified,
+  target_existed: data.target_existed,
+});
+
+export const readLargeFileChunk = async ({ path: filePath, offsetBytes = 0, maxBytes = 262144 }) => {
+  const fileStat = await stat(filePath);
+  if (!fileStat.isFile()) {
+    throw new Error("Not a regular file.");
+  }
+
+  const offsetRequested = Math.max(0, Number(offsetBytes) || 0);
+  const bytesRequested = Math.max(1, Number(maxBytes) || 0);
+  const actualOffset = Math.min(offsetRequested, fileStat.size);
+  const bytesToRead = Math.max(0, Math.min(bytesRequested, fileStat.size - actualOffset));
+
+  const handle = await open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(bytesToRead);
+    const { bytesRead } =
+      bytesToRead === 0 ? { bytesRead: 0 } : await handle.read(buffer, 0, bytesToRead, actualOffset);
+    const chunk = buffer.subarray(0, bytesRead);
+
+    return {
+      path: filePath,
+      file_size: fileStat.size,
+      offset_bytes_requested: offsetRequested,
+      offset_bytes: actualOffset,
+      bytes_requested: bytesRequested,
+      bytes_returned: chunk.length,
+      next_offset_bytes: actualOffset + chunk.length,
+      eof: actualOffset + chunk.length >= fileStat.size,
+      content_sha256: sha256Buffer(chunk),
+      content_base64: chunk.toString("base64"),
+    };
+  } finally {
+    await handle.close();
+  }
+};
+
+export const writeLargeFileMirror = async ({
+  path: filePath,
+  contentBase64,
+  append = false,
+  createDirs = true,
+  expectedSha256 = null,
+}) => {
+  const payload = decodeBase64Payload(contentBase64);
+  const contentSha256 = sha256Buffer(payload);
+  const normalizedExpectedSha256 = expectedSha256 ? String(expectedSha256).trim().toLowerCase() : "";
+  if (normalizedExpectedSha256 && !/^[a-f0-9]{64}$/.test(normalizedExpectedSha256)) {
+    throw new Error("expected_sha256 must be a 64-character SHA-256 hex string.");
+  }
+  if (normalizedExpectedSha256 && normalizedExpectedSha256 !== contentSha256) {
+    throw new Error("Decoded payload SHA-256 did not match expected_sha256.");
+  }
+
+  let targetExisted = false;
+  let previousFileSize = 0;
+  try {
+    const fileStat = await stat(filePath);
+    if (!fileStat.isFile()) {
+      throw new Error("Target exists but is not a regular file.");
+    }
+    targetExisted = true;
+    previousFileSize = fileStat.size;
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const parentDir = path.dirname(filePath);
+  if (createDirs && parentDir && parentDir !== ".") {
+    await mkdir(parentDir, { recursive: true });
+  }
+
+  await writeFile(filePath, payload, { flag: append ? "a" : "w" });
+
+  const finalStat = await stat(filePath);
+  if (!finalStat.isFile()) {
+    throw new Error("Target is not a regular file after write.");
+  }
+
+  let verified = false;
+  let verificationMode = "";
+  let fileSha256 = null;
+  if (append) {
+    verificationMode = "suffix-bytes";
+    if (payload.length === 0) {
+      verified = true;
+    } else {
+      const handle = await open(filePath, "r");
+      try {
+        const verifyBuffer = Buffer.alloc(payload.length);
+        const { bytesRead } = await handle.read(verifyBuffer, 0, payload.length, previousFileSize);
+        verified = bytesRead === payload.length && verifyBuffer.equals(payload);
+      } finally {
+        await handle.close();
+      }
+    }
+  } else {
+    verificationMode = "whole-file-sha256";
+    fileSha256 = await hashFileSha256(filePath);
+    verified = finalStat.size === payload.length && fileSha256 === contentSha256;
+  }
+
+  if (!verified) {
+    throw new Error("Mirror verification failed after writing the payload.");
+  }
+
+  return {
+    path: filePath,
+    append: Boolean(append),
+    previous_file_size: previousFileSize,
+    final_file_size: finalStat.size,
+    bytes_written: payload.length,
+    content_sha256: contentSha256,
+    verification_mode: verificationMode,
+    verified,
+    expected_sha256_verified: normalizedExpectedSha256 ? true : null,
+    target_existed: targetExisted,
+    file_sha256: fileSha256,
+  };
+};
+
+const readStdinUtf8 = async () => {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+};
+
+export const runLargeFileCli = async (argv) => {
+  const [command, ...args] = argv;
+  if (command === "read") {
+    const [filePath, offsetBytes = "0", maxBytes = "262144"] = args;
+    if (!filePath) {
+      throw new Error("Usage: node src/large-file-cli.js read <path> <offset_bytes> <max_bytes>");
+    }
+    const result = await readLargeFileChunk({
+      path: filePath,
+      offsetBytes: Number(offsetBytes),
+      maxBytes: Number(maxBytes),
+    });
+    process.stdout.write(JSON.stringify(result));
+    return;
+  }
+
+  if (command === "write") {
+    const [filePath, append = "0", createDirs = "1", expectedSha256 = ""] = args;
+    if (!filePath) {
+      throw new Error(
+        "Usage: node src/large-file-cli.js write <path> <append0or1> <create_dirs0or1> [expected_sha256]",
+      );
+    }
+    const stdinBase64 = await readStdinUtf8();
+    const result = await writeLargeFileMirror({
+      path: filePath,
+      contentBase64: stdinBase64,
+      append: append === "1",
+      createDirs: createDirs === "1",
+      expectedSha256: expectedSha256 || null,
+    });
+    process.stdout.write(JSON.stringify(result));
+    return;
+  }
+
+  throw new Error("Usage: node src/large-file-cli.js <read|write> ...");
+};
+
+const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  runLargeFileCli(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/server.js
+++ b/src/server.js
@@ -33,6 +33,11 @@ import {
   runWindowsPowerShell,
 } from "./host-tools.js";
 import { CloudflareAccessOAuthProvider, DemoOAuthProvider } from "./oauth.js";
+import {
+  normalizeLargeWritePayload,
+  summarizeLargeReadData,
+  summarizeLargeWriteData,
+} from "./large-file-cli.js";
 import { trimText } from "./process-utils.js";
 
 const outputSchema = {
@@ -123,7 +128,7 @@ const successResult = (summary, extra = {}) => {
     content: [
       {
         type: "text",
-        text: textFromResult(summary, extra.data, extra.stdout, extra.stderr),
+        text: extra.text ?? textFromResult(summary, extra.data, extra.stdout, extra.stderr),
       },
     ],
     structuredContent,
@@ -492,11 +497,11 @@ const buildServer = () => {
     safeReadOnlyTool(
       {
         title: "Read Large Docker Devbox File Chunk",
-        description: "Use this when you need a specific byte range from a larger file inside the Docker devbox, such as log tails or a later section of a generated source file.",
+        description: "Use this when you need an exact byte range from a larger file inside the Docker devbox. It returns a base64 chunk plus metadata for safe paging without UTF-8 corruption.",
         inputSchema: {
           path: z.string().min(1).describe("File path inside the Docker devbox."),
           offset_bytes: z.number().int().min(0).default(0).describe("Starting byte offset within the file."),
-          max_bytes: z.number().int().min(1).max(2000000).default(262144).describe("Maximum bytes to return from that offset."),
+          max_bytes: z.number().int().min(1).max(524288).default(262144).describe("Maximum raw bytes to return from that offset."),
         },
         outputSchema,
       },
@@ -505,8 +510,12 @@ const buildServer = () => {
     ),
     async ({ path, offset_bytes: offsetBytes, max_bytes: maxBytes }) => {
       try {
-        const result = await readLargeFileInDevbox({ path, offsetBytes, maxBytes });
-        return fromProcessResult(`Read ${path} from byte ${offsetBytes} in the Docker devbox.`, result);
+        const data = await readLargeFileInDevbox({ path, offsetBytes, maxBytes });
+        const summary = `Read ${path} from byte ${offsetBytes} in the Docker devbox.`;
+        return successResult(summary, {
+          data,
+          text: textFromResult(summary, summarizeLargeReadData(data)),
+        });
       } catch (error) {
         return errorResult(error, `Failed to read ${path} from byte ${offsetBytes} in the Docker devbox.`);
       }
@@ -547,25 +556,39 @@ const buildServer = () => {
     safeActionTool(
       {
         title: "Write Large Docker Devbox File",
-        description: "Use this when you need to create or overwrite a large text file inside the Docker devbox workspace using stdin-backed transfer instead of a shell-sized command line.",
+        description: "Use this when you need to create or overwrite a large file inside the Docker devbox workspace using base64-backed transfer with post-write verification.",
         inputSchema: {
           path: z.string().min(1).describe("File path inside the Docker devbox."),
-          content: z.string().describe("UTF-8 file contents to write."),
+          content: z.string().optional().describe("Optional UTF-8 text payload to write. Prefer content_base64 for exact byte preservation."),
+          content_base64: z.string().optional().describe("Base64-encoded raw bytes to write exactly as provided."),
           append: z.boolean().default(false).describe("Append to the file instead of overwriting it."),
           create_dirs: z.boolean().default(true).describe("Create parent directories if they do not exist."),
+          expected_sha256: z.string().regex(/^[A-Fa-f0-9]{64}$/).optional().describe("Optional expected SHA-256 of the decoded payload for end-to-end verification."),
         },
         outputSchema,
       },
       "Writing large Docker devbox file",
       "Large Docker devbox file written",
     ),
-    async ({ path, content, append, create_dirs: createDirs }) => {
+    async ({ path, content, content_base64: contentBase64, append, create_dirs: createDirs, expected_sha256: expectedSha256 }) => {
       try {
-        const result = await writeLargeFileInDevbox({ path, content, append, createDirs });
-        const summary = append ? `Appended large text payload to ${path} in the Docker devbox.` : `Wrote large text payload to ${path} in the Docker devbox.`;
-        return fromProcessResult(summary, result);
+        const normalizedPayload = normalizeLargeWritePayload({ content, contentBase64 });
+        const data = await writeLargeFileInDevbox({
+          path,
+          contentBase64: normalizedPayload,
+          append,
+          createDirs,
+          expectedSha256,
+        });
+        const summary = append
+          ? `Appended large payload to ${path} in the Docker devbox and verified the exact bytes.`
+          : `Wrote large payload to ${path} in the Docker devbox and verified the exact bytes.`;
+        return successResult(summary, {
+          data,
+          text: textFromResult(summary, summarizeLargeWriteData(data)),
+        });
       } catch (error) {
-        return errorResult(error, `Failed to write large text payload to ${path} in the Docker devbox.`);
+        return errorResult(error, `Failed to write large payload to ${path} in the Docker devbox.`);
       }
     },
   );

--- a/test/large-file-cli.test.js
+++ b/test/large-file-cli.test.js
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  decodeBase64Payload,
+  encodeUtf8Base64,
+  normalizeLargeWritePayload,
+  readLargeFileChunk,
+  writeLargeFileMirror,
+} from "../src/large-file-cli.js";
+
+const makeTempDir = () => mkdtemp(path.join(os.tmpdir(), "devbox-large-file-"));
+
+test("readLargeFileChunk returns exact base64 bytes and paging metadata", async () => {
+  const tempDir = await makeTempDir();
+  const filePath = path.join(tempDir, "sample.bin");
+  const payload = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd, 0x41, 0x42, 0x43]);
+  await writeFile(filePath, payload);
+
+  const result = await readLargeFileChunk({ path: filePath, offsetBytes: 2, maxBytes: 4 });
+
+  assert.equal(result.file_size, payload.length);
+  assert.equal(result.offset_bytes_requested, 2);
+  assert.equal(result.offset_bytes, 2);
+  assert.equal(result.bytes_requested, 4);
+  assert.equal(result.bytes_returned, 4);
+  assert.equal(result.next_offset_bytes, 6);
+  assert.equal(result.eof, false);
+  assert.deepEqual(decodeBase64Payload(result.content_base64), payload.subarray(2, 6));
+});
+
+test("readLargeFileChunk clamps later offsets to EOF and returns an empty chunk", async () => {
+  const tempDir = await makeTempDir();
+  const filePath = path.join(tempDir, "tail.bin");
+  const payload = Buffer.from("abcdef", "utf8");
+  await writeFile(filePath, payload);
+
+  const result = await readLargeFileChunk({ path: filePath, offsetBytes: 999, maxBytes: 64 });
+
+  assert.equal(result.offset_bytes, payload.length);
+  assert.equal(result.bytes_returned, 0);
+  assert.equal(result.next_offset_bytes, payload.length);
+  assert.equal(result.eof, true);
+  assert.equal(result.content_base64, "");
+});
+
+test("writeLargeFileMirror writes exact bytes and verifies full-file hash", async () => {
+  const tempDir = await makeTempDir();
+  const filePath = path.join(tempDir, "mirror.bin");
+  const payload = Buffer.from([0x00, 0x7f, 0x80, 0xff, 0x10, 0x20, 0x30]);
+
+  const result = await writeLargeFileMirror({
+    path: filePath,
+    contentBase64: payload.toString("base64"),
+  });
+
+  const written = await readFile(filePath);
+  assert.deepEqual(written, payload);
+  assert.equal(result.bytes_written, payload.length);
+  assert.equal(result.previous_file_size, 0);
+  assert.equal(result.final_file_size, payload.length);
+  assert.equal(result.verification_mode, "whole-file-sha256");
+  assert.equal(result.verified, true);
+  assert.equal(result.content_sha256, result.file_sha256);
+});
+
+test("writeLargeFileMirror appends exact suffix bytes and verifies them", async () => {
+  const tempDir = await makeTempDir();
+  const filePath = path.join(tempDir, "append.bin");
+  await writeFile(filePath, Buffer.from("hello", "utf8"));
+  const suffix = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+
+  const result = await writeLargeFileMirror({
+    path: filePath,
+    contentBase64: suffix.toString("base64"),
+    append: true,
+  });
+
+  const written = await readFile(filePath);
+  assert.deepEqual(written, Buffer.concat([Buffer.from("hello", "utf8"), suffix]));
+  assert.equal(result.previous_file_size, 5);
+  assert.equal(result.final_file_size, 9);
+  assert.equal(result.verification_mode, "suffix-bytes");
+  assert.equal(result.verified, true);
+});
+
+test("writeLargeFileMirror rejects invalid base64 payloads", async () => {
+  const tempDir = await makeTempDir();
+  const filePath = path.join(tempDir, "bad.bin");
+
+  await assert.rejects(
+    () =>
+      writeLargeFileMirror({
+        path: filePath,
+        contentBase64: "not-base64!!!",
+      }),
+    /Invalid base64 payload/,
+  );
+});
+
+test("writeLargeFileMirror rejects mismatched expected_sha256", async () => {
+  const tempDir = await makeTempDir();
+  const filePath = path.join(tempDir, "sha.bin");
+  const payload = Buffer.from("sha-check", "utf8");
+
+  await assert.rejects(
+    () =>
+      writeLargeFileMirror({
+        path: filePath,
+        contentBase64: payload.toString("base64"),
+        expectedSha256: "0".repeat(64),
+      }),
+    /expected_sha256/,
+  );
+});
+
+test("readLargeFileChunk rejects non-regular files", async () => {
+  const tempDir = await makeTempDir();
+  const dirPath = path.join(tempDir, "folder");
+  await mkdir(dirPath);
+
+  await assert.rejects(() => readLargeFileChunk({ path: dirPath }), /Not a regular file/);
+});
+
+test("normalizeLargeWritePayload encodes text and preserves explicit base64", async () => {
+  assert.equal(normalizeLargeWritePayload({ content: "hello" }), encodeUtf8Base64("hello"));
+  assert.equal(normalizeLargeWritePayload({ contentBase64: "aGVsbG8=" }), "aGVsbG8=");
+
+  assert.throws(
+    () => normalizeLargeWritePayload({ content: "hello", contentBase64: "aGVsbG8=" }),
+    /either content or content_base64, not both/i,
+  );
+
+  assert.throws(() => normalizeLargeWritePayload({}), /Either content or content_base64 is required/);
+});


### PR DESCRIPTION
## Summary
- make `devbox_read_large_file` byte-accurate by returning base64 data plus paging metadata instead of raw stdout text
- make `devbox_write_large_file` use base64 transport with post-write verification for exact mirror writes
- add local Node tests for chunk paging, round-trip integrity, append verification, invalid base64, and SHA mismatch cases

## Why
The earlier large-file tools were directionally useful but not actually hardened:
- `devbox_read_large_file` read raw bytes but then handed them back through text-oriented stdout handling, so byte offsets were not truly reliable for arbitrary data
- large reads were also silently constrained by server-side text trimming rather than an explicit chunk contract
- `devbox_write_large_file` accepted text over stdin, which was fine for UTF-8 text but not an honest exact-byte mirror path

This change moves the large-file path onto explicit base64 envelopes with metadata and verification so agents can page through files safely and write payloads without corruption.

## What Changed
- added `src/large-file-cli.js`
  - shared Node implementation for exact chunk reads and verified writes
  - CLI entrypoint used inside the devbox runtime
- updated `src/docker-runtime.js`
  - switched large read/write runtime calls from inline Python snippets to the shared Node large-file module
  - parse structured JSON results from the CLI instead of treating large binary reads as plain stdout text
- updated `src/server.js`
  - `devbox_read_large_file` now returns metadata plus `content_base64`
  - `devbox_write_large_file` now accepts `content_base64` and optional `expected_sha256`
  - preserved optional `content` input for UTF-8 convenience, but exact-byte callers should use `content_base64`
  - large read/write tool text output now summarizes metadata without dumping the full base64 blob into the textual response
- added `test/large-file-cli.test.js`
- added `npm test`
- updated README wording for the large-file tools

## Validation
- `npm test`
  - 8 tests passing
- `node --check src/server.js`
- `node --check src/large-file-cli.js`

## Notes
- `devbox_read_large_file` still pages large content in bounded chunks, but now the contract is explicit: the tool returns exact raw bytes as `content_base64` with `file_size`, `offset_bytes`, `next_offset_bytes`, `bytes_returned`, and `eof`
- `devbox_write_large_file` now verifies the written bytes after the write and fails if mirror verification does not hold


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large file read operations now include pagination, chunk metadata, and accurate byte offsets for improved navigation
  * Large file write operations now support base64 encoding and integrity verification for corruption-free transfers

* **Documentation**
  * Updated utility descriptions for large file operations

* **Tests**
  * Added comprehensive test coverage for file read/write operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->