### PR TITLE
host: elevate windows exec and guardian checks

### DIFF
--- a/scripts/Watch-ChatGptDevboxGuardian.ps1
+++ b/scripts/Watch-ChatGptDevboxGuardian.ps1
@@ -41,6 +41,24 @@ try {
         exit 0
     }
 
+    Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public static class ChatGptDevboxGuardianTokenProbe {
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr OpenProcess(UInt32 access, bool inheritHandle, UInt32 processId);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    public static extern bool OpenProcessToken(IntPtr processHandle, UInt32 desiredAccess, out IntPtr tokenHandle);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    public static extern bool GetTokenInformation(IntPtr tokenHandle, int tokenInfoClass, IntPtr tokenInfo, int tokenInfoLength, out int returnLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool CloseHandle(IntPtr handle);
+}
+"@
+
     function Write-GuardianLog {
         param(
             [Parameter(Mandatory = $true)][string]$Message,
@@ -236,6 +254,81 @@ try {
             Select-Object -First 1
     }
 
+    function Get-ProcessElevationInfo {
+        param([Parameter(Mandatory = $true)][uint32]$ProcessId)
+
+        $PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        $TOKEN_QUERY = 0x0008
+        $TokenElevation = 20
+        $TokenIntegrityLevel = 25
+
+        $processHandle = [ChatGptDevboxGuardianTokenProbe]::OpenProcess($PROCESS_QUERY_LIMITED_INFORMATION, $false, $ProcessId)
+        if ($processHandle -eq [IntPtr]::Zero) {
+            return $null
+        }
+
+        try {
+            $tokenHandle = [IntPtr]::Zero
+            if (-not [ChatGptDevboxGuardianTokenProbe]::OpenProcessToken($processHandle, $TOKEN_QUERY, [ref]$tokenHandle)) {
+                return $null
+            }
+
+            try {
+                $returnLength = 0
+                $elevationBuffer = [Runtime.InteropServices.Marshal]::AllocHGlobal(4)
+                try {
+                    if (-not [ChatGptDevboxGuardianTokenProbe]::GetTokenInformation($tokenHandle, $TokenElevation, $elevationBuffer, 4, [ref]$returnLength)) {
+                        return $null
+                    }
+
+                    $isElevated = ([Runtime.InteropServices.Marshal]::ReadInt32($elevationBuffer) -ne 0)
+                }
+                finally {
+                    [Runtime.InteropServices.Marshal]::FreeHGlobal($elevationBuffer)
+                }
+
+                $integrityLength = 0
+                [void][ChatGptDevboxGuardianTokenProbe]::GetTokenInformation($tokenHandle, $TokenIntegrityLevel, [IntPtr]::Zero, 0, [ref]$integrityLength)
+                $integrityBuffer = [Runtime.InteropServices.Marshal]::AllocHGlobal($integrityLength)
+                try {
+                    if (-not [ChatGptDevboxGuardianTokenProbe]::GetTokenInformation($tokenHandle, $TokenIntegrityLevel, $integrityBuffer, $integrityLength, [ref]$returnLength)) {
+                        return $null
+                    }
+
+                    $sidPtr = [Runtime.InteropServices.Marshal]::ReadIntPtr($integrityBuffer)
+                    $subAuthorityCount = [Runtime.InteropServices.Marshal]::ReadByte($sidPtr, 1)
+                    $ridOffset = 8 + 4 * ($subAuthorityCount - 1)
+                    $rid = [Runtime.InteropServices.Marshal]::ReadInt32($sidPtr, $ridOffset)
+                    $integrity = if ($rid -ge 0x4000) {
+                        'System'
+                    } elseif ($rid -ge 0x3000) {
+                        'High'
+                    } elseif ($rid -ge 0x2000) {
+                        'Medium'
+                    } else {
+                        'Low'
+                    }
+
+                    return [pscustomobject]@{
+                        IsElevated = $isElevated
+                        Integrity = $integrity
+                    }
+                }
+                finally {
+                    [Runtime.InteropServices.Marshal]::FreeHGlobal($integrityBuffer)
+                }
+            }
+            finally {
+                if ($tokenHandle -ne [IntPtr]::Zero) {
+                    [void][ChatGptDevboxGuardianTokenProbe]::CloseHandle($tokenHandle)
+                }
+            }
+        }
+        finally {
+            [void][ChatGptDevboxGuardianTokenProbe]::CloseHandle($processHandle)
+        }
+    }
+
     function Test-ContainerRunning {
         param([string]$ContainerName)
 
@@ -278,6 +371,8 @@ try {
         $publicHealthy = $null
         $mcpProcess = Get-OwnedMcpProcess
         $mcpProcessHealthy = $false
+        $mcpProcessElevated = $null
+        $mcpProcessIntegrity = $null
 
         if ($desiredState.ShouldRun) {
             if (-not $dockerReady) {
@@ -299,7 +394,17 @@ try {
             if (-not $mcpProcess) {
                 $reasons.Add('MCP server process is missing')
             } else {
-                $mcpProcessHealthy = $true
+                $elevationInfo = Get-ProcessElevationInfo -ProcessId ([uint32]$mcpProcess.ProcessId)
+                if ($elevationInfo) {
+                    $mcpProcessElevated = [bool]$elevationInfo.IsElevated
+                    $mcpProcessIntegrity = [string]$elevationInfo.Integrity
+                }
+
+                if ($mcpProcessElevated -ne $true) {
+                    $reasons.Add('MCP server process is not elevated')
+                } else {
+                    $mcpProcessHealthy = $true
+                }
             }
 
             $localHealthy = Test-HealthUrl -Url ("http://127.0.0.1:{0}/healthz" -f $settings.Port)
@@ -325,6 +430,8 @@ try {
             McpProcessId = if ($mcpProcess) { [int]$mcpProcess.ProcessId } else { $null }
             McpProcessCommandLine = if ($mcpProcess) { [string]$mcpProcess.CommandLine } else { $null }
             McpProcessHealthy = $mcpProcessHealthy
+            McpProcessElevated = $mcpProcessElevated
+            McpProcessIntegrity = $mcpProcessIntegrity
             LocalHealth = $localHealthy
             PublicHealth = $publicHealthy
             IsHealthy = ($desiredState.ShouldRun -eq $false) -or ($reasons.Count -eq 0)

--- a/src/host-tools.js
+++ b/src/host-tools.js
@@ -1,4 +1,6 @@
+import os from "node:os";
 import path from "node:path";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 
 import { config } from "./config.js";
 import { SpawnProcessError, spawnProcess } from "./process-utils.js";
@@ -32,25 +34,174 @@ const ensureHostExecEnabled = () => {
 };
 
 const normalizeProgram = (program) => path.win32.basename(String(program)).replace(/\.exe$/i, "").toLowerCase();
+const psSingleQuote = (value) => String(value).replace(/'/g, "''");
+
+export const buildWindowsPowerShellArgs = (command) => {
+  const encodedCommand = Buffer.from(String(command), "utf16le").toString("base64");
+  return ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", encodedCommand];
+};
+
+const buildPowerShellAdminCheckCommand = () => `
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+[Console]::Out.Write((@{
+  isAdmin = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+} | ConvertTo-Json -Compress))
+`;
+
+const readTextFileOrEmpty = async (filePath) => {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return "";
+    }
+
+    throw error;
+  }
+};
+
+export const buildElevatedWindowsPowerShellWrapper = ({ command, workingDir, stdoutPath, stderrPath, exitCodePath }) => {
+  const commandBase64 = Buffer.from(String(command), "utf16le").toString("base64");
+  return `
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+$stdoutPath = '${psSingleQuote(stdoutPath)}'
+$stderrPath = '${psSingleQuote(stderrPath)}'
+$exitCodePath = '${psSingleQuote(exitCodePath)}'
+$commandBase64 = '${commandBase64}'
+Set-Location -LiteralPath '${psSingleQuote(workingDir)}'
+$decodedCommand = [Text.Encoding]::Unicode.GetString([Convert]::FromBase64String($commandBase64))
+$scriptBlock = [ScriptBlock]::Create($decodedCommand)
+$global:LASTEXITCODE = 0
+try {
+  & $scriptBlock 1> $stdoutPath 2> $stderrPath 3>> $stdoutPath 4>> $stdoutPath 5>> $stdoutPath 6>> $stdoutPath
+  $exitCode = if ($global:LASTEXITCODE -is [int]) { [int]$global:LASTEXITCODE } else { 0 }
+} catch {
+  $_ | Out-File -LiteralPath $stderrPath -Encoding utf8 -Append
+  if ($_.ScriptStackTrace) {
+    $_.ScriptStackTrace | Out-File -LiteralPath $stderrPath -Encoding utf8 -Append
+  }
+  $exitCode = 1
+}
+Set-Content -LiteralPath $exitCodePath -Value ([string]$exitCode) -Encoding ascii
+exit $exitCode
+`;
+};
+
+export const buildElevatedWindowsPowerShellLauncher = ({ command, workingDir, stdoutPath, stderrPath, exitCodePath, timeoutMs }) => {
+  const childArgs = buildWindowsPowerShellArgs(
+    buildElevatedWindowsPowerShellWrapper({
+      command,
+      workingDir,
+      stdoutPath,
+      stderrPath,
+      exitCodePath,
+    }),
+  );
+
+  const escapedChildArgs = childArgs.map((arg) => `'${psSingleQuote(arg)}'`).join(", ");
+
+  return `
+$ErrorActionPreference = 'Stop'
+$arguments = @(${escapedChildArgs})
+$process = Start-Process -FilePath 'powershell.exe' -Verb RunAs -PassThru -WindowStyle Hidden -WorkingDirectory '${psSingleQuote(workingDir)}' -ArgumentList $arguments
+if ($null -eq $process) {
+  throw 'Failed to start elevated PowerShell process.'
+}
+if (-not $process.WaitForExit(${Math.max(1, timeoutMs)})) {
+  try {
+    Stop-Process -Id $process.Id -Force -ErrorAction Stop
+  } catch {
+  }
+  throw 'Command timed out after ${Math.max(1, timeoutMs)} ms.'
+}
+exit $process.ExitCode
+`;
+};
 
 export const getHostToolStatus = () => ({
   enabled: config.enableWindowsHostExec,
   defaultWorkdir: config.hostDefaultWorkdir,
   allowlist: config.hostProgramAllowlist,
+  resolvedNodeExe: config.nodeExe,
+  windowsHostExecDefaultsToAdmin: true,
 });
+
+export const resolveHostProgramExecutable = (program) => {
+  const normalizedProgram = normalizeProgram(program);
+  if (normalizedProgram === "node") {
+    return config.nodeExe;
+  }
+
+  return program;
+};
 
 export const runWindowsPowerShell = async ({ command, workingDir = config.hostDefaultWorkdir, timeoutMs }) => {
   ensureHostExecEnabled();
 
   try {
-    return await spawnProcess(
-      "powershell.exe",
-      ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command],
-      {
+    const adminCheck = await spawnProcess("powershell.exe", buildWindowsPowerShellArgs(buildPowerShellAdminCheckCommand()), {
+      cwd: workingDir,
+      timeoutMs: Math.min(timeoutMs ?? 15000, 15000),
+    });
+
+    const isAdmin = Boolean(JSON.parse(adminCheck.stdout || "{}").isAdmin);
+    if (isAdmin) {
+      return await spawnProcess("powershell.exe", buildWindowsPowerShellArgs(command), {
         cwd: workingDir,
         timeoutMs,
-      },
-    );
+      });
+    }
+
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "docker-chatgpt-devbox-hostexec-"));
+    const stdoutPath = path.join(tempDir, "stdout.txt");
+    const stderrPath = path.join(tempDir, "stderr.txt");
+    const exitCodePath = path.join(tempDir, "exitcode.txt");
+
+    try {
+      await spawnProcess(
+        "powershell.exe",
+        buildWindowsPowerShellArgs(
+          buildElevatedWindowsPowerShellLauncher({
+            command,
+            workingDir,
+            stdoutPath,
+            stderrPath,
+            exitCodePath,
+            timeoutMs: timeoutMs ?? 300000,
+          }),
+        ),
+        {
+          cwd: workingDir,
+          timeoutMs: (timeoutMs ?? 300000) + 15000,
+        },
+      );
+
+      const [stdout, stderr, exitCodeText] = await Promise.all([
+        readTextFileOrEmpty(stdoutPath),
+        readTextFileOrEmpty(stderrPath),
+        readTextFileOrEmpty(exitCodePath),
+      ]);
+      const parsedExitCode = Number.parseInt(String(exitCodeText).trim() || "0", 10);
+      const exitCode = Number.isFinite(parsedExitCode) ? parsedExitCode : 0;
+
+      if (exitCode !== 0) {
+        throw new HostCommandError(stderr.trim() || stdout.trim() || "Windows PowerShell command failed.", {
+          exitCode,
+          stdout,
+          stderr,
+        });
+      }
+
+      return {
+        stdout,
+        stderr,
+        exitCode,
+      };
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   } catch (error) {
     throw wrapHostError(error, "Windows PowerShell command failed.");
   }
@@ -72,7 +223,7 @@ export const runAllowedProgram = async ({
   }
 
   try {
-    return await spawnProcess(program, args, {
+    return await spawnProcess(resolveHostProgramExecutable(program), args, {
       cwd: workingDir,
       timeoutMs,
     });

--- a/src/server.js
+++ b/src/server.js
@@ -649,7 +649,7 @@ const buildServer = () => {
       {
         title: "Run Windows PowerShell Command",
         description:
-          "Use this when you explicitly need native Windows host tooling rather than the reproducible Docker devbox, such as winget, host Git, host Docker CLI, or PowerShell automation.",
+          "Use this when you explicitly need native Windows host tooling rather than the reproducible Docker devbox, such as winget, host Git, host Docker CLI, or PowerShell automation. This tool defaults to elevated administrator execution and will prompt for UAC when needed.",
         inputSchema: {
           command: z.string().min(1).describe("PowerShell command to run on the Windows host."),
           working_dir: z.string().default(config.hostDefaultWorkdir).describe("Working directory on the Windows host."),

--- a/test/host-tools.test.js
+++ b/test/host-tools.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { spawnProcess } from "../src/process-utils.js";
+
+process.env.MCP_AUTH_MODE = "none";
+process.env.PUBLIC_BASE_URL = "";
+
+const {
+  buildWindowsPowerShellArgs,
+  buildElevatedWindowsPowerShellWrapper,
+  buildElevatedWindowsPowerShellLauncher,
+  resolveHostProgramExecutable,
+  getHostToolStatus,
+} = await import("../src/host-tools.js");
+
+test("buildWindowsPowerShellArgs encodes the original script exactly", () => {
+  const command = "$value = 'A \"quoted\" value with ''single'' quotes'; Write-Output $value";
+  const args = buildWindowsPowerShellArgs(command);
+
+  assert.equal(args[0], "-NoLogo");
+  assert.equal(args[1], "-NoProfile");
+  assert.equal(args[2], "-NonInteractive");
+  assert.equal(args[5], "-EncodedCommand");
+  assert.equal(Buffer.from(args[6], "base64").toString("utf16le"), command);
+});
+
+test("encoded PowerShell execution preserves nested quotes end to end", async () => {
+  const command = "$value = 'A \"quoted\" value with ''single'' quotes'; Write-Output $value";
+  const result = await spawnProcess("powershell.exe", buildWindowsPowerShellArgs(command), {
+    cwd: process.cwd(),
+    timeoutMs: 15000,
+  });
+
+  assert.equal(result.stdout.trim(), "A \"quoted\" value with 'single' quotes");
+});
+
+test("resolveHostProgramExecutable maps node to the real node.exe path", () => {
+  assert.equal(resolveHostProgramExecutable("node"), process.execPath);
+  assert.equal(resolveHostProgramExecutable("node.exe"), process.execPath);
+  assert.match(getHostToolStatus().resolvedNodeExe, /node(\.exe)?$/i);
+});
+
+test("buildElevatedWindowsPowerShellWrapper preserves working directory and output paths", () => {
+  const wrapper = buildElevatedWindowsPowerShellWrapper({
+    command: "Write-Output 'ok'",
+    workingDir: "C:\\Temp\\quoted path",
+    stdoutPath: "C:\\Temp\\stdout.txt",
+    stderrPath: "C:\\Temp\\stderr.txt",
+    exitCodePath: "C:\\Temp\\exit.txt",
+  });
+
+  assert.equal(wrapper.includes("Set-Location -LiteralPath 'C:\\Temp\\quoted path'"), true);
+  assert.equal(wrapper.includes("$stdoutPath = 'C:\\Temp\\stdout.txt'"), true);
+  assert.equal(wrapper.includes("$stderrPath = 'C:\\Temp\\stderr.txt'"), true);
+  assert.equal(wrapper.includes("$exitCodePath = 'C:\\Temp\\exit.txt'"), true);
+  assert.equal(wrapper.includes("$commandBase64 = '"), true);
+});
+
+test("buildElevatedWindowsPowerShellLauncher uses RunAs elevation", () => {
+  const launcher = buildElevatedWindowsPowerShellLauncher({
+    command: "Write-Output 'ok'",
+    workingDir: "C:\\Temp",
+    stdoutPath: "C:\\Temp\\stdout.txt",
+    stderrPath: "C:\\Temp\\stderr.txt",
+    exitCodePath: "C:\\Temp\\exit.txt",
+    timeoutMs: 15000,
+  });
+
+  assert.match(launcher, /Start-Process -FilePath 'powershell\.exe' -Verb RunAs/);
+  assert.match(launcher, /WaitForExit\(15000\)/);
+  assert.match(launcher, /Stop-Process -Id \$process\.Id -Force/);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - MCP server now monitors process elevation status and integrity level classification
  - Windows host command execution defaults to elevated administrator mode with automatic UAC prompting support

* **Documentation**
  - Updated Windows host command tool description to clarify default elevation and UAC behavior

* **Tests**
  - Added test coverage for Windows PowerShell command execution utilities and elevation handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->