### PR TITLE
Add Termux and Android bootstrap support

### DIFF
--- a/.github/workflows/bootstrap-binaries.yml
+++ b/.github/workflows/bootstrap-binaries.yml
@@ -3,20 +3,21 @@ name: Build bootstrap binaries
 on:
   push:
     branches: [main]
-    paths:
-      - "bootstrap/**"
-      - ".github/workflows/bootstrap-binaries.yml"
+    tags:
+      - "bootstrap-v*"
   pull_request:
     paths:
       - "bootstrap/**"
+      - "scripts/install-termux.sh"
+      - "docs/TERMUX.md"
       - ".github/workflows/bootstrap-binaries.yml"
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  build:
+  desktop:
     name: ${{ matrix.artifact }}
     strategy:
       fail-fast: false
@@ -25,20 +26,24 @@ jobs:
           - os: ubuntu-latest
             artifact: devbox-setup-linux-x86_64
             binary: bootstrap/target/release/devbox-setup
+            output: devbox-setup-linux-x86_64
           - os: windows-latest
             artifact: devbox-setup-windows-x86_64
             binary: bootstrap/target/release/devbox-setup.exe
+            output: devbox-setup-windows-x86_64.exe
           - os: macos-15-intel
             artifact: devbox-setup-macos-x86_64
             binary: bootstrap/target/release/devbox-setup
+            output: devbox-setup-macos-x86_64
           - os: macos-15
             artifact: devbox-setup-macos-aarch64
             binary: bootstrap/target/release/devbox-setup
+            output: devbox-setup-macos-aarch64
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Select stable Rust
         run: rustup default stable
       - name: Format check
@@ -47,9 +52,84 @@ jobs:
         run: cargo test --manifest-path bootstrap/Cargo.toml
       - name: Build release binary
         run: cargo build --release --manifest-path bootstrap/Cargo.toml
+      - name: Prepare named binary
+        shell: bash
+        run: cp "${{ matrix.binary }}" "${{ matrix.output }}"
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.binary }}
+          path: ${{ matrix.output }}
           if-no-files-found: error
+
+  android:
+    name: Android and Termux binaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Select stable Rust
+        run: rustup default stable
+      - name: Install Android Rust targets
+        run: >-
+          rustup target add
+          aarch64-linux-android
+          armv7-linux-androideabi
+          x86_64-linux-android
+          i686-linux-android
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --version 4.1.2 --locked
+      - name: Format check
+        run: cargo fmt --manifest-path bootstrap/Cargo.toml -- --check
+      - name: Test host logic
+        run: cargo test --manifest-path bootstrap/Cargo.toml
+      - name: Build Android API 21 binaries
+        working-directory: bootstrap
+        run: |
+          for abi in arm64-v8a armeabi-v7a x86_64 x86; do
+            cargo ndk --platform 21 -t "$abi" build --release
+          done
+      - name: Prepare Android artifacts
+        run: |
+          mkdir -p release-assets
+          cp bootstrap/target/aarch64-linux-android/release/devbox-setup release-assets/devbox-setup-android-arm64-v8a
+          cp bootstrap/target/armv7-linux-androideabi/release/devbox-setup release-assets/devbox-setup-android-armeabi-v7a
+          cp bootstrap/target/x86_64-linux-android/release/devbox-setup release-assets/devbox-setup-android-x86_64
+          cp bootstrap/target/i686-linux-android/release/devbox-setup release-assets/devbox-setup-android-x86
+          file release-assets/*
+      - name: Upload Android binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: devbox-setup-android
+          path: release-assets/*
+          if-no-files-found: error
+
+  release:
+    name: Publish bootstrap release
+    if: startsWith(github.ref, 'refs/tags/bootstrap-v')
+    needs: [desktop, android]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all binaries
+        uses: actions/download-artifact@v8
+        with:
+          pattern: devbox-setup-*
+          path: release-assets
+          merge-multiple: true
+      - name: Generate checksums
+        run: |
+          cd release-assets
+          sha256sum devbox-setup-* > SHA256SUMS
+          cat SHA256SUMS
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Devbox bootstrap ${{ github.ref_name }}
+          generate_release_notes: true
+          make_latest: true
+          body: |
+            Cross-platform Devbox setup binaries, including Android API 21+ builds for Termux.
+
+            Canonical Termux app: https://github.com/adybag14-cyber/termux-app
+          files: release-assets/*

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Prebuilt binaries are produced by the **Build bootstrap binaries** GitHub Action
 - Linux x86-64
 - macOS x86-64
 - macOS Apple Silicon
+- Android/Termux arm64-v8a
+- Android/Termux armeabi-v7a
+- Android/Termux x86-64
+- Android/Termux x86
 
 Download the artifact for your operating system from the latest successful workflow run, extract it, and run it.
 
@@ -61,11 +65,33 @@ Useful installer options:
 --workspace /path/to/workspace
 --no-start
 --no-link
+--skip-system-packages
 --skip-install
 --dry-run
 ```
 
 The installer does not replace an existing `.env` with `.env.example`; it preserves existing lines and updates only explicitly selected keys.
+
+
+### Android and Termux
+
+Install the signed canonical Termux app from:
+
+- <https://github.com/adybag14-cyber/termux-app>
+- <https://github.com/adybag14-cyber/termux-app/releases>
+
+Then run inside Termux:
+
+```bash
+pkg install -y curl ca-certificates
+curl --fail --location --output install-devbox.sh \
+  https://raw.githubusercontent.com/adybag14-cyber/devbox/main/scripts/install-termux.sh
+sh install-devbox.sh
+```
+
+The installer chooses the correct Android ABI, SHA-256 verifies and installs the matching release binary, provisions the required Termux packages, configures host mode, starts Devbox, and checks its health endpoint.
+
+Full Android instructions: [docs/TERMUX.md](./docs/TERMUX.md)
 
 ## Build the Rust installer yourself
 
@@ -109,6 +135,7 @@ The Rust bootstrap binary still needs the runtime prerequisites used by Devbox i
 
 ### Host mode
 
+- Android API 21+ through the canonical Termux app
 - Termux, Linux, or macOS
 - optional but useful: `gh`, `python3`, `ripgrep`, and `curl`
 
@@ -154,7 +181,9 @@ Behavior:
 - generic host tools are exposed through `host_*`
 - legacy `windows_host_*` names remain compatibility aliases
 
-Termux instructions: [docs/TERMUX.md](./docs/TERMUX.md)
+Termux and Android instructions: [docs/TERMUX.md](./docs/TERMUX.md)
+
+Canonical Termux app: <https://github.com/adybag14-cyber/termux-app>
 
 Linux/macOS details: [docs/HOST_COMPATIBILITY.md](./docs/HOST_COMPATIBILITY.md)
 

--- a/bootstrap/Cargo.lock
+++ b/bootstrap/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "devbox-setup"
-version = "0.1.0"
+version = "0.2.0"

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devbox-setup"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.74"
 description = "Cross-platform bootstrap installer for Devbox MCP"

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,9 +1,10 @@
 # Devbox setup binary
 
-`devbox-setup` is a dependency-free Rust bootstrap program for new Devbox MCP installations.
+`devbox-setup` is a dependency-free Rust bootstrap program for new Devbox MCP installations on Windows, Linux, macOS, and Termux on Android.
 
 It can configure an existing checkout or clone the official repository into `./devbox`, then:
 
+- detects Termux and provisions Android packages with `pkg`
 - verifies Node.js 18+ and npm
 - creates `.env` from `.env.example` without discarding an existing configuration
 - creates `workspace/` and `run/`
@@ -11,12 +12,19 @@ It can configure an existing checkout or clone the official repository into `./d
 - attempts `npm link` without blocking setup if the global npm prefix is not writable
 - starts the service and checks `/healthz`
 
-Build and test:
+Build and test on the host:
 
 ```bash
 cargo test --manifest-path bootstrap/Cargo.toml
 cargo build --release --manifest-path bootstrap/Cargo.toml
 ```
+
+Android release targets are built with Android NDK API 21 for:
+
+- `aarch64-linux-android`
+- `armv7-linux-androideabi`
+- `x86_64-linux-android`
+- `i686-linux-android`
 
 Run from an existing checkout:
 
@@ -30,4 +38,13 @@ Run from an empty directory to clone and configure Devbox:
 devbox-setup
 ```
 
-Use `devbox-setup --help` for runtime, port, workspace, and non-starting setup options.
+Termux users can install the matching Android binary with:
+
+```bash
+curl --fail --location --output install-devbox.sh   https://raw.githubusercontent.com/adybag14-cyber/devbox/main/scripts/install-termux.sh
+sh install-devbox.sh
+```
+
+Canonical Termux app: <https://github.com/adybag14-cyber/termux-app>
+
+Use `devbox-setup --help` for runtime, port, workspace, package-provisioning, and non-starting setup options.

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -10,7 +10,16 @@ use std::thread;
 use std::time::Duration;
 
 const DEFAULT_REPO_URL: &str = "https://github.com/adybag14-cyber/devbox.git";
+const CANONICAL_TERMUX_REPO: &str = "https://github.com/adybag14-cyber/termux-app";
 const MINIMUM_NODE_MAJOR: u32 = 18;
+const TERMUX_PACKAGES: &[&str] = &[
+    "nodejs",
+    "git",
+    "python",
+    "ripgrep",
+    "curl",
+    "ca-certificates",
+];
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug)]
@@ -70,6 +79,7 @@ struct Options {
     bind_host: Option<String>,
     port: Option<u16>,
     workspace: Option<PathBuf>,
+    install_system_packages: bool,
     install_dependencies: bool,
     link_command: bool,
     start_server: bool,
@@ -85,6 +95,7 @@ impl Default for Options {
             bind_host: None,
             port: None,
             workspace: None,
+            install_system_packages: true,
             install_dependencies: true,
             link_command: true,
             start_server: true,
@@ -103,6 +114,7 @@ DEFAULT BEHAVIOUR:
     - Uses the current directory when it is already a Devbox checkout.
     - Otherwise clones Devbox into ./devbox.
     - Creates .env without overwriting an existing file.
+    - On Termux, installs required Android packages with `pkg`.
     - Installs npm dependencies, links the `devbox` command, and starts it.
 
 OPTIONS:
@@ -112,6 +124,7 @@ OPTIONS:
     --host <ADDRESS>       Set HOST in .env
     --port <PORT>          Set PORT in .env
     --workspace <PATH>     Set host workspace and default work directory
+    --skip-system-packages Do not install Termux packages with pkg
     --skip-install         Do not run npm install
     --no-link              Do not run npm link
     --no-start             Do not start the MCP service
@@ -157,6 +170,7 @@ fn parse_args(arguments: impl IntoIterator<Item = String>) -> SetupResult<Option
             "--workspace" => {
                 options.workspace = Some(PathBuf::from(next_value(&mut arguments, "--workspace")?))
             }
+            "--skip-system-packages" => options.install_system_packages = false,
             "--skip-install" => options.install_dependencies = false,
             "--no-link" => options.link_command = false,
             "--no-start" => options.start_server = false,
@@ -313,6 +327,38 @@ fn parse_node_major(version: &str) -> Option<u32> {
         .next()?
         .parse::<u32>()
         .ok()
+}
+
+fn is_termux_values(termux_version: Option<&str>, prefix: Option<&str>) -> bool {
+    termux_version.is_some_and(|value| !value.trim().is_empty())
+        || prefix.is_some_and(|value| value.contains("com.termux/files/usr"))
+}
+
+fn is_termux_environment() -> bool {
+    let termux_version = env::var("TERMUX_VERSION").ok();
+    let prefix = env::var("PREFIX").ok();
+    is_termux_values(termux_version.as_deref(), prefix.as_deref())
+}
+
+fn termux_package_arguments() -> Vec<&'static str> {
+    let mut arguments = vec!["install", "-y"];
+    arguments.extend_from_slice(TERMUX_PACKAGES);
+    arguments
+}
+
+fn install_termux_prerequisites(options: &Options) -> SetupResult<()> {
+    if !is_termux_environment() || !options.install_system_packages {
+        return Ok(());
+    }
+
+    println!("Termux on Android detected.");
+    println!("Canonical Termux app: {CANONICAL_TERMUX_REPO}");
+    let arguments = termux_package_arguments();
+    run_command("pkg", &arguments, None, options.dry_run).map_err(|error| {
+        Box::new(SetupError(format!(
+            "failed to install Termux packages with pkg: {error}. Use --skip-system-packages only when Node.js 18+, npm, and Git are already installed"
+        ))) as Box<dyn Error>
+    })
 }
 
 fn verify_toolchain() -> SetupResult<()> {
@@ -496,11 +542,17 @@ fn prepare_files(repo: &Path, options: &Options) -> SetupResult<PreparedConfig> 
         content.remove(0);
     }
 
+    let termux = is_termux_environment();
     if env_created || options.runtime.is_some() {
+        let default_runtime = if termux {
+            RuntimeMode::Host
+        } else {
+            RuntimeMode::Auto
+        };
         content = set_env_value(
             &content,
             "DEVBOX_RUNTIME_MODE",
-            options.runtime.unwrap_or(RuntimeMode::Auto).as_str(),
+            options.runtime.unwrap_or(default_runtime).as_str(),
         );
     }
     if let Some(host) = &options.bind_host {
@@ -521,10 +573,20 @@ fn prepare_files(repo: &Path, options: &Options) -> SetupResult<PreparedConfig> 
             }
         })
         .unwrap_or_else(|| repo.join("workspace"));
-    if options.workspace.is_some() {
+    if options.workspace.is_some() || (termux && env_created) {
         let workspace_value = workspace.to_string_lossy();
         content = set_env_value(&content, "HOST_WORKSPACE_PATH", &workspace_value);
         content = set_env_value(&content, "HOST_DEFAULT_WORKDIR", &workspace_value);
+    }
+    if termux && env_created {
+        let shell = env::var("PREFIX")
+            .ok()
+            .map(|prefix| PathBuf::from(prefix).join("bin/bash"))
+            .filter(|path| path.is_file())
+            .or_else(|| env::var("SHELL").ok().map(PathBuf::from));
+        if let Some(shell) = shell {
+            content = set_env_value(&content, "HOST_SHELL", &shell.to_string_lossy());
+        }
     }
 
     if options.dry_run {
@@ -634,6 +696,7 @@ fn wait_for_health(host: &str, port: u16) -> bool {
 
 fn setup(options: Options) -> SetupResult<()> {
     println!("Devbox MCP setup {VERSION}");
+    install_termux_prerequisites(&options)?;
     verify_toolchain()?;
     let repo = clone_or_locate_repo(&options)?;
     if options.dry_run && !is_devbox_repo(&repo) {
@@ -686,6 +749,10 @@ fn setup(options: Options) -> SetupResult<()> {
     println!();
     println!("Setup complete.");
     println!("Repository: {}", repo.display());
+    if is_termux_environment() {
+        println!("Platform: Termux on Android");
+        println!("Canonical Termux app: {CANONICAL_TERMUX_REPO}");
+    }
     println!(
         "Runtime: {} (resolved: {})",
         prepared.runtime.as_str(),
@@ -732,6 +799,26 @@ mod tests {
     }
 
     #[test]
+    fn detects_termux_from_version_or_prefix() {
+        assert!(is_termux_values(Some("0.118"), None));
+        assert!(is_termux_values(
+            None,
+            Some("/data/data/com.termux/files/usr")
+        ));
+        assert!(!is_termux_values(None, Some("/usr")));
+        assert!(!is_termux_values(Some(""), None));
+    }
+
+    #[test]
+    fn termux_packages_include_required_runtime_tools() {
+        let arguments = termux_package_arguments();
+        assert_eq!(&arguments[..2], &["install", "-y"]);
+        for package in ["nodejs", "git", "python", "ripgrep", "curl"] {
+            assert!(arguments.contains(&package));
+        }
+    }
+
+    #[test]
     fn updates_existing_environment_values_without_losing_comments() {
         let source = "# keep this\nPORT=8100\nHOST=0.0.0.0\n";
         let updated = set_env_value(source, "PORT", "9000");
@@ -774,12 +861,14 @@ mod tests {
             "host".to_string(),
             "--port".to_string(),
             "9000".to_string(),
+            "--skip-system-packages".to_string(),
             "--no-start".to_string(),
         ])
         .unwrap();
         assert_eq!(options.repo, Some(PathBuf::from("sample")));
         assert_eq!(options.runtime, Some(RuntimeMode::Host));
         assert_eq!(options.port, Some(9000));
+        assert!(!options.install_system_packages);
         assert!(!options.start_server);
     }
 

--- a/docs/TERMUX.md
+++ b/docs/TERMUX.md
@@ -1,79 +1,94 @@
-# Termux Host Mode
+# Termux and Android Support
 
-This repo can run directly on Termux without Docker.
+Devbox runs directly on Android through Termux host mode. Docker is not required.
 
-## Install prerequisites
+## Canonical Termux app
+
+Use the signed Android builds from the repository maintained for this project:
+
+- Repository: <https://github.com/adybag14-cyber/termux-app>
+- Releases: <https://github.com/adybag14-cyber/termux-app/releases>
+
+The canonical fork tracks `termux/termux-app`, publishes signed weekly universal APKs, supports Android API 21 or newer, and includes arm64-v8a, armeabi-v7a, x86_64, and x86 support.
+
+Do not install a build signed by a different distributor over the canonical build. Android treats different signing keys as different update lineages, so changing source can require uninstalling the existing app and losing its private app data.
+
+## Automatic setup
+
+Inside the canonical Termux app:
 
 ```bash
-pkg update
-pkg install nodejs git ripgrep python curl
+pkg install -y curl ca-certificates
+curl --fail --location --output install-devbox.sh   https://raw.githubusercontent.com/adybag14-cyber/devbox/main/scripts/install-termux.sh
+sh install-devbox.sh
 ```
 
-## Install devbox
+The script detects the Android ABI, downloads and SHA-256 verifies the matching `devbox-setup` binary from the latest Devbox GitHub release, installs it into `$PREFIX/bin`, and runs it.
+
+The Rust setup program then:
+
+1. Detects Termux from `TERMUX_VERSION` or `$PREFIX`.
+2. Installs `nodejs`, `git`, `python`, `ripgrep`, `curl`, and CA certificates with `pkg`.
+3. Clones Devbox into `./devbox`, unless it is run from an existing checkout.
+4. Creates a Termux host-mode `.env`.
+5. Installs npm dependencies and links the `devbox` command.
+6. Starts the MCP service and verifies `/healthz`.
+
+Use `--skip-system-packages` only when the required Termux packages are already installed.
+
+## Supported Android binaries
+
+| Android ABI | Common devices | Release asset |
+|---|---|---|
+| `arm64-v8a` | Most modern Android phones and tablets | `devbox-setup-android-arm64-v8a` |
+| `armeabi-v7a` | Older 32-bit ARM devices | `devbox-setup-android-armeabi-v7a` |
+| `x86_64` | Android emulators and some ChromeOS devices | `devbox-setup-android-x86_64` |
+| `x86` | Older Android emulators/devices | `devbox-setup-android-x86` |
+
+The binaries target Android API 21, matching the canonical Termux app minimum.
+
+## Manual source installation
 
 ```bash
-git clone https://github.com/adybag14-cyber/devbox.git ~/devbox
-cd ~/devbox
+pkg install -y nodejs git python ripgrep curl ca-certificates
+git clone https://github.com/adybag14-cyber/devbox.git "$HOME/devbox"
+cd "$HOME/devbox"
 cp .env.example .env
 npm install
+npm link
+node bin/devbox.js start
 ```
 
-Recommended `.env` settings for Termux:
+Recommended configuration:
 
 ```bash
 DEVBOX_RUNTIME_MODE=host
 HOST_WORKSPACE_PATH=$HOME/devbox/workspace
-HOST_DEFAULT_WORKDIR=$HOME
-HOST_SHELL=/data/data/com.termux/files/usr/bin/bash
+HOST_DEFAULT_WORKDIR=$HOME/devbox/workspace
+HOST_SHELL=$PREFIX/bin/bash
 ENABLE_HOST_EXEC=true
 ```
 
-If you want the `devbox` command in `$PREFIX/bin`:
-
-```bash
-cd ~/devbox
-npm link
-```
-
-That installs the package bin entry so you can start it from anywhere in Termux.
-
-## Start the service
-
-Background service:
-
-```bash
-devbox
-```
-
-Foreground service:
-
-```bash
-devbox run
-```
-
-Check status:
+## Service commands
 
 ```bash
 devbox status
-```
-
-Stop the background service:
-
-```bash
+devbox restart
 devbox stop
+devbox run
 ```
 
-## Verify locally
+Verify locally:
 
 ```bash
-curl http://127.0.0.1:8100/healthz
-curl http://127.0.0.1:8100/
+curl --fail http://127.0.0.1:8100/healthz
+curl --fail http://127.0.0.1:8100/
 ```
 
-## Notes
+## Android operational notes
 
-- Host mode runs directly on the Termux host.
-- `devbox_exec_readonly` is advisory only in host mode; it is not sandboxed like Docker mode.
-- `host_exec` and `host_run_program` operate on the Termux host tools available in your PATH.
-- `windows_host_*` MCP tool names still exist as compatibility aliases, but they use the same host implementation on Termux.
-- If you want public OAuth flows, set `PUBLIC_BASE_URL` and the appropriate auth env vars before starting the service.
+- Keep the Termux session or wake lock active when Android background restrictions would otherwise stop the process.
+- The MCP endpoint listens only on the configured interface. The default `0.0.0.0` binding is reachable from the device network; set `HOST=127.0.0.1` for loopback-only access.
+- Host mode is not a container sandbox. `host_exec` operates with the same Android/Termux permissions as the app.
+- Files under shared Android storage require Android storage permission and `termux-setup-storage`; Devbox does not request that permission automatically.
+- Public OAuth deployments still require `PUBLIC_BASE_URL` and the appropriate authentication variables.

--- a/scripts/install-termux.sh
+++ b/scripts/install-termux.sh
@@ -1,0 +1,57 @@
+#!/data/data/com.termux/files/usr/bin/sh
+set -eu
+
+DEVBOX_REPO="https://github.com/adybag14-cyber/devbox"
+TERMUX_REPO="https://github.com/adybag14-cyber/termux-app"
+
+if [ -z "${PREFIX:-}" ] || [ ! -x "${PREFIX}/bin/pkg" ]; then
+  echo "This installer must run inside Termux." >&2
+  echo "Canonical Android app: ${TERMUX_REPO}/releases" >&2
+  exit 1
+fi
+
+api_level="$(getprop ro.build.version.sdk 2>/dev/null || true)"
+if [ -n "$api_level" ] && [ "$api_level" -lt 21 ] 2>/dev/null; then
+  echo "Android API 21 or newer is required; detected API ${api_level}." >&2
+  exit 1
+fi
+
+case "$(uname -m)" in
+  aarch64|arm64) asset="devbox-setup-android-arm64-v8a" ;;
+  armv7l|armv8l|armeabi-v7a) asset="devbox-setup-android-armeabi-v7a" ;;
+  x86_64|amd64) asset="devbox-setup-android-x86_64" ;;
+  i686|i386|x86) asset="devbox-setup-android-x86" ;;
+  *)
+    echo "Unsupported Android architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+pkg install -y curl ca-certificates
+
+install_path="${DEVBOX_SETUP_INSTALL_PATH:-${PREFIX}/bin/devbox-setup}"
+release_base="${DEVBOX_SETUP_RELEASE_BASE:-${DEVBOX_REPO}/releases/latest/download}"
+download_url="${DEVBOX_SETUP_DOWNLOAD_URL:-${release_base}/${asset}}"
+checksum_url="${DEVBOX_SETUP_CHECKSUM_URL:-${release_base}/SHA256SUMS}"
+temporary="${TMPDIR:-${PREFIX}/tmp}/devbox-setup.$$.tmp"
+checksums="${TMPDIR:-${PREFIX}/tmp}/devbox-setup.$$.sha256"
+trap 'rm -f "$temporary" "$checksums"' EXIT HUP INT TERM
+
+echo "Canonical Termux app: ${TERMUX_REPO}"
+echo "Downloading ${asset} from ${download_url}"
+curl --fail --location --retry 3 --output "$temporary" "$download_url"
+curl --fail --location --retry 3 --output "$checksums" "$checksum_url"
+expected="$(awk -v name="$asset" '$2 == name { print $1; exit }' "$checksums")"
+actual="$(sha256sum "$temporary" | awk '{ print $1 }')"
+if [ -z "$expected" ] || [ "$actual" != "$expected" ]; then
+  echo "Checksum verification failed for ${asset}." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$install_path")"
+chmod 0755 "$temporary"
+mv -f "$temporary" "$install_path"
+rm -f "$checksums"
+trap - EXIT HUP INT TERM
+
+exec "$install_path" "$@"


### PR DESCRIPTION
## Summary
- add first-class Termux/Android detection to the Rust bootstrap installer
- provision `nodejs`, `git`, `python`, `ripgrep`, `curl`, and CA certificates with `pkg`
- create Termux-specific host-mode `.env` defaults and shell/workspace paths
- add `--skip-system-packages`
- add a checksum-verifying Termux installer with Android ABI detection
- build Android API 21 binaries for arm64-v8a, armeabi-v7a, x86_64, and x86
- publish cross-platform binaries and SHA256SUMS automatically for `bootstrap-v*` tags
- document the canonical Termux app at https://github.com/adybag14-cyber/termux-app

## Validation
- Rust 1.74.1: 11 tests passed
- current Rust stable: 11 tests passed
- Clippy with `-D warnings`: passed
- JavaScript suite: 29 tests, 28 passed, 1 platform-specific skip
- direct NDK 29 / API 21 builds passed for all four Android Rust targets
- cargo-ndk 4.1.2 arm64 build passed with the exact CI command
- simulated Termux `pkg`, `.env`, host-mode, ABI selection, download, checksum, and execution handoff passed
- actionlint passed
- ShellCheck and shell syntax passed
- no files deleted

## README protection
The existing JavaScript section beginning with `## Free script to approve all messages.` remains byte-for-byte identical to main.

SHA-256: `be5db6c6c040da6b6af6e57f560f16f13aadebbd3a627c677390c9c8b40ccfee`