### PR TITLE
guardian: persist effective public auth state

### DIFF
--- a/scripts/Start-ChatGptDevboxMcp.ps1
+++ b/scripts/Start-ChatGptDevboxMcp.ps1
@@ -522,9 +522,12 @@ $authMode = if ($OAuth -or $Public) {
     $configuredAuthMode
 }
 
+$effectivePublic = -not [string]::IsNullOrWhiteSpace($publicBaseUrl)
+$effectiveOAuth = -not [string]::IsNullOrWhiteSpace($authMode) -and $authMode -ne "none"
+
 Write-GuardianSettings -RunDir $runDir -Settings @{
-    Public = [bool]$Public
-    OAuth = [bool]$OAuth
+    Public = [bool]$effectivePublic
+    OAuth = [bool]$effectiveOAuth
     Port = $port
     DevboxContainerName = $containerName
     CloudflaredContainerName = $cloudflaredContainerName


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration settings for Public and OAuth deployments are now correctly derived from runtime values and persisted to the configuration file, ensuring the stored settings accurately reflect actual deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->