### PR TITLE
feat: add termux host runtime and devbox cli

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,26 +4,35 @@ MCP_AUTH_MODE=none
 PUBLIC_BASE_URL=
 MAX_TEXT_OUTPUT_CHARS=20000
 
+# Runtime selection: auto, docker, or host
+# - auto => docker on Windows, host on Termux/Linux/macOS
+DEVBOX_RUNTIME_MODE=auto
+
 DEVBOX_CONTAINER_NAME=chatgpt-devbox-runtime
 DEVBOX_IMAGE_NAME=chatgpt-devbox-runtime:local
-DEVBOX_WORKSPACE_PATH=/workspace
-# Leave blank to default to <repo>\workspace
+# In host mode this defaults to HOST_WORKSPACE_PATH
+DEVBOX_WORKSPACE_PATH=
+# Leave blank to default to <repo>/workspace
 HOST_WORKSPACE_PATH=
-DEVBOX_DEFAULT_USER=root
+# In docker mode this defaults to root; in host mode it defaults to the current user
+DEVBOX_DEFAULT_USER=
 DEVBOX_AUTO_START=true
 
-ENABLE_WINDOWS_HOST_EXEC=true
-# Leave blank to default to your Windows home directory
+ENABLE_HOST_EXEC=true
+# Leave blank to default to the workspace path or your shell home
 HOST_DEFAULT_WORKDIR=
-HOST_PROGRAM_ALLOWLIST=powershell,pwsh,cmd,git,gh,docker,node,npm,npx,python,py,pip,winget
+# Leave blank to use the platform default shell (/bin/sh on posix, powershell.exe on Windows)
+HOST_SHELL=
+HOST_PROGRAM_ALLOWLIST=
 
 # Leave blank to use the current Node executable
 NODE_EXE=
-# Leave blank to default to <repo>\run\oauth-state.json
+# Leave blank to default to <repo>/run/oauth-state.json
 OAUTH_STATE_FILE_PATH=
+
 CLOUDFLARED_CONTAINER_NAME=chatgpt-devbox-cloudflared
-CLOUDFLARED_PUBLIC_HOSTNAME=mcp.example.com
+CLOUDFLARED_PUBLIC_HOSTNAME=
 CLOUDFLARED_TUNNEL_TOKEN=
-CLOUDFLARE_ACCESS_TEAM_DOMAIN=https://your-team.cloudflareaccess.com
+CLOUDFLARE_ACCESS_TEAM_DOMAIN=
 CLOUDFLARE_ACCESS_AUD=
-CLOUDFLARE_ACCESS_JWKS_URL=https://your-team.cloudflareaccess.com/cdn-cgi/access/certs
+CLOUDFLARE_ACCESS_JWKS_URL=

--- a/README.md
+++ b/README.md
@@ -1,213 +1,176 @@
-# Docker ChatGPT Devbox MCP
+# Devbox MCP
 
-This repo runs a ChatGPT-compatible remote MCP server on Windows. The main execution environment is a reproducible Linux Docker devbox. An optional Windows host bridge exposes native host tools such as PowerShell, Git, Docker CLI, Node, Python, and winget. Please note ChatGPT may become too powerful you have been warned!!!!!
-## DO you need auto-approval and openai is annoying you with every approve box command what if you could allow pasting in the dev console and then never have to think about it again???
+This repo runs a ChatGPT-compatible remote MCP server with two runtime modes:
 
-```
-let lastClicked = null;
+- Docker mode: the original Windows + Docker Desktop workflow.
+- Host mode: direct host execution for Termux, Linux, and macOS without Docker.
 
-setInterval(() => {
-  const btn = [...document.querySelectorAll('button')].find(b => {
-    const rect = b.getBoundingClientRect();
-    const bg = getComputedStyle(b).backgroundColor;
-
-    const sizeMatch =
-      rect.width >= 195 && rect.width <= 199 &&
-      rect.height >= 35 && rect.height <= 37;
-
-    const colorMatch =
-      bg === 'rgb(13, 13, 13)' ||
-      bg === 'rgb(0, 0, 0)';
-
-    return sizeMatch && colorMatch ;
-  });
-
-  if (btn && btn !== lastClicked) {
-    lastClicked = btn;
-    console.log('Clicking:', btn.innerText.trim(), btn.getBoundingClientRect());
-    btn.click();
-  }
-}, 1000)
-```
-
-If you are lazy to type continue and press enter here's another console script for you. 
-```
-(function() {
-  function getMainBoxAndButton() {
-    // Find the first visible contenteditable box
-    const box = Array.from(document.querySelectorAll('[contenteditable="true"]'))
-                     .find(el => el.offsetParent !== null); // only visible elements
-
-    // Try to find a send button within the same container
-    let sendBtn = null;
-    if (box) {
-      const container = box.closest('div');
-      if (container) {
-        sendBtn = container.querySelector('button, input[type="submit"]');
-      }
-    }
-
-    return { box, sendBtn };
-  }
-
-  function typeAndSend() {
-    const { box, sendBtn } = getMainBoxAndButton();
-    if (!box) {
-      console.warn('No visible typing box found!');
-      return;
-    }
-
-    // Focus the box
-    box.focus();
-
-    // Move cursor to the end
-    const sel = window.getSelection();
-    const range = document.createRange();
-    range.selectNodeContents(box);
-    range.collapse(false);
-    sel.removeAllRanges();
-    sel.addRange(range);
-
-    // Insert the exact phrase "continue "
-    document.execCommand('insertText', false, 'continue ');
-
-    // Click send if a button exists
-    if (sendBtn && !sendBtn.disabled) {
-      sendBtn.click();
-    } else {
-      // If no button, try simulating Enter key
-      const enterEvent = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        code: 'Enter',
-        keyCode: 13,
-        which: 13,
-        bubbles: true
-      });
-      box.dispatchEvent(enterEvent);
-    }
-  }
-
-  // Run immediately
-  typeAndSend();
-
-  // Repeat every 2 minutes
-  setInterval(typeAndSend, 2 * 60 * 1000);
-})();
-```
-
+Host mode is the default on Termux/Linux/macOS. Docker mode remains the default on Windows.
 
 ## What is included
 
 - `src/server.js`: MCP server exposed over Streamable HTTP
-- `runtime.Dockerfile`: reproducible Linux devbox image
-- `workspace/`: host workspace mounted into the devbox at `/workspace`
-- `scripts/Start-ChatGptDevboxMcp.ps1`: builds the runtime, starts the devbox, starts the MCP server, and can publish a public HTTPS URL
-- `scripts/Stop-ChatGptDevboxMcp.ps1`: stops the MCP server and optional tunnel/devbox runtime
-- `scripts/Get-ChatGptSetup.ps1`: prints the values to paste into the ChatGPT custom app form
-- `scripts/Get-CloudflareAccessSetup.ps1`: prints the Cloudflare Access settings needed to protect `/authorize*`
+- `src/runtime.js`: runtime selector for Docker vs host mode
+- `src/docker-runtime.js`: original Docker-backed devbox runtime
+- `src/host-runtime.js`: host-backed runtime for Termux/Linux/macOS
+- `src/host-tools.js`: host shell + allowed-program execution helpers
+- `src/launcher.js`: local service launcher helpers
+- `bin/devbox.js`: installable `devbox` command
+- `runtime.Dockerfile`: reproducible Linux devbox image for Docker mode
+- `scripts/Start-ChatGptDevboxMcp.ps1`: Windows/Docker startup flow
+- `scripts/Stop-ChatGptDevboxMcp.ps1`: Windows/Docker shutdown flow
+
+## Runtime modes
+
+### Host mode
+
+Use host mode when Docker is unavailable or unnecessary.
+
+Supported today:
+- Termux on Android
+- Linux
+- macOS
+
+Behavior:
+- shell/file operations run directly on the host
+- `devbox_exec_readonly` is best-effort in host mode; it is not container-sandboxed
+- host tools are exposed through `host_*` MCP tools
+- legacy `windows_host_*` tool names remain as compatibility aliases
+
+### Docker mode
+
+Use Docker mode when you want the original reproducible container workflow.
+
+Behavior:
+- devbox shell/file tools run inside the Docker runtime container
+- read-only shell commands still use disposable read-only containers
+- host tools remain explicit and separate from the devbox runtime
 
 ## Requirements
+
+### Termux / Linux / macOS host mode
+
+- Node.js
+- npm
+- Git
+- optional but useful: `gh`, `python3`, `ripgrep`, `curl`
+
+### Windows Docker mode
 
 - Windows
 - Docker Desktop
 - Node.js
 - PowerShell
 - Git
-- Optional:
-  - GitHub CLI for repo auth sync into the devbox
-  - Cloudflare Tunnel for a stable public hostname
-  - Cloudflare Access if you want real browser auth on `/authorize*`
+- optional: GitHub CLI, Cloudflare Tunnel, Cloudflare Access
 
 ## Clone and bootstrap
+
+```bash
+git clone https://github.com/adybag14-cyber/devbox.git
+cd devbox
+cp .env.example .env
+npm install
+```
+
+Important `.env` values:
+
+- `DEVBOX_RUNTIME_MODE=auto|host|docker`
+- `HOST_WORKSPACE_PATH`
+- `HOST_DEFAULT_WORKDIR`
+- `HOST_SHELL`
+- `HOST_PROGRAM_ALLOWLIST`
+- `PUBLIC_BASE_URL` when using OAuth modes
+
+## Termux quick start
+
+Full notes: [docs/TERMUX.md](./docs/TERMUX.md)
+
+```bash
+pkg install nodejs git ripgrep python curl
+cd ~/devbox
+cp .env.example .env
+npm install
+npm link
+devbox
+```
+
+That starts the MCP service in the background and prints the local URL plus log path.
+
+Useful commands:
+
+```bash
+devbox status
+devbox restart
+devbox stop
+devbox run
+```
+
+`devbox run` keeps the server in the foreground. Plain `devbox` behaves like `devbox start`.
+
+## Linux / macOS host-mode quick start
+
+Full notes: [docs/HOST_COMPATIBILITY.md](./docs/HOST_COMPATIBILITY.md)
+
+```bash
+cd /path/to/devbox
+cp .env.example .env
+npm install
+npm link
+DEVBOX_RUNTIME_MODE=host devbox
+```
+
+If you want the old container workflow on Linux/macOS, set:
+
+```bash
+DEVBOX_RUNTIME_MODE=docker
+```
+
+## Windows Docker-mode quick start
 
 ```powershell
 git clone https://github.com/adybag14-cyber/devbox.git
 cd .\devbox
 Copy-Item .env.example .env
-```
-
-You can leave these `.env` values blank and the repo will derive them automatically:
-
-- `HOST_WORKSPACE_PATH`: defaults to `<repo>\workspace`
-- `HOST_DEFAULT_WORKDIR`: defaults to your Windows home directory
-- `NODE_EXE`: defaults to the current `node.exe`
-- `OAUTH_STATE_FILE_PATH`: defaults to `<repo>\run\oauth-state.json`
-
-## Start locally
-
-```powershell
-cd .\devbox
+npm install
 .\scripts\Start-ChatGptDevboxMcp.ps1
 ```
 
-## Start with a public URL
-
-```powershell
-cd .\devbox
-.\scripts\Start-ChatGptDevboxMcp.ps1 -Public -OAuth
-```
-
-If `.env` contains both `CLOUDFLARED_PUBLIC_HOSTNAME` and `CLOUDFLARED_TUNNEL_TOKEN`, `-Public` uses the named Cloudflare tunnel and keeps the MCP URL stable on your domain.
-
-If you want the stack to stay available across logon and recover from basic runtime failures, install the guardian with `.\scripts\Install-ChatGptDevboxGuardian.ps1` for local mode or `.\scripts\Install-ChatGptDevboxGuardian.ps1 -Public -OAuth` for the public OAuth path. Setup and status commands are in [docs/GUARDIAN.md](./docs/GUARDIAN.md).
-
 ## ChatGPT connector values
 
-After startup:
+After the service is up, inspect:
 
-```powershell
-.\scripts\Get-ChatGptSetup.ps1
+```bash
+curl http://127.0.0.1:8100/
 ```
 
-Typical output:
+Typical local values:
 
-- `Name`: `Docker Devbox`
-- `Description`: `Reproducible Docker devbox shell plus optional Windows host tools`
-- `MCP Server URL`: `https://<your-host>/mcp`
-- `Authentication`: `OAuth`
+- `Name`: `Devbox MCP`
+- `MCP Server URL`: `http://127.0.0.1:8100/mcp` locally, or your public base URL when exposed
+- `Authentication`: `none`, `demo-oauth`, or `cloudflare-access`
 
-## Cloudflare Access mode
+## Public URL / OAuth
 
-If you want the ChatGPT OAuth flow to require a real login:
+If you expose the service publicly, set:
 
-1. Create a Cloudflare Access self-hosted application that protects `https://<your-host>/authorize*`.
-2. Restrict the Access policy to your identity.
-3. Set these values in `.env`:
-   - `MCP_AUTH_MODE=cloudflare-access`
-   - `CLOUDFLARE_ACCESS_TEAM_DOMAIN=https://<your-team>.cloudflareaccess.com`
-   - `CLOUDFLARE_ACCESS_AUD=<Access application AUD>`
-   - `CLOUDFLARE_ACCESS_JWKS_URL=https://<your-team>.cloudflareaccess.com/cdn-cgi/access/certs`
-4. Restart with:
+- `PUBLIC_BASE_URL`
+- `MCP_AUTH_MODE=demo-oauth` or `MCP_AUTH_MODE=cloudflare-access`
 
-```powershell
-.\scripts\Start-ChatGptDevboxMcp.ps1 -Public -OAuth
-```
-
-Use this helper to print the Access-side target:
-
-```powershell
-.\scripts\Get-CloudflareAccessSetup.ps1
-```
-
-## Stop
-
-```powershell
-cd .\devbox
-.\scripts\Stop-ChatGptDevboxMcp.ps1 -Tunnel
-```
-
-Use `-All` to also stop the devbox container.
-
-## Reproducing on another device
-
-See [docs/REPRODUCE.md](./docs/REPRODUCE.md) for a full copy-to-another-machine checklist.
+Cloudflare Access details are still documented by the existing helper scripts and Windows docs.
 
 ## Security notes
 
-- `windows_host_exec` is high risk because it gives ChatGPT PowerShell access to the Windows host.
-- `windows_host_run_program` is limited by `HOST_PROGRAM_ALLOWLIST`.
-- Do not commit `.env`, `.env.runtime`, `run/`, `workspace/`, or other live runtime state.
+- `host_exec` is high risk because it provides direct host shell access.
+- `host_run_program` is limited by `HOST_PROGRAM_ALLOWLIST`.
+- `windows_host_*` tools remain for compatibility, but on non-Windows hosts they route to the generic host implementation.
+- Do not commit `.env`, `run/`, `workspace/`, or other live runtime state.
 
+## Validation
 
-It also includes `devbox_write_large_file`, a base64-backed large file writer that verifies the exact bytes written so agents can mirror payloads without corruption.
-It also includes `devbox_read_large_file`, a base64 chunk reader with real byte offsets, chunk metadata, and paging support for later sections of large logs and generated files.
+```bash
+npm test
+node bin/devbox.js start
+curl http://127.0.0.1:8100/healthz
+node bin/devbox.js stop
+```

--- a/bin/devbox.js
+++ b/bin/devbox.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { runLauncher } from "../src/launcher.js";
+
+const result = await runLauncher(process.argv.slice(2));
+
+if (result.command === "run") {
+  console.log(`devbox running in foreground at ${result.url}`);
+} else if (result.running) {
+  console.log(`devbox ${result.command} ok`);
+  console.log(`url: ${result.url}`);
+  if (result.pid) {
+    console.log(`pid: ${result.pid}`);
+  }
+  console.log(`log: ${result.logFile}`);
+} else {
+  console.log(`devbox ${result.command} ok`);
+  console.log(`url: ${result.url}`);
+  console.log(`log: ${result.logFile}`);
+  console.log("status: stopped");
+}

--- a/docs/HOST_COMPATIBILITY.md
+++ b/docs/HOST_COMPATIBILITY.md
@@ -1,0 +1,63 @@
+# Host Compatibility
+
+The repo now supports host mode on:
+
+- Termux
+- Linux
+- macOS
+
+## Status
+
+### Termux
+Supported and validated locally.
+
+### Linux
+Supported by the same host-mode path used on Termux:
+- default runtime mode resolves to `host`
+- launcher works through `npm link` + `devbox`
+- host shell defaults to `/bin/sh`
+
+### macOS
+Supported by the same host-mode path used on Linux:
+- default runtime mode resolves to `host`
+- launcher works through `npm link` + `devbox`
+- host shell defaults to `$SHELL` or `/bin/sh`
+
+## Notes for Linux/macOS
+
+Install:
+
+```bash
+git clone https://github.com/adybag14-cyber/devbox.git
+cd devbox
+cp .env.example .env
+npm install
+npm link
+```
+
+Start:
+
+```bash
+DEVBOX_RUNTIME_MODE=host devbox
+```
+
+Optional host-mode env overrides:
+
+```bash
+HOST_WORKSPACE_PATH=/path/to/workspace
+HOST_DEFAULT_WORKDIR=/path/to/default/workdir
+HOST_SHELL=/bin/bash
+ENABLE_HOST_EXEC=true
+```
+
+## Docker on Linux/macOS
+
+If you still want the old container-backed flow, force it explicitly:
+
+```bash
+DEVBOX_RUNTIME_MODE=docker
+```
+
+## Current limitation
+
+Host mode does not sandbox read-only shell execution. `devbox_exec_readonly` is best-effort and intended for cooperative agents, not hard isolation.

--- a/docs/TERMUX.md
+++ b/docs/TERMUX.md
@@ -1,0 +1,79 @@
+# Termux Host Mode
+
+This repo can run directly on Termux without Docker.
+
+## Install prerequisites
+
+```bash
+pkg update
+pkg install nodejs git ripgrep python curl
+```
+
+## Install devbox
+
+```bash
+git clone https://github.com/adybag14-cyber/devbox.git ~/devbox
+cd ~/devbox
+cp .env.example .env
+npm install
+```
+
+Recommended `.env` settings for Termux:
+
+```bash
+DEVBOX_RUNTIME_MODE=host
+HOST_WORKSPACE_PATH=$HOME/devbox/workspace
+HOST_DEFAULT_WORKDIR=$HOME
+HOST_SHELL=/data/data/com.termux/files/usr/bin/bash
+ENABLE_HOST_EXEC=true
+```
+
+If you want the `devbox` command in `$PREFIX/bin`:
+
+```bash
+cd ~/devbox
+npm link
+```
+
+That installs the package bin entry so you can start it from anywhere in Termux.
+
+## Start the service
+
+Background service:
+
+```bash
+devbox
+```
+
+Foreground service:
+
+```bash
+devbox run
+```
+
+Check status:
+
+```bash
+devbox status
+```
+
+Stop the background service:
+
+```bash
+devbox stop
+```
+
+## Verify locally
+
+```bash
+curl http://127.0.0.1:8100/healthz
+curl http://127.0.0.1:8100/
+```
+
+## Notes
+
+- Host mode runs directly on the Termux host.
+- `devbox_exec_readonly` is advisory only in host mode; it is not sandboxed like Docker mode.
+- `host_exec` and `host_run_program` operate on the Termux host tools available in your PATH.
+- `windows_host_*` MCP tool names still exist as compatibility aliases, but they use the same host implementation on Termux.
+- If you want public OAuth flows, set `PUBLIC_BASE_URL` and the appropriate auth env vars before starting the service.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "express": "5.1.0",
         "jose": "^6.1.0",
         "zod": "4.1.11"
+      },
+      "bin": {
+        "devbox": "bin/devbox.js"
       }
     },
     "node_modules/@hono/node-server": {
@@ -423,7 +426,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -627,7 +629,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1177,7 +1178,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
       "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "ChatGPT-facing MCP server for a reproducible Docker devbox plus optional Windows host tooling.",
+  "description": "ChatGPT-facing MCP server for Docker or host-mode devbox execution, including Termux/Linux/macOS host tooling.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/adybag14-cyber/devbox.git"
   },
+  "bin": {
+    "devbox": "./bin/devbox.js"
+  },
   "scripts": {
     "start": "node src/server.js",
+    "devbox": "node ./bin/devbox.js",
     "test": "node --test"
   },
   "dependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { defaultHostProgramAllowlist, detectPlatform, resolveHostShell, resolveRuntimeMode } from "./platform.js";
+
 const parseInteger = (value, fallback) => {
   const parsed = Number.parseInt(value ?? "", 10);
   return Number.isFinite(parsed) ? parsed : fallback;
@@ -39,29 +41,38 @@ const normalizeUrl = (value) => {
 const rawPublicBaseUrl = process.env.PUBLIC_BASE_URL?.trim();
 const publicBaseUrl = rawPublicBaseUrl ? rawPublicBaseUrl.replace(/\/+$/, "") : "";
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const platform = detectPlatform(process.env);
+const runtimeMode = resolveRuntimeMode({ requestedMode: process.env.DEVBOX_RUNTIME_MODE, platform });
 const defaultHostWorkspacePath = path.join(projectRoot, "workspace");
+const hostWorkspacePath = process.env.HOST_WORKSPACE_PATH?.trim() || defaultHostWorkspacePath;
 const defaultOauthStateFilePath = path.join(projectRoot, "run", "oauth-state.json");
-const defaultHostWorkdir = os.homedir() || projectRoot;
+const defaultHostWorkdir = process.env.HOST_DEFAULT_WORKDIR?.trim() || hostWorkspacePath || os.homedir() || projectRoot;
 const defaultNodeExe = process.execPath || "node";
+const defaultDevboxWorkspacePath = runtimeMode === "host" ? hostWorkspacePath : "/workspace";
+const enableHostExec = parseBoolean(process.env.ENABLE_HOST_EXEC ?? process.env.ENABLE_WINDOWS_HOST_EXEC, true);
+const hostShell = resolveHostShell(process.env, platform);
+const hostProgramAllowlist = parseCsv(process.env.HOST_PROGRAM_ALLOWLIST, defaultHostProgramAllowlist(platform));
+const defaultDevboxUser = runtimeMode === "host" ? process.env.USER?.trim() || process.env.LOGNAME?.trim() || "" : "root";
 
 export const config = {
+  platform,
+  runtimeMode,
+  hostShell,
   host: process.env.HOST?.trim() || "0.0.0.0",
   port: parseInteger(process.env.PORT, 8100),
-  authMode: process.env.MCP_AUTH_MODE?.trim() || "demo-oauth",
+  authMode: process.env.MCP_AUTH_MODE?.trim() || "none",
   publicBaseUrl,
   maxTextOutputChars: parseInteger(process.env.MAX_TEXT_OUTPUT_CHARS, 20000),
   devboxContainerName: process.env.DEVBOX_CONTAINER_NAME?.trim() || "chatgpt-devbox-runtime",
   devboxImageName: process.env.DEVBOX_IMAGE_NAME?.trim() || "chatgpt-devbox-runtime:local",
-  devboxWorkspacePath: process.env.DEVBOX_WORKSPACE_PATH?.trim() || "/workspace",
-  hostWorkspacePath: process.env.HOST_WORKSPACE_PATH?.trim() || defaultHostWorkspacePath,
-  devboxDefaultUser: process.env.DEVBOX_DEFAULT_USER?.trim() || "root",
+  devboxWorkspacePath: process.env.DEVBOX_WORKSPACE_PATH?.trim() || defaultDevboxWorkspacePath,
+  hostWorkspacePath,
+  devboxDefaultUser: process.env.DEVBOX_DEFAULT_USER?.trim() || defaultDevboxUser,
   devboxAutoStart: parseBoolean(process.env.DEVBOX_AUTO_START, true),
-  enableWindowsHostExec: parseBoolean(process.env.ENABLE_WINDOWS_HOST_EXEC, true),
-  hostDefaultWorkdir: process.env.HOST_DEFAULT_WORKDIR?.trim() || defaultHostWorkdir,
-  hostProgramAllowlist: parseCsv(
-    process.env.HOST_PROGRAM_ALLOWLIST,
-    ["powershell", "pwsh", "cmd", "git", "gh", "docker", "node", "npm", "npx", "python", "py", "pip", "winget"],
-  ),
+  enableHostExec,
+  enableWindowsHostExec: enableHostExec,
+  hostDefaultWorkdir: defaultHostWorkdir,
+  hostProgramAllowlist,
   nodeExe: process.env.NODE_EXE?.trim() || defaultNodeExe,
   oauthStateFilePath: process.env.OAUTH_STATE_FILE_PATH?.trim() || defaultOauthStateFilePath,
   cloudflaredContainerName: process.env.CLOUDFLARED_CONTAINER_NAME?.trim() || "chatgpt-devbox-cloudflared",

--- a/src/host-runtime.js
+++ b/src/host-runtime.js
@@ -1,0 +1,298 @@
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdir, lstat, readdir, readFile, writeFile } from "node:fs/promises";
+
+import { readLargeFileChunk, writeLargeFileMirror } from "./large-file-cli.js";
+import { detectPlatform, resolveHostShell } from "./platform.js";
+import { SpawnProcessError, spawnProcess } from "./process-utils.js";
+
+export class HostRuntimeCommandError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "HostRuntimeCommandError";
+    this.exitCode = details.exitCode ?? null;
+    this.stdout = details.stdout ?? "";
+    this.stderr = details.stderr ?? "";
+  }
+}
+
+const getRuntimeConfig = (env = process.env) => {
+  const platform = detectPlatform(env);
+  const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const hostWorkspacePath = env.HOST_WORKSPACE_PATH?.trim() || path.join(projectRoot, "workspace");
+  const hostDefaultWorkdir = env.HOST_DEFAULT_WORKDIR?.trim() || hostWorkspacePath || os.homedir() || projectRoot;
+
+  return {
+    platform,
+    hostWorkspacePath,
+    hostDefaultWorkdir,
+    hostShell: resolveHostShell(env, platform),
+  };
+};
+
+const wrapRuntimeError = (error, fallbackMessage) => {
+  if (error instanceof HostRuntimeCommandError) {
+    return error;
+  }
+
+  if (error instanceof SpawnProcessError) {
+    return new HostRuntimeCommandError(error.message || fallbackMessage, {
+      exitCode: error.exitCode,
+      stdout: error.stdout,
+      stderr: error.stderr,
+    });
+  }
+
+  return new HostRuntimeCommandError(error instanceof Error ? error.message : fallbackMessage);
+};
+
+const asProcessResult = (stdout = "") => ({ stdout, stderr: "", exitCode: 0 });
+
+const escapeRegex = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const globToRegExp = (value) => new RegExp(`^${escapeRegex(String(value)).replace(/\\\*/g, ".*").replace(/\\\?/g, ".")}$`);
+
+const isBinaryBuffer = (buffer) => buffer.includes(0);
+
+const createMatcher = (pattern, caseSensitive) => {
+  try {
+    return new RegExp(pattern, caseSensitive ? "g" : "gi");
+  } catch {
+    const needle = caseSensitive ? String(pattern) : String(pattern).toLowerCase();
+    return {
+      test(value) {
+        const haystack = caseSensitive ? String(value) : String(value).toLowerCase();
+        return haystack.includes(needle);
+      },
+    };
+  }
+};
+
+const shellArgsForCommand = ({ command, platform }) =>
+  platform.isWindows
+    ? ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", command]
+    : ["-lc", command];
+
+const entryType = (stats) => {
+  if (stats.isDirectory()) {
+    return "d";
+  }
+  if (stats.isFile()) {
+    return "f";
+  }
+  if (stats.isSymbolicLink()) {
+    return "l";
+  }
+  return "?";
+};
+
+const walkEntries = async ({ rootPath, recursive, maxDepth, currentDepth = 0, collected = [] }) => {
+  const stats = await lstat(rootPath);
+  collected.push(`${entryType(stats)}\t${rootPath}`);
+
+  if (!stats.isDirectory()) {
+    return collected;
+  }
+
+  if (!recursive || currentDepth >= Math.max(0, maxDepth)) {
+    return collected;
+  }
+
+  const children = await readdir(rootPath);
+  const sortedChildren = [...children].sort((left, right) => left.localeCompare(right));
+  for (const child of sortedChildren) {
+    await walkEntries({
+      rootPath: path.join(rootPath, child),
+      recursive,
+      maxDepth,
+      currentDepth: currentDepth + 1,
+      collected,
+    });
+  }
+
+  return collected;
+};
+
+const walkFiles = async ({ rootPath, matcher, maxDepth, currentDepth = 0, collected = [] }) => {
+  const stats = await lstat(rootPath);
+  if (stats.isFile()) {
+    if (!matcher || matcher.test(path.basename(rootPath)) || matcher.test(rootPath)) {
+      collected.push(rootPath);
+    }
+    return collected;
+  }
+
+  if (!stats.isDirectory() || currentDepth > Math.max(0, maxDepth)) {
+    return collected;
+  }
+
+  const children = await readdir(rootPath);
+  for (const child of [...children].sort((left, right) => left.localeCompare(right))) {
+    await walkFiles({
+      rootPath: path.join(rootPath, child),
+      matcher,
+      maxDepth,
+      currentDepth: currentDepth + 1,
+      collected,
+    });
+  }
+
+  return collected;
+};
+
+export const getHostRuntimeInfo = async () => {
+  const runtimeConfig = getRuntimeConfig();
+
+  return {
+    mode: "host",
+    exists: true,
+    running: true,
+    status: "ready",
+    name: `${runtimeConfig.platform.id}-host-runtime`,
+    workspacePath: runtimeConfig.hostWorkspacePath,
+    platform: runtimeConfig.platform.id,
+    hostDefaultWorkdir: runtimeConfig.hostDefaultWorkdir,
+    hostShell: runtimeConfig.hostShell,
+  };
+};
+
+export const ensureHostRuntimeReady = async () => {
+  const runtimeConfig = getRuntimeConfig();
+  await mkdir(runtimeConfig.hostWorkspacePath, { recursive: true });
+  return getHostRuntimeInfo();
+};
+
+export const execInHostRuntime = async ({ command, workingDir, timeoutMs }) => {
+  const runtimeConfig = getRuntimeConfig();
+  await ensureHostRuntimeReady();
+  const cwd = workingDir || runtimeConfig.hostDefaultWorkdir;
+
+  try {
+    return await spawnProcess(runtimeConfig.hostShell, shellArgsForCommand({ command, platform: runtimeConfig.platform }), {
+      cwd,
+      timeoutMs,
+    });
+  } catch (error) {
+    throw wrapRuntimeError(error, "Host runtime command failed.");
+  }
+};
+
+export const execReadOnlyInHostRuntime = async ({ command, workingDir, timeoutMs }) =>
+  execInHostRuntime({ command, workingDir, timeoutMs });
+
+export const listFilesInHostRuntime = async ({ path: targetPath, recursive = false, maxDepth = 4 }) => {
+  const info = await ensureHostRuntimeReady();
+  const resolvedPath = targetPath || info.workspacePath;
+  const entries = await walkEntries({ rootPath: resolvedPath, recursive, maxDepth: recursive ? maxDepth : 0 });
+  return asProcessResult(`${entries.sort((left, right) => left.localeCompare(right)).join("\n")}\n`);
+};
+
+export const readFileInHostRuntime = async ({ path: filePath, maxBytes = 65536 }) => {
+  try {
+    const buffer = await readFile(filePath);
+    return asProcessResult(buffer.subarray(0, Math.max(1, maxBytes)).toString("utf8"));
+  } catch (error) {
+    throw wrapRuntimeError(error, `Failed to read ${filePath}.`);
+  }
+};
+
+export const readLargeFileInHostRuntime = async ({ path: filePath, offsetBytes = 0, maxBytes = 262144 }) =>
+  readLargeFileChunk({ path: filePath, offsetBytes, maxBytes });
+
+export const writeFileInHostRuntime = async ({ path: filePath, content, append = false, createDirs = true }) => {
+  try {
+    if (createDirs) {
+      await mkdir(path.dirname(filePath), { recursive: true });
+    }
+    await writeFile(filePath, String(content), { encoding: "utf8", flag: append ? "a" : "w" });
+    return asProcessResult("");
+  } catch (error) {
+    throw wrapRuntimeError(error, `Failed to write ${filePath}.`);
+  }
+};
+
+export const writeLargeFileInHostRuntime = async ({
+  path: filePath,
+  contentBase64,
+  append = false,
+  createDirs = true,
+  expectedSha256 = null,
+}) =>
+  writeLargeFileMirror({
+    path: filePath,
+    contentBase64,
+    append,
+    createDirs,
+    expectedSha256,
+  });
+
+export const searchFilesInHostRuntime = async ({
+  pattern,
+  path: searchPath,
+  glob = "*",
+  caseSensitive = false,
+  maxMatches = 200,
+}) => {
+  const info = await ensureHostRuntimeReady();
+  const rootPath = searchPath || info.workspacePath;
+  const matcher = glob ? globToRegExp(glob) : null;
+  const lineMatcher = createMatcher(pattern, caseSensitive);
+  const files = await walkFiles({ rootPath, matcher, maxDepth: 12 });
+  const matches = [];
+
+  for (const filePath of files) {
+    if (matches.length >= Math.max(1, maxMatches)) {
+      break;
+    }
+
+    const buffer = await readFile(filePath);
+    if (isBinaryBuffer(buffer)) {
+      continue;
+    }
+
+    const lines = buffer.toString("utf8").split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      if (lineMatcher.test(lines[index])) {
+        matches.push(`${filePath}:${index + 1}:${lines[index]}`);
+        if (matches.length >= Math.max(1, maxMatches)) {
+          break;
+        }
+      }
+    }
+  }
+
+  return asProcessResult(matches.join("\n") + (matches.length ? "\n" : ""));
+};
+
+export const getHostRuntimeVersions = async () => {
+  const runtimeConfig = getRuntimeConfig();
+  const candidates = runtimeConfig.platform.isWindows
+    ? [
+        ["node", ["--version"]],
+        ["npm", ["--version"]],
+        ["git", ["--version"]],
+        ["gh", ["--version"]],
+        ["python", ["--version"]],
+      ]
+    : [
+        ["node", ["--version"]],
+        ["npm", ["--version"]],
+        ["git", ["--version"]],
+        ["gh", ["--version"]],
+        ["python3", ["--version"]],
+        ["rg", ["--version"]],
+      ];
+
+  const versions = [];
+  for (const [program, args] of candidates) {
+    try {
+      const result = await spawnProcess(program, args, { cwd: runtimeConfig.hostDefaultWorkdir, timeoutMs: 15000 });
+      const line = `${program}=${`${result.stdout}${result.stderr}`.split(/\r?\n/).find(Boolean) ?? "available"}`;
+      versions.push(line.trim());
+    } catch {
+      versions.push(`${program}=unavailable`);
+    }
+  }
+
+  return versions;
+};

--- a/src/host-tools.js
+++ b/src/host-tools.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 
 import { config } from "./config.js";
+import { detectPlatform, resolveHostShell } from "./platform.js";
 import { SpawnProcessError, spawnProcess } from "./process-utils.js";
 
 export class HostCommandError extends Error {
@@ -27,13 +28,21 @@ const wrapHostError = (error, fallbackMessage) => {
   return new HostCommandError(error instanceof Error ? error.message : fallbackMessage);
 };
 
+const platform = detectPlatform(process.env);
+const hostShell = resolveHostShell(process.env, platform);
+
 const ensureHostExecEnabled = () => {
-  if (!config.enableWindowsHostExec) {
-    throw new HostCommandError("Windows host command execution is disabled in the current configuration.");
+  if (!config.enableHostExec) {
+    throw new HostCommandError(`${platform.displayName} host command execution is disabled in the current configuration.`);
   }
 };
 
-const normalizeProgram = (program) => path.win32.basename(String(program)).replace(/\.exe$/i, "").toLowerCase();
+const normalizeProgram = (program) =>
+  String(program)
+    .split(/[\\/]/)
+    .pop()
+    ?.replace(/\.exe$/i, "")
+    .toLowerCase() || "";
 const psSingleQuote = (value) => String(value).replace(/'/g, "''");
 export const MAX_POWERSHELL_ENCODED_COMMAND_CHARS_BEFORE_FILE = 24000;
 
@@ -143,11 +152,14 @@ exit $process.ExitCode
 };
 
 export const getHostToolStatus = () => ({
-  enabled: config.enableWindowsHostExec,
+  enabled: config.enableHostExec,
+  platform: config.platform.id,
+  platformDisplayName: config.platform.displayName,
+  shell: hostShell,
   defaultWorkdir: config.hostDefaultWorkdir,
   allowlist: config.hostProgramAllowlist,
   resolvedNodeExe: config.nodeExe,
-  windowsHostExecDefaultsToAdmin: true,
+  windowsHostExecDefaultsToAdmin: platform.isWindows,
 });
 
 export const resolveHostProgramExecutable = (program) => {
@@ -258,11 +270,29 @@ export const runWindowsPowerShell = async ({ command, workingDir = config.hostDe
   }
 };
 
+export const runHostShellCommand = async ({ command, workingDir = config.hostDefaultWorkdir, timeoutMs }) => {
+  ensureHostExecEnabled();
+
+  if (platform.isWindows) {
+    return runWindowsPowerShell({ command, workingDir, timeoutMs });
+  }
+
+  try {
+    return await spawnProcess(hostShell, ["-lc", command], {
+      cwd: workingDir,
+      timeoutMs,
+    });
+  } catch (error) {
+    throw wrapHostError(error, `${platform.displayName} host shell command failed.`);
+  }
+};
+
 export const runAllowedProgram = async ({
   program,
   args = [],
   workingDir = config.hostDefaultWorkdir,
   timeoutMs,
+  input,
 }) => {
   ensureHostExecEnabled();
 
@@ -277,6 +307,7 @@ export const runAllowedProgram = async ({
     return await spawnProcess(resolveHostProgramExecutable(program), args, {
       cwd: workingDir,
       timeoutMs,
+      input,
     });
   } catch (error) {
     throw wrapHostError(error, `Host program "${program}" failed.`);

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -1,0 +1,159 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdir, open, readFile, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+
+import { config } from "./config.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const projectRoot = path.resolve(__dirname, "..");
+
+export const getLauncherPaths = (root = projectRoot) => {
+  const runDir = path.join(root, "run");
+  return {
+    runDir,
+    pidFile: path.join(runDir, "devbox.pid"),
+    logFile: path.join(runDir, "devbox.log"),
+  };
+};
+
+export const parseLauncherArgs = (argv = []) => {
+  const first = String(argv[0] ?? "").trim().toLowerCase();
+  const command = first || "start";
+
+  if (["run", "serve", "foreground"].includes(command)) {
+    return { command: "run", background: false };
+  }
+
+  if (["status", "stop", "restart", "start"].includes(command)) {
+    return { command, background: command === "start" };
+  }
+
+  return { command: "start", background: true };
+};
+
+export const buildServerUrl = ({ host = config.host, port = config.port } = {}) => {
+  const normalizedHost = ["0.0.0.0", "::", "[::]"].includes(String(host).trim()) ? "127.0.0.1" : String(host).trim() || "127.0.0.1";
+  return `http://${normalizedHost}:${port}`;
+};
+
+export const isProcessAlive = (pid) => {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const readPidFile = async (pidFile) => {
+  try {
+    const pidText = await readFile(pidFile, "utf8");
+    const pid = Number.parseInt(String(pidText).trim(), 10);
+    return Number.isInteger(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+};
+
+const ensureRunDir = async (runDir) => {
+  await mkdir(runDir, { recursive: true });
+};
+
+export const getServerStatus = async (root = projectRoot) => {
+  const paths = getLauncherPaths(root);
+  await ensureRunDir(paths.runDir);
+  const pid = await readPidFile(paths.pidFile);
+  const running = isProcessAlive(pid);
+
+  if (!running && pid !== null) {
+    await rm(paths.pidFile, { force: true });
+  }
+
+  return {
+    running,
+    pid: running ? pid : null,
+    pidFile: paths.pidFile,
+    logFile: paths.logFile,
+    url: buildServerUrl(),
+  };
+};
+
+export const startServerProcess = async (root = projectRoot) => {
+  const status = await getServerStatus(root);
+  if (status.running) {
+    return { ...status, started: false };
+  }
+
+  const paths = getLauncherPaths(root);
+  await ensureRunDir(paths.runDir);
+  const logHandle = await open(paths.logFile, "a");
+  const child = spawn(process.execPath, [path.join(root, "src/server.js")], {
+    cwd: root,
+    env: process.env,
+    detached: true,
+    stdio: ["ignore", logHandle.fd, logHandle.fd],
+  });
+
+  child.unref();
+  await writeFile(paths.pidFile, `${child.pid}\n`, "utf8");
+  await logHandle.close();
+
+  return {
+    ...(await getServerStatus(root)),
+    started: true,
+  };
+};
+
+export const stopServerProcess = async (root = projectRoot) => {
+  const paths = getLauncherPaths(root);
+  const pid = await readPidFile(paths.pidFile);
+  if (!isProcessAlive(pid)) {
+    await rm(paths.pidFile, { force: true });
+    return { ...(await getServerStatus(root)), stopped: false };
+  }
+
+  process.kill(pid, "SIGTERM");
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  if (isProcessAlive(pid)) {
+    process.kill(pid, "SIGKILL");
+  }
+
+  await rm(paths.pidFile, { force: true });
+  return { ...(await getServerStatus(root)), stopped: true };
+};
+
+export const runLauncher = async (argv = process.argv.slice(2), root = projectRoot) => {
+  const parsed = parseLauncherArgs(argv);
+
+  if (parsed.command === "run") {
+    await import("./server.js");
+    return { command: "run", url: buildServerUrl() };
+  }
+
+  if (parsed.command === "status") {
+    return { command: "status", ...(await getServerStatus(root)) };
+  }
+
+  if (parsed.command === "stop") {
+    return { command: "stop", ...(await stopServerProcess(root)) };
+  }
+
+  if (parsed.command === "restart") {
+    await stopServerProcess(root);
+    return { command: "restart", ...(await startServerProcess(root)) };
+  }
+
+  return { command: "start", ...(await startServerProcess(root)) };
+};

--- a/src/platform.js
+++ b/src/platform.js
@@ -1,0 +1,47 @@
+const normalizeMode = (value) => String(value ?? "").trim().toLowerCase();
+
+export const detectPlatform = (env = process.env, processPlatform = process.platform) => {
+  const prefix = String(env.PREFIX ?? "");
+  const isTermux = Boolean(env.TERMUX_VERSION || prefix.includes("com.termux/files/usr"));
+  const isWindows = processPlatform === "win32";
+  const isMacOS = processPlatform === "darwin";
+  const isLinux = processPlatform === "linux" || isTermux;
+  const id = isTermux ? "termux" : isWindows ? "windows" : isMacOS ? "macos" : isLinux ? "linux" : processPlatform || "unknown";
+  const displayName = isTermux ? "Termux" : isWindows ? "Windows" : isMacOS ? "macOS" : isLinux ? "Linux" : processPlatform || "Unknown";
+
+  return {
+    id,
+    displayName,
+    isTermux,
+    isWindows,
+    isMacOS,
+    isLinux,
+    nodePlatform: processPlatform,
+  };
+};
+
+export const resolveRuntimeMode = ({ requestedMode, platform }) => {
+  const normalizedMode = normalizeMode(requestedMode);
+  if (normalizedMode === "host" || normalizedMode === "docker") {
+    return normalizedMode;
+  }
+
+  if (platform?.isWindows) {
+    return "docker";
+  }
+
+  return "host";
+};
+
+export const defaultHostProgramAllowlist = (platform) =>
+  platform?.isWindows
+    ? ["powershell", "pwsh", "cmd", "git", "gh", "docker", "node", "npm", "npx", "python", "py", "pip", "winget"]
+    : ["bash", "sh", "git", "gh", "node", "npm", "npx", "python", "python3", "pip", "pip3", "rg", "curl"];
+
+export const resolveHostShell = (env = process.env, platform = detectPlatform(env)) => {
+  if (platform?.isWindows) {
+    return String(env.HOST_SHELL ?? env.ComSpec ?? "powershell.exe").trim() || "powershell.exe";
+  }
+
+  return String(env.HOST_SHELL ?? env.SHELL ?? "/bin/sh").trim() || "/bin/sh";
+};

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,0 +1,114 @@
+import { config } from "./config.js";
+import { HostCommandError, getHostGithubAuthContext, runAllowedProgram } from "./host-tools.js";
+import {
+  getHostRuntimeInfo,
+  ensureHostRuntimeReady,
+  execInHostRuntime,
+  execReadOnlyInHostRuntime,
+  getHostRuntimeVersions,
+  listFilesInHostRuntime,
+  readFileInHostRuntime,
+  readLargeFileInHostRuntime,
+  searchFilesInHostRuntime,
+  writeFileInHostRuntime,
+  writeLargeFileInHostRuntime,
+} from "./host-runtime.js";
+import {
+  DockerCommandError,
+  ensureDevboxRunning as ensureDockerDevboxRunning,
+  execInDevbox as execInDockerDevbox,
+  execReadOnlyInDevbox as execReadOnlyInDockerDevbox,
+  getDevboxGithubAuthStatus as getDockerDevboxGithubAuthStatus,
+  getDevboxInfo as getDockerDevboxInfo,
+  getDevboxVersions as getDockerDevboxVersions,
+  listFilesInDevbox as listFilesInDockerDevbox,
+  readFileInDevbox as readFileInDockerDevbox,
+  readLargeFileInDevbox as readLargeFileInDockerDevbox,
+  recreateDevbox as recreateDockerDevbox,
+  restartDevbox as restartDockerDevbox,
+  searchFilesInDevbox as searchFilesInDockerDevbox,
+  syncGithubAuthToDevbox as syncGithubAuthToDockerDevbox,
+  stopDevbox as stopDockerDevbox,
+  writeFileInDevbox as writeFileInDockerDevbox,
+  writeLargeFileInDevbox as writeLargeFileInDockerDevbox,
+} from "./docker-runtime.js";
+
+export const isDockerRuntime = config.runtimeMode === "docker";
+export const runtimeTitle = isDockerRuntime ? "Docker Devbox" : `${config.platform.displayName} Host Devbox`;
+export const runtimeLabel = isDockerRuntime ? "Docker devbox" : `${config.platform.displayName} host devbox`;
+export const runtimeServerName = isDockerRuntime ? "Docker ChatGPT Devbox MCP" : `${config.platform.displayName} Host Devbox MCP`;
+export const hostTitle = config.platform.isWindows ? "Windows Host" : `${config.platform.displayName} Host`;
+export const hostCommandTitle = config.platform.isWindows ? "Windows PowerShell" : `${config.platform.displayName} Host Shell`;
+
+const hostControlInfo = async (action) => ({
+  ...(await getHostRuntimeInfo()),
+  controlAction: action,
+  controlMessage: `Host mode runs inside the current server process. Use the devbox launcher command to ${action} the service itself.`,
+});
+
+const getHostModeGithubAuthStatus = async () => {
+  const context = await getHostGithubAuthContext();
+  return {
+    statusSummary: context.statusSummary,
+    userName: context.userName,
+    userEmail: context.userEmail,
+  };
+};
+
+const syncGithubAuthToHostRuntime = async ({ token, userName, userEmail }) => {
+  if (!token) {
+    throw new HostCommandError("A GitHub token is required to sync auth into the host runtime.");
+  }
+
+  await runAllowedProgram({
+    program: "gh",
+    args: ["auth", "login", "--hostname", "github.com", "--with-token"],
+    input: `${token}\n`,
+    timeoutMs: 20000,
+  });
+
+  await runAllowedProgram({
+    program: "gh",
+    args: ["auth", "setup-git", "--hostname", "github.com"],
+    timeoutMs: 15000,
+  });
+
+  if (userName) {
+    await runAllowedProgram({
+      program: "git",
+      args: ["config", "--global", "user.name", userName],
+      timeoutMs: 5000,
+    });
+  }
+
+  if (userEmail) {
+    await runAllowedProgram({
+      program: "git",
+      args: ["config", "--global", "user.email", userEmail],
+      timeoutMs: 5000,
+    });
+  }
+
+  return getHostModeGithubAuthStatus();
+};
+
+export const DockerOrHostCommandError = isDockerRuntime ? DockerCommandError : HostCommandError;
+
+export const getDevboxInfo = () => (isDockerRuntime ? getDockerDevboxInfo() : getHostRuntimeInfo());
+export const ensureDevboxRunning = () => (isDockerRuntime ? ensureDockerDevboxRunning() : ensureHostRuntimeReady());
+export const stopDevbox = () => (isDockerRuntime ? stopDockerDevbox() : hostControlInfo("stop"));
+export const restartDevbox = () => (isDockerRuntime ? restartDockerDevbox() : hostControlInfo("restart"));
+export const recreateDevbox = () => (isDockerRuntime ? recreateDockerDevbox() : hostControlInfo("recreate"));
+export const execInDevbox = (options) => (isDockerRuntime ? execInDockerDevbox(options) : execInHostRuntime(options));
+export const execReadOnlyInDevbox = (options) => (isDockerRuntime ? execReadOnlyInDockerDevbox(options) : execReadOnlyInHostRuntime(options));
+export const getDevboxVersions = () => (isDockerRuntime ? getDockerDevboxVersions() : getHostRuntimeVersions());
+export const listFilesInDevbox = (options) => (isDockerRuntime ? listFilesInDockerDevbox(options) : listFilesInHostRuntime(options));
+export const readFileInDevbox = (options) => (isDockerRuntime ? readFileInDockerDevbox(options) : readFileInHostRuntime(options));
+export const readLargeFileInDevbox = (options) => (isDockerRuntime ? readLargeFileInDockerDevbox(options) : readLargeFileInHostRuntime(options));
+export const writeFileInDevbox = (options) => (isDockerRuntime ? writeFileInDockerDevbox(options) : writeFileInHostRuntime(options));
+export const writeLargeFileInDevbox = (options) => (isDockerRuntime ? writeLargeFileInDockerDevbox(options) : writeLargeFileInHostRuntime(options));
+export const searchFilesInDevbox = (options) => (isDockerRuntime ? searchFilesInDockerDevbox(options) : searchFilesInHostRuntime(options));
+export const getDevboxGithubAuthStatus = () =>
+  (isDockerRuntime ? getDockerDevboxGithubAuthStatus() : getHostModeGithubAuthStatus());
+export const syncGithubAuthToDevbox = (options) =>
+  (isDockerRuntime ? syncGithubAuthToDockerDevbox(options) : syncGithubAuthToHostRuntime(options));

--- a/src/server.js
+++ b/src/server.js
@@ -7,30 +7,35 @@ import * as z from "zod/v4";
 
 import { config, version } from "./config.js";
 import {
-  DockerCommandError,
   ensureDevboxRunning,
   execInDevbox,
   execReadOnlyInDevbox,
   getDevboxInfo,
   getDevboxGithubAuthStatus,
   getDevboxVersions,
+  hostCommandTitle,
+  hostTitle,
+  isDockerRuntime,
   listFilesInDevbox,
   readFileInDevbox,
   readLargeFileInDevbox,
   recreateDevbox,
   restartDevbox,
+  runtimeLabel,
+  runtimeServerName,
+  runtimeTitle,
   searchFilesInDevbox,
   syncGithubAuthToDevbox,
   stopDevbox,
   writeFileInDevbox,
   writeLargeFileInDevbox,
-} from "./docker-runtime.js";
+} from "./runtime.js";
 import {
   HostCommandError,
   getHostGithubAuthContext,
   getHostToolStatus,
   runAllowedProgram,
-  runWindowsPowerShell,
+  runHostShellCommand,
 } from "./host-tools.js";
 import { CloudflareAccessOAuthProvider, DemoOAuthProvider } from "./oauth.js";
 import {
@@ -135,8 +140,15 @@ const successResult = (summary, extra = {}) => {
   };
 };
 
+const isCommandStyleError = (error) =>
+  Boolean(
+    error &&
+      typeof error === "object" &&
+      (error instanceof HostCommandError || "exitCode" in error || "stdout" in error || "stderr" in error),
+  );
+
 const errorResult = (error, fallbackSummary = "The command failed.") => {
-  if (error instanceof DockerCommandError || error instanceof HostCommandError) {
+  if (isCommandStyleError(error)) {
     const stdout = trimText(error.stdout, config.maxTextOutputChars);
     const stderr = trimText(error.stderr, config.maxTextOutputChars);
     const summary = error.message || fallbackSummary;
@@ -153,7 +165,7 @@ const errorResult = (error, fallbackSummary = "The command failed.") => {
         summary,
         stdout: stdout.text,
         stderr: stderr.text,
-        exitCode: error.exitCode,
+        exitCode: error.exitCode ?? null,
         truncated: stdout.truncated || stderr.truncated,
       },
       isError: true,
@@ -193,9 +205,9 @@ const fromProcessResult = (summary, result, extra = {}) => {
 const buildServer = () => {
   const server = new McpServer(
     {
-      name: "Docker ChatGPT Devbox MCP",
+      name: runtimeServerName,
       version,
-      websiteUrl: "https://docs.docker.com/",
+      websiteUrl: "https://github.com/adybag14-cyber/devbox",
     },
     {
       capabilities: {
@@ -208,19 +220,19 @@ const buildServer = () => {
     "devbox_github_auth_status",
     safeReadOnlyTool(
       {
-        title: "Docker Devbox GitHub Auth Status",
-        description: "Use this when you need to confirm whether the Docker devbox is authenticated to GitHub and which git identity is configured.",
+        title: `${runtimeTitle} GitHub Auth Status`,
+        description: `Use this when you need to confirm whether the ${runtimeLabel} is authenticated to GitHub and which git identity is configured.`,
         outputSchema,
       },
-      "Checking Docker devbox GitHub auth",
-      "Docker devbox GitHub auth checked",
+      `Checking ${runtimeLabel} GitHub auth`,
+      `${runtimeLabel} GitHub auth checked`,
     ),
     async () => {
       try {
         const data = await getDevboxGithubAuthStatus();
-        return successResult("Fetched Docker devbox GitHub auth status.", { data });
+        return successResult(`Fetched ${runtimeLabel} GitHub auth status.`, { data });
       } catch (error) {
-        return errorResult(error, "Failed to fetch Docker devbox GitHub auth status.");
+        return errorResult(error, `Failed to fetch ${runtimeLabel} GitHub auth status.`);
       }
     },
   );
@@ -229,9 +241,9 @@ const buildServer = () => {
     "devbox_sync_github_auth_from_host",
     safeActionTool(
       {
-        title: "Sync Host GitHub Auth Into Docker Devbox",
+        title: `Sync Host GitHub Auth Into ${runtimeTitle}`,
         description:
-          "Use this when the Windows host already has a valid GitHub CLI login and the Docker devbox should inherit GitHub authentication and git identity from the host.",
+          `Use this when the host already has a valid GitHub CLI login and the ${runtimeLabel} should inherit GitHub authentication and git identity from the host.`,
         outputSchema,
       },
       "Syncing host GitHub auth",
@@ -246,7 +258,7 @@ const buildServer = () => {
           userEmail: hostGithub.userEmail,
         });
 
-        return successResult("Synced the host GitHub CLI authentication into the Docker devbox.", {
+        return successResult(`Synced the host GitHub CLI authentication into the ${runtimeLabel}.`, {
           data: {
             ...data,
             hostUserName: hostGithub.userName || null,
@@ -254,7 +266,7 @@ const buildServer = () => {
           },
         });
       } catch (error) {
-        return errorResult(error, "Failed to sync host GitHub authentication into the Docker devbox.");
+        return errorResult(error, `Failed to sync host GitHub authentication into the ${runtimeLabel}.`);
       }
     },
   );
@@ -263,12 +275,12 @@ const buildServer = () => {
     "devbox_status",
     safeReadOnlyTool(
       {
-        title: "Docker Devbox Status",
-        description: "Use this when you need the current state of the reproducible Docker devbox and its installed toolchain.",
+        title: `${runtimeTitle} Status`,
+        description: `Use this when you need the current state of the ${runtimeLabel} and its installed toolchain.`,
         outputSchema,
       },
-      "Checking Docker devbox status",
-      "Docker devbox status ready",
+      `Checking ${runtimeLabel} status`,
+      `${runtimeLabel} status ready`,
     ),
     async () => {
       try {
@@ -277,16 +289,16 @@ const buildServer = () => {
           ...info,
           hostWorkspacePath: config.hostWorkspacePath,
           devboxWorkspacePath: config.devboxWorkspacePath,
-          windowsHostExecEnabled: config.enableWindowsHostExec,
+          hostExecEnabled: config.enableHostExec,
         };
 
         if (info.running) {
           data.versions = await getDevboxVersions();
         }
 
-        return successResult("Fetched Docker devbox status.", { data });
+        return successResult(`Fetched ${runtimeLabel} status.`, { data });
       } catch (error) {
-        return errorResult(error, "Failed to fetch Docker devbox status.");
+        return errorResult(error, `Failed to fetch ${runtimeLabel} status.`);
       }
     },
   );
@@ -295,19 +307,22 @@ const buildServer = () => {
     "devbox_start",
     safeActionTool(
       {
-        title: "Start Docker Devbox",
-        description: "Use this when the Docker devbox is stopped or missing and needs to be brought online.",
+        title: `Start ${runtimeTitle}`,
+        description: `Use this when the ${runtimeLabel} is stopped or missing and needs to be brought online.`,
         outputSchema,
       },
-      "Starting Docker devbox",
-      "Docker devbox started",
+      `Starting ${runtimeLabel}`,
+      `${runtimeLabel} started`,
     ),
     async () => {
       try {
         const info = await ensureDevboxRunning();
-        return successResult(`Docker devbox ${info.name} is running.`, { data: info });
+        const summary = isDockerRuntime
+          ? `${runtimeTitle} ${info.name} is running.`
+          : `${runtimeTitle} is ready in the current server process.`;
+        return successResult(summary, { data: info });
       } catch (error) {
-        return errorResult(error, "Failed to start the Docker devbox.");
+        return errorResult(error, `Failed to start the ${runtimeLabel}.`);
       }
     },
   );
@@ -316,19 +331,22 @@ const buildServer = () => {
     "devbox_stop",
     safeActionTool(
       {
-        title: "Stop Docker Devbox",
-        description: "Use this when the Docker devbox should be shut down without deleting the workspace.",
+        title: `Stop ${runtimeTitle}`,
+        description: `Use this when the ${runtimeLabel} should be shut down without deleting the workspace.`,
         outputSchema,
       },
-      "Stopping Docker devbox",
-      "Docker devbox stopped",
+      `Stopping ${runtimeLabel}`,
+      `${runtimeLabel} stopped`,
     ),
     async () => {
       try {
         const info = await stopDevbox();
-        return successResult(`Docker devbox ${info.name} is stopped.`, { data: info });
+        const summary = isDockerRuntime
+          ? `${runtimeTitle} ${info.name} is stopped.`
+          : info.controlMessage || `${runtimeTitle} stop is managed by the launcher command.`;
+        return successResult(summary, { data: info });
       } catch (error) {
-        return errorResult(error, "Failed to stop the Docker devbox.");
+        return errorResult(error, `Failed to stop the ${runtimeLabel}.`);
       }
     },
   );
@@ -337,19 +355,22 @@ const buildServer = () => {
     "devbox_restart",
     safeActionTool(
       {
-        title: "Restart Docker Devbox",
-        description: "Use this when the Docker devbox container needs a clean restart.",
+        title: `Restart ${runtimeTitle}`,
+        description: `Use this when the ${runtimeLabel} needs a clean restart.`,
         outputSchema,
       },
-      "Restarting Docker devbox",
-      "Docker devbox restarted",
+      `Restarting ${runtimeLabel}`,
+      `${runtimeLabel} restarted`,
     ),
     async () => {
       try {
         const info = await restartDevbox();
-        return successResult(`Docker devbox ${info.name} has been restarted.`, { data: info });
+        const summary = isDockerRuntime
+          ? `${runtimeTitle} ${info.name} has been restarted.`
+          : info.controlMessage || `${runtimeTitle} restart is managed by the launcher command.`;
+        return successResult(summary, { data: info });
       } catch (error) {
-        return errorResult(error, "Failed to restart the Docker devbox.");
+        return errorResult(error, `Failed to restart the ${runtimeLabel}.`);
       }
     },
   );
@@ -358,19 +379,22 @@ const buildServer = () => {
     "devbox_recreate",
     safeActionTool(
       {
-        title: "Recreate Docker Devbox",
-        description: "Use this when the Docker devbox container itself should be rebuilt from the configured image while preserving the mounted workspace.",
+        title: `Recreate ${runtimeTitle}`,
+        description: `Use this when the ${runtimeLabel} should be rebuilt from the configured backend while preserving the workspace.`,
         outputSchema,
       },
-      "Recreating Docker devbox",
-      "Docker devbox recreated",
+      `Recreating ${runtimeLabel}`,
+      `${runtimeLabel} recreated`,
     ),
     async () => {
       try {
         const info = await recreateDevbox();
-        return successResult(`Docker devbox ${info.name} has been recreated.`, { data: info });
+        const summary = isDockerRuntime
+          ? `${runtimeTitle} ${info.name} has been recreated.`
+          : info.controlMessage || `${runtimeTitle} recreation is managed by the launcher command.`;
+        return successResult(summary, { data: info });
       } catch (error) {
-        return errorResult(error, "Failed to recreate the Docker devbox.");
+        return errorResult(error, `Failed to recreate the ${runtimeLabel}.`);
       }
     },
   );
@@ -379,19 +403,20 @@ const buildServer = () => {
     "devbox_exec_readonly",
     safeReadOnlyTool(
       {
-        title: "Run Read-Only Shell Command In Docker Devbox",
-        description:
-          "Prefer this for inspection-only shell work such as ls, find, cat, sed -n, rg, git diff, git log, or config inspection. It runs in a disposable container with the workspace mounted read-only and network disabled, so project writes and outbound network access should fail.",
+        title: `Run Read-Only Shell Command In ${runtimeTitle}`,
+        description: isDockerRuntime
+          ? "Prefer this for inspection-only shell work such as ls, find, cat, sed -n, rg, git diff, git log, or config inspection. It runs in a disposable container with the workspace mounted read-only and network disabled, so project writes and outbound network access should fail."
+          : `Prefer this for inspection-only shell work such as ls, find, cat, sed -n, rg, git diff, git log, or config inspection. In ${runtimeLabel} mode this runs directly on the host shell, so read-only behavior is advisory rather than sandbox-enforced.`,
         inputSchema: {
-          command: z.string().min(1).describe("Read-only shell command to run inside the Docker devbox."),
-          working_dir: z.string().default(config.devboxWorkspacePath).describe("Working directory inside the Docker devbox."),
+          command: z.string().min(1).describe(`Read-only shell command to run inside the ${runtimeLabel}.`),
+          working_dir: z.string().default(config.devboxWorkspacePath).describe(`Working directory inside the ${runtimeLabel}.`),
           timeout_seconds: z.number().int().min(1).max(7200).default(300).describe("Command timeout in seconds."),
-          user: z.string().default(config.devboxDefaultUser).describe("Linux user inside the disposable read-only container."),
+          user: z.string().default(config.devboxDefaultUser).describe(isDockerRuntime ? "Linux user inside the disposable read-only container." : `Host user hint for ${runtimeLabel} mode.`),
         },
         outputSchema,
       },
-      "Running read-only shell command in devbox",
-      "Read-only devbox shell command finished",
+      `Running read-only shell command in ${runtimeLabel}`,
+      `Read-only ${runtimeLabel} shell command finished`,
     ),
     async ({ command, working_dir: workingDir, timeout_seconds: timeoutSeconds, user }) => {
       try {
@@ -401,9 +426,9 @@ const buildServer = () => {
           timeoutMs: (timeoutSeconds + 5) * 1000,
           user,
         });
-        return fromProcessResult(`Ran a read-only shell command in the Docker devbox at ${workingDir}.`, result);
+        return fromProcessResult(`Ran a read-only shell command in the ${runtimeLabel} at ${workingDir}.`, result);
       } catch (error) {
-        return errorResult(error, "Failed to run the read-only Docker devbox shell command.");
+        return errorResult(error, `Failed to run the read-only ${runtimeLabel} shell command.`);
       }
     },
   );
@@ -412,19 +437,20 @@ const buildServer = () => {
     "devbox_exec",
     safeActionTool(
       {
-        title: "Run Mutating Shell Command In Docker Devbox",
-        description:
-          "Use this only when the shell command needs side effects such as writing files, building artifacts, installing packages, changing git state, or otherwise mutating the devbox or workspace. Prefer devbox_exec_readonly for inspection, search, and file-reading commands.",
+        title: `Run Mutating Shell Command In ${runtimeTitle}`,
+        description: isDockerRuntime
+          ? "Use this only when the shell command needs side effects such as writing files, building artifacts, installing packages, changing git state, or otherwise mutating the devbox or workspace. Prefer devbox_exec_readonly for inspection, search, and file-reading commands."
+          : `Use this when the shell command needs side effects such as writing files, building artifacts, installing packages, changing git state, or otherwise mutating the ${runtimeLabel}. Prefer devbox_exec_readonly for inspection, search, and file-reading commands.`,
         inputSchema: {
-          command: z.string().min(1).describe("Shell command to run inside the Docker devbox."),
-          working_dir: z.string().default(config.devboxWorkspacePath).describe("Working directory inside the Docker devbox."),
+          command: z.string().min(1).describe(`Shell command to run inside the ${runtimeLabel}.`),
+          working_dir: z.string().default(config.devboxWorkspacePath).describe(`Working directory inside the ${runtimeLabel}.`),
           timeout_seconds: z.number().int().min(1).max(7200).default(300).describe("Command timeout in seconds."),
-          user: z.string().default(config.devboxDefaultUser).describe("Linux user inside the devbox container."),
+          user: z.string().default(config.devboxDefaultUser).describe(isDockerRuntime ? "Linux user inside the devbox container." : `Host user hint for ${runtimeLabel} mode.`),
         },
         outputSchema,
       },
-      "Running shell command in devbox",
-      "Devbox shell command finished",
+      `Running shell command in ${runtimeLabel}`,
+      `${runtimeLabel} shell command finished`,
     ),
     async ({ command, working_dir: workingDir, timeout_seconds: timeoutSeconds, user }) => {
       try {
@@ -434,9 +460,9 @@ const buildServer = () => {
           timeoutMs: (timeoutSeconds + 5) * 1000,
           user,
         });
-        return fromProcessResult(`Ran a shell command in the Docker devbox at ${workingDir}.`, result);
+        return fromProcessResult(`Ran a shell command in the ${runtimeLabel} at ${workingDir}.`, result);
       } catch (error) {
-        return errorResult(error, "Failed to run the Docker devbox shell command.");
+        return errorResult(error, `Failed to run the ${runtimeLabel} shell command.`);
       }
     },
   );
@@ -445,17 +471,17 @@ const buildServer = () => {
     "devbox_list_files",
     safeReadOnlyTool(
       {
-        title: "List Docker Devbox Files",
-        description: "Use this when you need a directory listing inside the Docker devbox workspace or another container path.",
+        title: `List ${runtimeTitle} Files`,
+        description: `Use this when you need a directory listing inside the ${runtimeLabel} workspace or another configured path.`,
         inputSchema: {
-          path: z.string().default(config.devboxWorkspacePath).describe("Directory path inside the Docker devbox."),
+          path: z.string().default(config.devboxWorkspacePath).describe(`Directory path inside the ${runtimeLabel}.`),
           recursive: z.boolean().default(false).describe("When true, recurse into subdirectories."),
           max_depth: z.number().int().min(1).max(20).default(4).describe("Maximum recursive depth when recursive is true."),
         },
         outputSchema,
       },
-      "Listing Docker devbox files",
-      "Docker devbox files listed",
+      `Listing ${runtimeLabel} files`,
+      `${runtimeLabel} files listed`,
     ),
     async ({ path, recursive, max_depth: maxDepth }) => {
       try {
@@ -471,23 +497,23 @@ const buildServer = () => {
     "devbox_read_file",
     safeReadOnlyTool(
       {
-        title: "Read Docker Devbox File",
-        description: "Use this when you need text content from a file inside the Docker devbox.",
+        title: `Read ${runtimeTitle} File`,
+        description: `Use this when you need text content from a file inside the ${runtimeLabel}.`,
         inputSchema: {
-          path: z.string().min(1).describe("File path inside the Docker devbox."),
+          path: z.string().min(1).describe(`File path inside the ${runtimeLabel}.`),
           max_bytes: z.number().int().min(1).max(500000).default(65536).describe("Maximum bytes to return."),
         },
         outputSchema,
       },
-      "Reading Docker devbox file",
-      "Docker devbox file read",
+      `Reading ${runtimeLabel} file`,
+      `${runtimeLabel} file read`,
     ),
     async ({ path, max_bytes: maxBytes }) => {
       try {
         const result = await readFileInDevbox({ path, maxBytes });
-        return fromProcessResult(`Read ${path} from the Docker devbox.`, result);
+        return fromProcessResult(`Read ${path} from the ${runtimeLabel}.`, result);
       } catch (error) {
-        return errorResult(error, `Failed to read ${path} from the Docker devbox.`);
+        return errorResult(error, `Failed to read ${path} from the ${runtimeLabel}.`);
       }
     },
   );
@@ -496,28 +522,28 @@ const buildServer = () => {
     "devbox_read_large_file",
     safeReadOnlyTool(
       {
-        title: "Read Large Docker Devbox File Chunk",
-        description: "Use this when you need an exact byte range from a larger file inside the Docker devbox. It returns a base64 chunk plus metadata for safe paging without UTF-8 corruption.",
+        title: `Read Large ${runtimeTitle} File Chunk`,
+        description: `Use this when you need an exact byte range from a larger file inside the ${runtimeLabel}. It returns a base64 chunk plus metadata for safe paging without UTF-8 corruption.`,
         inputSchema: {
-          path: z.string().min(1).describe("File path inside the Docker devbox."),
+          path: z.string().min(1).describe(`File path inside the ${runtimeLabel}.`),
           offset_bytes: z.number().int().min(0).default(0).describe("Starting byte offset within the file."),
           max_bytes: z.number().int().min(1).max(524288).default(262144).describe("Maximum raw bytes to return from that offset."),
         },
         outputSchema,
       },
-      "Reading large Docker devbox file chunk",
-      "Large Docker devbox file chunk read",
+      `Reading large ${runtimeLabel} file chunk`,
+      `Large ${runtimeLabel} file chunk read`,
     ),
     async ({ path, offset_bytes: offsetBytes, max_bytes: maxBytes }) => {
       try {
         const data = await readLargeFileInDevbox({ path, offsetBytes, maxBytes });
-        const summary = `Read ${path} from byte ${offsetBytes} in the Docker devbox.`;
+        const summary = `Read ${path} from byte ${offsetBytes} in the ${runtimeLabel}.`;
         return successResult(summary, {
           data,
           text: textFromResult(summary, summarizeLargeReadData(data)),
         });
       } catch (error) {
-        return errorResult(error, `Failed to read ${path} from byte ${offsetBytes} in the Docker devbox.`);
+        return errorResult(error, `Failed to read ${path} from byte ${offsetBytes} in the ${runtimeLabel}.`);
       }
     },
   );
@@ -526,39 +552,38 @@ const buildServer = () => {
     "devbox_write_file",
     safeActionTool(
       {
-        title: "Write Docker Devbox File",
-        description: "Use this when you need to create or overwrite a text file inside the Docker devbox workspace.",
+        title: `Write ${runtimeTitle} File`,
+        description: `Use this when you need to create or overwrite a text file inside the ${runtimeLabel} workspace.`,
         inputSchema: {
-          path: z.string().min(1).describe("File path inside the Docker devbox."),
+          path: z.string().min(1).describe(`File path inside the ${runtimeLabel}.`),
           content: z.string().describe("UTF-8 file contents to write."),
           append: z.boolean().default(false).describe("Append to the file instead of overwriting it."),
           create_dirs: z.boolean().default(true).describe("Create parent directories if they do not exist."),
         },
         outputSchema,
       },
-      "Writing Docker devbox file",
-      "Docker devbox file written",
+      `Writing ${runtimeLabel} file`,
+      `${runtimeLabel} file written`,
     ),
     async ({ path, content, append, create_dirs: createDirs }) => {
       try {
         const result = await writeFileInDevbox({ path, content, append, createDirs });
-        const summary = append ? `Appended text to ${path} in the Docker devbox.` : `Wrote ${path} in the Docker devbox.`;
+        const summary = append ? `Appended text to ${path} in the ${runtimeLabel}.` : `Wrote ${path} in the ${runtimeLabel}.`;
         return fromProcessResult(summary, result);
       } catch (error) {
-        return errorResult(error, `Failed to write ${path} in the Docker devbox.`);
+        return errorResult(error, `Failed to write ${path} in the ${runtimeLabel}.`);
       }
     },
   );
-
 
   server.registerTool(
     "devbox_write_large_file",
     safeActionTool(
       {
-        title: "Write Large Docker Devbox File",
-        description: "Use this when you need to create or overwrite a large file inside the Docker devbox workspace using base64-backed transfer with post-write verification.",
+        title: `Write Large ${runtimeTitle} File`,
+        description: `Use this when you need to create or overwrite a large file inside the ${runtimeLabel} workspace using base64-backed transfer with post-write verification.`,
         inputSchema: {
-          path: z.string().min(1).describe("File path inside the Docker devbox."),
+          path: z.string().min(1).describe(`File path inside the ${runtimeLabel}.`),
           content: z.string().optional().describe("Optional UTF-8 text payload to write. Prefer content_base64 for exact byte preservation."),
           content_base64: z.string().optional().describe("Base64-encoded raw bytes to write exactly as provided."),
           append: z.boolean().default(false).describe("Append to the file instead of overwriting it."),
@@ -567,8 +592,8 @@ const buildServer = () => {
         },
         outputSchema,
       },
-      "Writing large Docker devbox file",
-      "Large Docker devbox file written",
+      `Writing large ${runtimeLabel} file`,
+      `Large ${runtimeLabel} file written`,
     ),
     async ({ path, content, content_base64: contentBase64, append, create_dirs: createDirs, expected_sha256: expectedSha256 }) => {
       try {
@@ -581,14 +606,14 @@ const buildServer = () => {
           expectedSha256,
         });
         const summary = append
-          ? `Appended large payload to ${path} in the Docker devbox and verified the exact bytes.`
-          : `Wrote large payload to ${path} in the Docker devbox and verified the exact bytes.`;
+          ? `Appended large payload to ${path} in the ${runtimeLabel} and verified the exact bytes.`
+          : `Wrote large payload to ${path} in the ${runtimeLabel} and verified the exact bytes.`;
         return successResult(summary, {
           data,
           text: textFromResult(summary, summarizeLargeWriteData(data)),
         });
       } catch (error) {
-        return errorResult(error, `Failed to write large payload to ${path} in the Docker devbox.`);
+        return errorResult(error, `Failed to write large payload to ${path} in the ${runtimeLabel}.`);
       }
     },
   );
@@ -597,10 +622,12 @@ const buildServer = () => {
     "devbox_search_files",
     safeReadOnlyTool(
       {
-        title: "Search Docker Devbox Files",
-        description: "Use this when you need ripgrep-style text search inside the Docker devbox workspace.",
+        title: `Search ${runtimeTitle} Files`,
+        description: isDockerRuntime
+          ? "Use this when you need ripgrep-style text search inside the Docker devbox workspace."
+          : `Use this when you need text search inside the ${runtimeLabel} workspace. ripgrep-style syntax is supported best-effort in host mode.`,
         inputSchema: {
-          pattern: z.string().min(1).describe("Search pattern for ripgrep."),
+          pattern: z.string().min(1).describe("Search pattern for ripgrep or regex-style matching."),
           path: z.string().default(config.devboxWorkspacePath).describe("Directory path to search."),
           glob: z.string().default("*").describe("Optional glob filter."),
           case_sensitive: z.boolean().default(false).describe("When true, use case-sensitive search."),
@@ -608,103 +635,162 @@ const buildServer = () => {
         },
         outputSchema,
       },
-      "Searching Docker devbox files",
-      "Docker devbox search finished",
+      `Searching ${runtimeLabel} files`,
+      `${runtimeLabel} search finished`,
     ),
     async ({ pattern, path, glob, case_sensitive: caseSensitive, max_matches: maxMatches }) => {
       try {
         const result = await searchFilesInDevbox({ pattern, path, glob, caseSensitive, maxMatches });
-        return fromProcessResult(`Searched ${path} for "${pattern}" inside the Docker devbox.`, result);
+        return fromProcessResult(`Searched ${path} for "${pattern}" inside the ${runtimeLabel}.`, result);
       } catch (error) {
-        return errorResult(error, `Failed to search ${path} inside the Docker devbox.`);
+        return errorResult(error, `Failed to search ${path} inside the ${runtimeLabel}.`);
       }
     },
+  );
+
+  const hostStatusHandler = async () => {
+    try {
+      return successResult(`Fetched ${hostTitle.toLowerCase()} tool status.`, {
+        data: getHostToolStatus(),
+      });
+    } catch (error) {
+      return errorResult(error, `Failed to fetch ${hostTitle.toLowerCase()} tool status.`);
+    }
+  };
+
+  const hostExecHandler = async ({ command, working_dir: workingDir, timeout_seconds: timeoutSeconds }) => {
+    try {
+      const result = await runHostShellCommand({
+        command,
+        workingDir,
+        timeoutMs: (timeoutSeconds + 5) * 1000,
+      });
+      return fromProcessResult(`Ran a ${hostCommandTitle.toLowerCase()} command in ${workingDir}.`, result);
+    } catch (error) {
+      return errorResult(error, `Failed to run the ${hostCommandTitle.toLowerCase()} command.`);
+    }
+  };
+
+  const hostRunProgramHandler = async ({ program, args, working_dir: workingDir, timeout_seconds: timeoutSeconds }) => {
+    try {
+      const result = await runAllowedProgram({
+        program,
+        args,
+        workingDir,
+        timeoutMs: (timeoutSeconds + 5) * 1000,
+      });
+      return fromProcessResult(`Ran ${program} on the ${hostTitle.toLowerCase()}.`, result);
+    } catch (error) {
+      return errorResult(error, `Failed to run ${program} on the ${hostTitle.toLowerCase()}.`);
+    }
+  };
+
+  server.registerTool(
+    "host_status",
+    safeReadOnlyTool(
+      {
+        title: `${hostTitle} Tool Status`,
+        description: `Use this when you need to inspect whether ${hostTitle.toLowerCase()} execution is enabled and which native programs are allowed.`,
+        outputSchema,
+      },
+      `Checking ${hostTitle.toLowerCase()} tool status`,
+      `${hostTitle} tool status ready`,
+    ),
+    hostStatusHandler,
   );
 
   server.registerTool(
     "windows_host_status",
     safeReadOnlyTool(
       {
-        title: "Windows Host Tool Status",
-        description: "Use this when you need to inspect whether Windows host execution is enabled and which native programs are allowed.",
+        title: `${hostTitle} Tool Status`,
+        description: `Compatibility alias for host_status. Use this when you need to inspect whether ${hostTitle.toLowerCase()} execution is enabled and which native programs are allowed.`,
         outputSchema,
       },
-      "Checking Windows host tool status",
-      "Windows host tool status ready",
+      `Checking ${hostTitle.toLowerCase()} tool status`,
+      `${hostTitle} tool status ready`,
     ),
-    async () => {
-      try {
-        return successResult("Fetched Windows host tool status.", {
-          data: getHostToolStatus(),
-        });
-      } catch (error) {
-        return errorResult(error, "Failed to fetch Windows host tool status.");
-      }
-    },
+    hostStatusHandler,
+  );
+
+  server.registerTool(
+    "host_exec",
+    safeActionTool(
+      {
+        title: `Run ${hostCommandTitle} Command`,
+        description: config.platform.isWindows
+          ? `Use this when you explicitly need native ${hostTitle.toLowerCase()} tooling rather than the ${runtimeLabel}, such as winget, host Git, host Docker CLI, or PowerShell automation. This may prompt for elevation on Windows when needed.`
+          : `Use this when you explicitly need native ${hostTitle.toLowerCase()} tooling rather than the ${runtimeLabel}, such as shell automation, git, node, python, or other host commands.`,
+        inputSchema: {
+          command: z.string().min(1).describe(`Command to run on the ${hostTitle.toLowerCase()}.`),
+          working_dir: z.string().default(config.hostDefaultWorkdir).describe(`Working directory on the ${hostTitle.toLowerCase()}.`),
+          timeout_seconds: z.number().int().min(1).max(7200).default(300).describe("Command timeout in seconds."),
+        },
+        outputSchema,
+      },
+      `Running ${hostCommandTitle.toLowerCase()} command`,
+      `${hostCommandTitle} command finished`,
+    ),
+    hostExecHandler,
   );
 
   server.registerTool(
     "windows_host_exec",
     safeActionTool(
       {
-        title: "Run Windows PowerShell Command",
-        description:
-          "Use this when you explicitly need native Windows host tooling rather than the reproducible Docker devbox, such as winget, host Git, host Docker CLI, or PowerShell automation. This tool defaults to elevated administrator execution and will prompt for UAC when needed.",
+        title: `Run ${hostCommandTitle} Command`,
+        description: `Compatibility alias for host_exec. Use this when you explicitly need native ${hostTitle.toLowerCase()} tooling rather than the ${runtimeLabel}.`,
         inputSchema: {
-          command: z.string().min(1).describe("PowerShell command to run on the Windows host."),
-          working_dir: z.string().default(config.hostDefaultWorkdir).describe("Working directory on the Windows host."),
+          command: z.string().min(1).describe(`Command to run on the ${hostTitle.toLowerCase()}.`),
+          working_dir: z.string().default(config.hostDefaultWorkdir).describe(`Working directory on the ${hostTitle.toLowerCase()}.`),
           timeout_seconds: z.number().int().min(1).max(7200).default(300).describe("Command timeout in seconds."),
         },
         outputSchema,
       },
-      "Running Windows PowerShell command",
-      "Windows PowerShell command finished",
+      `Running ${hostCommandTitle.toLowerCase()} command`,
+      `${hostCommandTitle} command finished`,
     ),
-    async ({ command, working_dir: workingDir, timeout_seconds: timeoutSeconds }) => {
-      try {
-        const result = await runWindowsPowerShell({
-          command,
-          workingDir,
-          timeoutMs: (timeoutSeconds + 5) * 1000,
-        });
-        return fromProcessResult(`Ran a Windows PowerShell command in ${workingDir}.`, result);
-      } catch (error) {
-        return errorResult(error, "Failed to run the Windows PowerShell command.");
-      }
-    },
+    hostExecHandler,
+  );
+
+  server.registerTool(
+    "host_run_program",
+    safeActionTool(
+      {
+        title: `Run Allowed ${hostTitle} Program`,
+        description: `Use this when you need a specific allowed ${hostTitle.toLowerCase()} program such as git, node, python, gh, or other tools from HOST_PROGRAM_ALLOWLIST with structured arguments.`,
+        inputSchema: {
+          program: z.string().min(1).describe("Program name or path. It must be allowed by HOST_PROGRAM_ALLOWLIST."),
+          args: z.array(z.string()).default([]).describe("Argument list for the program."),
+          working_dir: z.string().default(config.hostDefaultWorkdir).describe(`Working directory on the ${hostTitle.toLowerCase()}.`),
+          timeout_seconds: z.number().int().min(1).max(7200).default(300).describe("Command timeout in seconds."),
+        },
+        outputSchema,
+      },
+      `Running allowed ${hostTitle.toLowerCase()} program`,
+      `Allowed ${hostTitle.toLowerCase()} program finished`,
+    ),
+    hostRunProgramHandler,
   );
 
   server.registerTool(
     "windows_host_run_program",
     safeActionTool(
       {
-        title: "Run Allowed Windows Host Program",
-        description:
-          "Use this when you need a specific allowed Windows host program such as git, docker, node, python, or winget with structured arguments.",
+        title: `Run Allowed ${hostTitle} Program`,
+        description: `Compatibility alias for host_run_program. Use this when you need a specific allowed ${hostTitle.toLowerCase()} program with structured arguments.`,
         inputSchema: {
           program: z.string().min(1).describe("Program name or path. It must be allowed by HOST_PROGRAM_ALLOWLIST."),
           args: z.array(z.string()).default([]).describe("Argument list for the program."),
-          working_dir: z.string().default(config.hostDefaultWorkdir).describe("Working directory on the Windows host."),
+          working_dir: z.string().default(config.hostDefaultWorkdir).describe(`Working directory on the ${hostTitle.toLowerCase()}.`),
           timeout_seconds: z.number().int().min(1).max(7200).default(300).describe("Command timeout in seconds."),
         },
         outputSchema,
       },
-      "Running allowed Windows program",
-      "Allowed Windows program finished",
+      `Running allowed ${hostTitle.toLowerCase()} program`,
+      `Allowed ${hostTitle.toLowerCase()} program finished`,
     ),
-    async ({ program, args, working_dir: workingDir, timeout_seconds: timeoutSeconds }) => {
-      try {
-        const result = await runAllowedProgram({
-          program,
-          args,
-          workingDir,
-          timeoutMs: (timeoutSeconds + 5) * 1000,
-        });
-        return fromProcessResult(`Ran ${program} on the Windows host.`, result);
-      } catch (error) {
-        return errorResult(error, `Failed to run ${program} on the Windows host.`);
-      }
-    },
+    hostRunProgramHandler,
   );
 
   return server;
@@ -763,7 +849,7 @@ if (config.authMode === "demo-oauth" || config.authMode === "cloudflare-access")
       issuerUrl,
       resourceServerUrl: mcpServerUrl,
       scopesSupported: ["mcp:tools"],
-      resourceName: "Docker ChatGPT Devbox MCP",
+      resourceName: runtimeServerName,
     }),
   );
 
@@ -781,9 +867,11 @@ if (config.authMode === "demo-oauth" || config.authMode === "cloudflare-access")
 
 app.get("/", async (_req, res) => {
   const baseResponse = {
-    name: "Docker ChatGPT Devbox MCP",
+    name: runtimeServerName,
     version,
     auth_mode: config.authMode,
+    runtime_mode: config.runtimeMode,
+    platform: config.platform.id,
     public_base_url: config.publicBaseUrl || null,
     mcp_url: config.publicBaseUrl ? `${config.publicBaseUrl}/mcp` : null,
     oauth: oauthInfo,
@@ -791,8 +879,8 @@ app.get("/", async (_req, res) => {
       config.authMode === "cloudflare-access"
         ? "Cloudflare Access-backed OAuth is enabled for ChatGPT app testing. Protect the /authorize path with a Cloudflare Access application."
         : config.authMode === "demo-oauth"
-          ? "Demo OAuth is enabled for ChatGPT app testing. The Docker devbox is the main execution environment; Windows host tools are separate and explicit."
-          : "No Authentication mode is active. The Docker devbox is the main execution environment; Windows host tools are separate and explicit.",
+          ? `Demo OAuth is enabled for ChatGPT app testing. The ${runtimeLabel} is the main execution environment; host tools are separate and explicit.`
+          : `No authentication mode is active. The ${runtimeLabel} is the main execution environment; host tools are separate and explicit.`,
   };
 
   if (config.authMode !== "none" && !isLocalRequest(_req)) {
@@ -809,11 +897,14 @@ app.get("/", async (_req, res) => {
   res.json({
     ...baseResponse,
     runtime: {
+      runtimeMode: config.runtimeMode,
+      platform: config.platform.id,
+      hostShell: config.hostShell,
       devboxContainerName: config.devboxContainerName,
       devboxImageName: config.devboxImageName,
       devboxWorkspacePath: config.devboxWorkspacePath,
       hostWorkspacePath: config.hostWorkspacePath,
-      windowsHostExecEnabled: config.enableWindowsHostExec,
+      hostExecEnabled: config.enableHostExec,
     },
     devbox,
   });
@@ -872,7 +963,8 @@ app.get("/mcp", ...getHandlers);
 app.delete("/mcp", ...deleteHandlers);
 
 app.listen(config.port, config.host, () => {
-  console.log(`Docker ChatGPT Devbox MCP listening on ${config.host}:${config.port}`);
+  console.log(`${runtimeServerName} listening on ${config.host}:${config.port}`);
+  console.log(`Runtime mode: ${config.runtimeMode} (${config.platform.displayName})`);
   console.log(`Auth mode: ${config.authMode}`);
   if (config.publicBaseUrl) {
     console.log(`Public MCP URL: ${config.publicBaseUrl}/mcp`);

--- a/test/host-runtime.test.js
+++ b/test/host-runtime.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+
+const importFresh = async (relativePath) => {
+  const href = pathToFileURL(path.join(process.cwd(), relativePath)).href;
+  return import(`${href}?t=${Date.now()}-${Math.random()}`);
+};
+
+test("host runtime reports ready status and creates the workspace directory", async () => {
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "devbox-host-runtime-"));
+  process.env.MCP_AUTH_MODE = "none";
+  process.env.PUBLIC_BASE_URL = "";
+  process.env.DEVBOX_RUNTIME_MODE = "host";
+  process.env.HOST_WORKSPACE_PATH = path.join(workspaceDir, "workspace");
+  process.env.DEVBOX_WORKSPACE_PATH = process.env.HOST_WORKSPACE_PATH;
+
+  const { ensureHostRuntimeReady } = await importFresh("src/host-runtime.js");
+  const info = await ensureHostRuntimeReady();
+
+  assert.equal(info.mode, "host");
+  assert.equal(info.exists, true);
+  assert.equal(info.running, true);
+  assert.equal(info.workspacePath, process.env.HOST_WORKSPACE_PATH);
+});
+
+test("host runtime can run shell commands and perform file operations", async () => {
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "devbox-host-runtime-"));
+  process.env.MCP_AUTH_MODE = "none";
+  process.env.PUBLIC_BASE_URL = "";
+  process.env.DEVBOX_RUNTIME_MODE = "host";
+  process.env.HOST_WORKSPACE_PATH = workspaceDir;
+  process.env.DEVBOX_WORKSPACE_PATH = workspaceDir;
+  process.env.HOST_DEFAULT_WORKDIR = workspaceDir;
+
+  const {
+    execInHostRuntime,
+    listFilesInHostRuntime,
+    readFileInHostRuntime,
+    searchFilesInHostRuntime,
+    writeFileInHostRuntime,
+  } = await importFresh("src/host-runtime.js");
+
+  await writeFile(path.join(workspaceDir, "notes.txt"), "alpha\nbeta\n", "utf8");
+  const execResult = await execInHostRuntime({ command: "printf 'termux-ok'", workingDir: workspaceDir, timeoutMs: 5000 });
+  const listResult = await listFilesInHostRuntime({ path: workspaceDir, recursive: true, maxDepth: 2 });
+  const readResult = await readFileInHostRuntime({ path: path.join(workspaceDir, "notes.txt"), maxBytes: 64 });
+  const searchResult = await searchFilesInHostRuntime({ pattern: "beta", path: workspaceDir, maxMatches: 10 });
+  await writeFileInHostRuntime({ path: path.join(workspaceDir, "written.txt"), content: "hello host runtime" });
+
+  assert.equal(execResult.stdout, "termux-ok");
+  assert.match(listResult.stdout, /notes\.txt/);
+  assert.equal(readResult.stdout, "alpha\nbeta\n");
+  assert.match(searchResult.stdout, /notes\.txt/);
+  assert.equal(await readFile(path.join(workspaceDir, "written.txt"), "utf8"), "hello host runtime");
+});

--- a/test/host-tools.test.js
+++ b/test/host-tools.test.js
@@ -3,24 +3,21 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
 
 import { spawnProcess } from "../src/process-utils.js";
 
-process.env.MCP_AUTH_MODE = "none";
-process.env.PUBLIC_BASE_URL = "";
+const hasPowerShell = process.platform === "win32";
 
-const {
-  MAX_POWERSHELL_ENCODED_COMMAND_CHARS_BEFORE_FILE,
-  buildWindowsPowerShellArgs,
-  buildWindowsPowerShellFileArgs,
-  buildElevatedWindowsPowerShellWrapper,
-  buildElevatedWindowsPowerShellLauncher,
-  shouldUsePowerShellScriptFile,
-  resolveHostProgramExecutable,
-  getHostToolStatus,
-} = await import("../src/host-tools.js");
+const importFreshHostTools = async () => {
+  process.env.MCP_AUTH_MODE = "none";
+  process.env.PUBLIC_BASE_URL = "";
+  const href = pathToFileURL(path.join(process.cwd(), "src/host-tools.js")).href;
+  return import(`${href}?t=${Date.now()}-${Math.random()}`);
+};
 
-test("buildWindowsPowerShellArgs encodes the original script exactly", () => {
+test("buildWindowsPowerShellArgs encodes the original script exactly", async () => {
+  const { buildWindowsPowerShellArgs } = await importFreshHostTools();
   const command = "$value = 'A \"quoted\" value with ''single'' quotes'; Write-Output $value";
   const args = buildWindowsPowerShellArgs(command);
 
@@ -31,7 +28,8 @@ test("buildWindowsPowerShellArgs encodes the original script exactly", () => {
   assert.equal(Buffer.from(args[6], "base64").toString("utf16le"), command);
 });
 
-test("encoded PowerShell execution preserves nested quotes end to end", async () => {
+test("encoded PowerShell execution preserves nested quotes end to end", { skip: !hasPowerShell }, async () => {
+  const { buildWindowsPowerShellArgs } = await importFreshHostTools();
   const command = "$value = 'A \"quoted\" value with ''single'' quotes'; Write-Output $value";
   const result = await spawnProcess("powershell.exe", buildWindowsPowerShellArgs(command), {
     cwd: process.cwd(),
@@ -41,7 +39,8 @@ test("encoded PowerShell execution preserves nested quotes end to end", async ()
   assert.equal(result.stdout.trim(), "A \"quoted\" value with 'single' quotes");
 });
 
-test("shouldUsePowerShellScriptFile switches to file-backed execution for large commands", () => {
+test("shouldUsePowerShellScriptFile switches to file-backed execution for large commands", async () => {
+  const { MAX_POWERSHELL_ENCODED_COMMAND_CHARS_BEFORE_FILE, buildWindowsPowerShellArgs, shouldUsePowerShellScriptFile } = await importFreshHostTools();
   const smallCommand = "Write-Output 'ok'";
   const largeCommand = `Write-Output '${"x".repeat(90000)}'`;
 
@@ -50,7 +49,8 @@ test("shouldUsePowerShellScriptFile switches to file-backed execution for large 
   assert.ok(buildWindowsPowerShellArgs(largeCommand).join(" ").length >= MAX_POWERSHELL_ENCODED_COMMAND_CHARS_BEFORE_FILE);
 });
 
-test("file-backed PowerShell execution handles very large one-shot payloads", async () => {
+test("file-backed PowerShell execution handles very large one-shot payloads", { skip: !hasPowerShell }, async () => {
+  const { buildWindowsPowerShellFileArgs } = await importFreshHostTools();
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "docker-chatgpt-devbox-host-tools-test-"));
   const scriptPath = path.join(tempDir, "large-command.ps1");
   const payload = "x".repeat(90000);
@@ -69,13 +69,15 @@ test("file-backed PowerShell execution handles very large one-shot payloads", as
   }
 });
 
-test("resolveHostProgramExecutable maps node to the real node.exe path", () => {
+test("resolveHostProgramExecutable maps node to the real node path", async () => {
+  const { getHostToolStatus, resolveHostProgramExecutable } = await importFreshHostTools();
   assert.equal(resolveHostProgramExecutable("node"), process.execPath);
   assert.equal(resolveHostProgramExecutable("node.exe"), process.execPath);
   assert.match(getHostToolStatus().resolvedNodeExe, /node(\.exe)?$/i);
 });
 
-test("buildElevatedWindowsPowerShellWrapper preserves working directory and output paths", () => {
+test("buildElevatedWindowsPowerShellWrapper preserves working directory and output paths", async () => {
+  const { buildElevatedWindowsPowerShellWrapper } = await importFreshHostTools();
   const wrapper = buildElevatedWindowsPowerShellWrapper({
     scriptPath: "C:\\Temp\\command.ps1",
     workingDir: "C:\\Temp\\quoted path",
@@ -91,7 +93,8 @@ test("buildElevatedWindowsPowerShellWrapper preserves working directory and outp
   assert.equal(wrapper.includes("& 'C:\\Temp\\command.ps1'"), true);
 });
 
-test("buildElevatedWindowsPowerShellLauncher uses RunAs elevation", () => {
+test("buildElevatedWindowsPowerShellLauncher uses RunAs elevation", async () => {
+  const { buildElevatedWindowsPowerShellLauncher } = await importFreshHostTools();
   const launcher = buildElevatedWindowsPowerShellLauncher({
     scriptPath: "C:\\Temp\\command.ps1",
     workingDir: "C:\\Temp",
@@ -104,4 +107,16 @@ test("buildElevatedWindowsPowerShellLauncher uses RunAs elevation", () => {
   assert.match(launcher, /Start-Process -FilePath 'powershell\.exe' -Verb RunAs/);
   assert.match(launcher, /WaitForExit\(15000\)/);
   assert.match(launcher, /Stop-Process -Id \$process\.Id -Force/);
+});
+
+test("runHostShellCommand executes a posix shell command on non-Windows hosts", { skip: hasPowerShell }, async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "devbox-host-shell-"));
+  process.env.HOST_DEFAULT_WORKDIR = tempDir;
+  process.env.HOST_SHELL = "/bin/sh";
+  process.env.ENABLE_HOST_EXEC = "true";
+
+  const { runHostShellCommand } = await importFreshHostTools();
+  const result = await runHostShellCommand({ command: "printf 'host-shell-ok'", workingDir: tempDir, timeoutMs: 5000 });
+
+  assert.equal(result.stdout, "host-shell-ok");
 });

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { buildServerUrl, getLauncherPaths, parseLauncherArgs } from "../src/launcher.js";
+
+test("parseLauncherArgs defaults to background start and supports explicit commands", () => {
+  assert.deepEqual(parseLauncherArgs([]), { command: "start", background: true });
+  assert.deepEqual(parseLauncherArgs(["start"]), { command: "start", background: true });
+  assert.deepEqual(parseLauncherArgs(["run"]), { command: "run", background: false });
+  assert.deepEqual(parseLauncherArgs(["status"]), { command: "status", background: false });
+});
+
+test("getLauncherPaths stores pid and log files under run/", () => {
+  const paths = getLauncherPaths("/tmp/devbox-project");
+
+  assert.equal(paths.runDir, path.join("/tmp/devbox-project", "run"));
+  assert.equal(paths.pidFile, path.join("/tmp/devbox-project", "run", "devbox.pid"));
+  assert.equal(paths.logFile, path.join("/tmp/devbox-project", "run", "devbox.log"));
+});
+
+test("buildServerUrl normalizes wildcard hosts to loopback", () => {
+  assert.equal(buildServerUrl({ host: "0.0.0.0", port: 8100 }), "http://127.0.0.1:8100");
+  assert.equal(buildServerUrl({ host: "::", port: 8100 }), "http://127.0.0.1:8100");
+  assert.equal(buildServerUrl({ host: "localhost", port: 8100 }), "http://localhost:8100");
+});

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  detectPlatform,
+  defaultHostProgramAllowlist,
+  resolveRuntimeMode,
+  resolveHostShell,
+} from "../src/platform.js";
+
+test("detectPlatform recognizes Termux from PREFIX", () => {
+  const platform = detectPlatform({ PREFIX: "/data/data/com.termux/files/usr" }, "linux");
+
+  assert.equal(platform.id, "termux");
+  assert.equal(platform.isTermux, true);
+  assert.equal(platform.isLinux, true);
+  assert.equal(platform.displayName, "Termux");
+});
+
+test("resolveRuntimeMode defaults to host on Termux and docker on Windows", () => {
+  assert.equal(resolveRuntimeMode({ requestedMode: "", platform: detectPlatform({ PREFIX: "/data/data/com.termux/files/usr" }, "linux") }), "host");
+  assert.equal(resolveRuntimeMode({ requestedMode: "", platform: detectPlatform({}, "win32") }), "docker");
+  assert.equal(resolveRuntimeMode({ requestedMode: "docker", platform: detectPlatform({}, "darwin") }), "docker");
+  assert.equal(resolveRuntimeMode({ requestedMode: "host", platform: detectPlatform({}, "linux") }), "host");
+});
+
+test("defaultHostProgramAllowlist includes shell-friendly tools on posix hosts", () => {
+  const allowlist = defaultHostProgramAllowlist(detectPlatform({}, "linux"));
+
+  assert.equal(allowlist.includes("bash"), true);
+  assert.equal(allowlist.includes("git"), true);
+  assert.equal(allowlist.includes("python3"), true);
+  assert.equal(allowlist.includes("powershell"), false);
+});
+
+test("resolveHostShell prefers SHELL on posix and PowerShell on Windows", () => {
+  assert.equal(resolveHostShell({ SHELL: "/bin/bash" }, detectPlatform({}, "linux")), "/bin/bash");
+  assert.equal(resolveHostShell({}, detectPlatform({}, "linux")), "/bin/sh");
+  assert.equal(resolveHostShell({}, detectPlatform({}, "win32")), "powershell.exe");
+});


### PR DESCRIPTION
- add runtime abstraction and host-mode launcher/CLI
- default Termux/Linux/macOS to host mode while keeping Docker on Windows
- generalize MCP server/runtime metadata and add host tooling docs/tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added host mode support for running on Linux, macOS, and Termux without Docker
  * Introduced `devbox` CLI tool for managing service lifecycle (start, stop, status, restart, run commands)
  * Added platform-aware runtime selection and configuration

* **Documentation**
  * Added setup guides for Termux and host-mode compatibility documentation
  * Updated README with new runtime modes and CLI usage instructions

* **Tests**
  * Added comprehensive test coverage for host runtime and platform detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->