### PR TITLE
Harden cross-platform display and window capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Behavior:
 - `devbox_exec_readonly` is best-effort and is not container-sandboxed
 - generic host tools are exposed through `host_*`
 - legacy `windows_host_*` names remain compatibility aliases
+- `host_capture_display` captures the native desktop; `host_capture_window` captures the largest visible window for a PID or its child processes
+- Windows window capture detects black `PrintWindow` results from GPU/DirectComposition/video/emulator surfaces and falls back to compositor-visible pixels; macOS uses CoreGraphics + `screencapture`; Linux supports X11 plus Sway/Hyprland/wlroots Wayland paths
 
 Termux and Android instructions: [docs/TERMUX.md](./docs/TERMUX.md)
 

--- a/docs/HOST_COMPATIBILITY.md
+++ b/docs/HOST_COMPATIBILITY.md
@@ -4,6 +4,29 @@ For public deployments, `devbox-tui --cloudflare-help` prints platform-specific 
 
 Devbox host mode is supported on Windows, Linux, macOS, and Termux/Android. Docker remains optional where available.
 
+## Display and window screenshots
+
+The preferred cross-platform screenshot tools are:
+
+- `host_capture_display`: capture the host desktop/virtual display
+- `host_capture_window`: capture the largest visible application window owned by a PID or one of its child processes
+- `host_capture_program`: compatibility alias for `host_capture_window`
+- `windows_host_capture_display` and `windows_host_capture_program`: legacy aliases retained for existing clients
+
+Windows uses a layered strategy rather than trusting `PrintWindow` alone. The capture code uses DWM extended frame bounds, skips cloaked/minimized helper windows, searches child processes for multi-process applications, tries `PrintWindow` with `PW_RENDERFULLCONTENT` and default flags, and samples both the complete frame and the client-area interior. If Windows reports a successful capture but the renderer area is effectively black (a common DirectX/DirectComposition, Android-emulator, WebView, or hardware-video failure), Devbox falls back to the pixels visible through the desktop compositor. That fallback can include occluding windows; the returned metadata explicitly reports `screen_fallback_may_include_occluders`.
+
+macOS uses CoreGraphics to discover active display bounds and PID-owned windows, then uses the native `screencapture` compositor path. Screen Recording permission is required. Grant it under **System Settings -> Privacy & Security -> Screen Recording** to the terminal/Node host process and restart that process. The CoreGraphics discovery helper is typechecked on both Intel and Apple Silicon CI runners.
+
+Linux supports both X11 and Wayland:
+
+- X11 window discovery: `wmctrl`, `xdotool` + `xwininfo`, or `xprop` + `xwininfo`; capture uses `maim` or ImageMagick `import`.
+- X11 full desktop: `maim`, `scrot`, `gnome-screenshot`, KDE `spectacle`, or ImageMagick `import`.
+- wlroots/Sway/Hyprland Wayland windows: compositor PID/window metadata plus `grim` region capture.
+- Wayland full desktop: `grim`, `gnome-screenshot`, or `spectacle`.
+
+Pure Wayland deliberately prevents arbitrary cross-application window enumeration on some compositors. When GNOME/KDE does not expose a non-interactive PID-selected window path, Devbox returns an explicit portal/security limitation instead of silently capturing the wrong window. XWayland applications can still use the X11 window path when `DISPLAY` is available.
+
+Termux/Android is intentionally different: ordinary terminal apps cannot capture another Android app by PID without Android's MediaProjection/user-consent flow, so the generic tools return an actionable unsupported error there.
 ## Native setup binaries
 
 Every bootstrap release contains the Rust `devbox-setup` CLI and the C++17 `devbox-tui` frontend. Linux ships x86-64 and ARM64 builds; macOS ships Intel and Apple Silicon builds; Windows ships x86-64; Termux ships four Android API 21+ ABIs.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "guardian": "node ./scripts/devbox-guardian.mjs",
     "guardian:check": "node ./scripts/devbox-guardian.mjs --once --no-repair",
     "test": "npm run test:unit && npm run test:mcp",
-    "test:unit": "node --test test/async-jobs.test.js test/async-locks.test.js test/env.test.js test/guardian-container-repair.test.js test/guardian-core.test.js test/host-runtime.test.js test/host-tools.test.js test/large-file-cli.test.js test/launcher.test.js test/platform.test.js test/process-utils.test.js",
+    "test:unit": "node --test test/async-jobs.test.js test/async-locks.test.js test/env.test.js test/guardian-container-repair.test.js test/guardian-core.test.js test/host-runtime.test.js test/host-tools.test.js test/large-file-cli.test.js test/launcher.test.js test/platform.test.js test/process-utils.test.js test/screen-capture.test.js",
     "test:mcp": "node --test test/mcp-http.test.js",
     "soak:live": "node scripts/run-live-mcp-soak.mjs",
     "usage:summary": "node scripts/summarize-mcp-telemetry.mjs"

--- a/scripts/ci/platform-runtime-e2e.mjs
+++ b/scripts/ci/platform-runtime-e2e.mjs
@@ -71,6 +71,8 @@ try {
     "devbox_write_large_file",
     "devbox_search_files",
     "host_status",
+    "host_capture_display",
+    "host_capture_window",
     "host_exec",
     "host_run_program",
   ];

--- a/scripts/ci/run-posix-runtime-e2e.sh
+++ b/scripts/ci/run-posix-runtime-e2e.sh
@@ -32,6 +32,7 @@ mkdir -p "$WORKSPACE"
 node bin/devbox.js stop >/dev/null 2>&1 || true
 
 npm ci
+node scripts/ci/screen-capture-platform-e2e.mjs
 node bin/devbox.js start
 node scripts/ci/platform-runtime-e2e.mjs \
   --url "http://127.0.0.1:$PORT/" \

--- a/scripts/ci/screen-capture-platform-e2e.mjs
+++ b/scripts/ci/screen-capture-platform-e2e.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 
@@ -80,6 +80,48 @@ try {
     assert.equal(x11Window.metadata.window_discovery, "wmctrl");
     assert.equal(x11Window.metadata.capture_method, "maim(window-id)");
     assert.equal(x11Window.metadata.window_title, "CI X11 Window");
+
+    // A broken preferred X11 discovery utility must not prevent later fallbacks.
+    await writeExecutable(path.join(bin, "wmctrl"), "#!/bin/sh\nexit 2\n");
+    await writeExecutable(path.join(bin, "xdotool"), "#!/bin/sh\nprintf '18874371\\n'\n");
+    await writeExecutable(
+      path.join(bin, "xwininfo"),
+      "#!/bin/sh\nprintf '  Absolute upper-left X: 30\\n  Absolute upper-left Y: 40\\n  Width: 640\\n  Height: 480\\n'\n",
+    );
+    const x11FallbackWindow = await captureLinuxProgram({ pid: process.pid, includeProcessTree: false, timeoutMs: 5000 });
+    assert.equal(x11FallbackWindow.metadata.window_discovery, "xdotool+xwininfo");
+
+    // Native compositor node IDs are not X11 window IDs. When grim is absent,
+    // do not hand a Sway/Hyprland ID to maim/import and risk the wrong window.
+    const constrainedPath = process.env.PATH;
+    const maimMarker = path.join(tmp, "maim-invoked");
+    await rm(path.join(bin, "grim"), { force: true });
+    await writeExecutable(
+      path.join(bin, "maim"),
+      `#!/bin/sh\nprintf called > "$DEVBOX_MAIM_MARKER"\nexit 7\n`,
+    );
+    process.env.DEVBOX_MAIM_MARKER = maimMarker;
+    process.env.PATH = bin;
+    delete process.env.DISPLAY;
+    process.env.WAYLAND_DISPLAY = "wayland-ci";
+    process.env.XDG_SESSION_TYPE = "wayland";
+    await assert.rejects(
+      captureLinuxProgram({ pid: process.pid, includeProcessTree: false, timeoutMs: 5000 }),
+      /Wayland compositor does not expose/u,
+    );
+    let maimWasInvoked = false;
+    try { await readFile(maimMarker); maimWasInvoked = true; } catch {}
+    assert.equal(maimWasInvoked, false);
+
+    // If an installed display backend itself fails, preserve that cause instead
+    // of incorrectly claiming that no backend is installed.
+    await writeExecutable(path.join(bin, "grim"), "#!/bin/sh\nprintf 'grim-denied' >&2\nexit 7\n");
+    await assert.rejects(
+      captureLinuxDisplay({ timeoutMs: 5000 }),
+      /grim-denied/u,
+    );
+    process.env.PATH = constrainedPath;
+    delete process.env.DEVBOX_MAIM_MARKER;
 
     console.log("Linux screen capture backend E2E passed for fake Wayland and X11 compositor paths.");
   } else if (process.platform === "darwin") {

--- a/scripts/ci/screen-capture-platform-e2e.mjs
+++ b/scripts/ci/screen-capture-platform-e2e.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+
+const run = async (file, args) => {
+  const child = spawn(file, args, { stdio: ["ignore", "pipe", "pipe"], env: process.env });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const [code] = await once(child, "exit");
+  if (code !== 0) throw new Error(`${file} ${args.join(" ")} failed (${code}): ${stderr || stdout}`);
+  return { stdout, stderr };
+};
+
+const makePngHeader = (width, height) => {
+  const buffer = Buffer.alloc(24);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buffer, 0);
+  buffer.write("IHDR", 12, "ascii");
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  return buffer;
+};
+
+const writeExecutable = async (file, content) => {
+  await writeFile(file, content, "utf8");
+  await chmod(file, 0o755);
+};
+
+const tmp = await mkdtemp(path.join(os.tmpdir(), "devbox-screen-ci-"));
+const bin = path.join(tmp, "bin");
+const fixture = path.join(tmp, "fixture.png");
+await import("node:fs/promises").then(({ mkdir }) => mkdir(bin, { recursive: true }));
+await writeFile(fixture, makePngHeader(640, 480));
+process.env.ENABLE_HOST_EXEC = "true";
+process.env.DEVBOX_CAPTURE_FIXTURE = fixture;
+process.env.DEVBOX_TEST_PID = String(process.pid);
+const originalPath = process.env.PATH ?? "";
+process.env.PATH = `${bin}${path.delimiter}${originalPath}`;
+
+const copyLastArgScript = `#!/bin/sh\nfor last do :; done\ncp "$DEVBOX_CAPTURE_FIXTURE" "$last"\n`;
+
+try {
+  if (process.platform === "linux") {
+    await writeExecutable(path.join(bin, "grim"), copyLastArgScript);
+    await writeExecutable(
+      path.join(bin, "swaymsg"),
+      `#!/bin/sh\nprintf '{"pid":%s,"name":"CI Wayland Window","visible":true,"rect":{"x":10,"y":20,"width":640,"height":480},"nodes":[],"floating_nodes":[]}\\n' "$DEVBOX_TEST_PID"\n`,
+    );
+    await writeExecutable(path.join(bin, "maim"), copyLastArgScript);
+    await writeExecutable(
+      path.join(bin, "wmctrl"),
+      `#!/bin/sh\nprintf '0x01200003  0 %s 30 40 640 480 ci-host CI X11 Window\\n' "$DEVBOX_TEST_PID"\n`,
+    );
+
+    const { captureLinuxDisplay, captureLinuxProgram } = await import("../../src/linux-screen-capture.js");
+
+    process.env.WAYLAND_DISPLAY = "wayland-ci";
+    process.env.XDG_SESSION_TYPE = "wayland";
+    delete process.env.DISPLAY;
+    const waylandDisplay = await captureLinuxDisplay({ timeoutMs: 5000 });
+    assert.equal(waylandDisplay.mimeType, "image/png");
+    assert.equal(waylandDisplay.metadata.capture_method, "grim(full-display)");
+    assert.equal(waylandDisplay.metadata.width, 640);
+    const waylandWindow = await captureLinuxProgram({ pid: process.pid, includeProcessTree: false, timeoutMs: 5000 });
+    assert.equal(waylandWindow.metadata.window_discovery, "swaymsg");
+    assert.match(waylandWindow.metadata.capture_method, /^grim\(sway-window-bounds\)$/u);
+
+    delete process.env.WAYLAND_DISPLAY;
+    process.env.DISPLAY = ":99";
+    process.env.XDG_SESSION_TYPE = "x11";
+    const x11Display = await captureLinuxDisplay({ timeoutMs: 5000 });
+    assert.equal(x11Display.metadata.capture_method, "maim(root)");
+    const x11Window = await captureLinuxProgram({ pid: process.pid, includeProcessTree: false, timeoutMs: 5000 });
+    assert.equal(x11Window.metadata.window_discovery, "wmctrl");
+    assert.equal(x11Window.metadata.capture_method, "maim(window-id)");
+    assert.equal(x11Window.metadata.window_title, "CI X11 Window");
+
+    console.log("Linux screen capture backend E2E passed for fake Wayland and X11 compositor paths.");
+  } else if (process.platform === "darwin") {
+    const { captureMacOSDisplay, captureMacOSProgram, macOSWindowQuerySwift } = await import("../../src/macos-screen-capture.js");
+    const swiftSource = path.join(tmp, "window-query.swift");
+    await writeFile(swiftSource, macOSWindowQuerySwift, "utf8");
+    await run("/usr/bin/swiftc", ["-typecheck", swiftSource]);
+
+    await writeExecutable(
+      path.join(bin, "swift"),
+      `#!/bin/sh\nif [ "$2" = display ]; then\n  printf '{"left":0,"top":0,"width":640,"height":480,"display_count":1}'\nelse\n  printf '{"left":20,"top":30,"width":640,"height":480,"window_id":4242,"window_owner_pid":%s,"window_owner_name":"CI App","window_title":"CI Window"}' "$DEVBOX_TEST_PID"\nfi\n`,
+    );
+    await writeExecutable(path.join(bin, "screencapture"), copyLastArgScript);
+
+    const display = await captureMacOSDisplay({ timeoutMs: 5000 });
+    assert.equal(display.mimeType, "image/png");
+    assert.equal(display.metadata.capture_method, "screencapture(CoreGraphics-virtual-bounds)");
+    assert.equal(display.metadata.width, 640);
+    const window = await captureMacOSProgram({ pid: process.pid, includeProcessTree: false, timeoutMs: 5000 });
+    assert.equal(window.metadata.window_id, 4242);
+    assert.equal(window.metadata.window_title, "CI Window");
+    assert.equal(window.metadata.capture_method, "screencapture(window-id)");
+
+    console.log("macOS screen capture backend E2E passed; CoreGraphics Swift helper typechecked and capture wiring executed.");
+  } else {
+    console.log(`Screen capture platform E2E skipped on ${process.platform}.`);
+  }
+} finally {
+  process.env.PATH = originalPath;
+  await rm(tmp, { recursive: true, force: true });
+}

--- a/src/linux-screen-capture.js
+++ b/src/linux-screen-capture.js
@@ -101,12 +101,18 @@ const noDisplayError = (session) =>
     `No capturable Linux graphical session was detected (session=${session.sessionType}). Set DISPLAY for X11 or WAYLAND_DISPLAY for Wayland and run Devbox inside the logged-in desktop session.`,
   );
 
-const missingDisplayBackendError = (session) =>
-  new HostCommandError(
-    session.wayland
-      ? "No supported Wayland screenshot backend was found. Install grim (wlroots), gnome-screenshot (GNOME), or spectacle (KDE)."
-      : "No supported X11 screenshot backend was found. Install maim, scrot, gnome-screenshot, spectacle, or ImageMagick's import command.",
-  );
+const missingDisplayBackendError = (session, cause = null) => {
+  const baseMessage = session.wayland
+    ? "No supported Wayland screenshot backend was found. Install grim (wlroots), gnome-screenshot (GNOME), or spectacle (KDE)."
+    : "No supported X11 screenshot backend was found. Install maim, scrot, gnome-screenshot, spectacle, or ImageMagick's import command.";
+  if (!cause) return new HostCommandError(baseMessage);
+  const causeMessage = cause instanceof Error ? cause.message : String(cause);
+  return new HostCommandError(`${baseMessage} Installed backend failure: ${causeMessage}`, {
+    exitCode: cause?.exitCode,
+    stdout: cause?.stdout,
+    stderr: cause?.stderr,
+  });
+};
 
 const capturePng = async (file, args, pngPath, { cwd, timeoutMs }) => {
   await captureCommand(file, args, { cwd, timeoutMs });
@@ -130,24 +136,30 @@ const captureLinuxFullPng = async ({ session, pngPath, tempDir, timeoutMs }) => 
         ["import", (file) => ["-window", "root", file], "ImageMagick-import(root)"],
       ];
 
+  let lastError = null;
   for (const [name, argsFor, method] of candidates) {
     const executable = await findExecutable([name]);
     if (!executable) continue;
     try {
       return { image: await capturePng(executable, argsFor(pngPath), pngPath, { cwd: tempDir, timeoutMs }), method };
-    } catch {
+    } catch (error) {
       // Try another compositor-compatible backend before surfacing failure.
+      lastError = error;
     }
   }
-  throw missingDisplayBackendError(session);
+  throw missingDisplayBackendError(session, lastError);
 };
 
 const discoverX11Window = async ({ candidatePids, timeoutMs }) => {
   const wmctrl = await findExecutable(["wmctrl"]);
   if (wmctrl) {
-    const result = await captureCommand(wmctrl, ["-lpG"], { timeoutMs });
-    const selected = selectLargestWindow(parseWmctrlWindows(result.stdout), candidatePids);
-    if (selected) return { ...selected, discovery: "wmctrl" };
+    try {
+      const result = await captureCommand(wmctrl, ["-lpG"], { timeoutMs });
+      const selected = selectLargestWindow(parseWmctrlWindows(result.stdout), candidatePids);
+      if (selected) return { ...selected, discovery: "wmctrl" };
+    } catch {
+      // Continue through the remaining X11 discovery backends.
+    }
   }
 
   const xdotool = await findExecutable(["xdotool"]);
@@ -179,8 +191,13 @@ const discoverX11Window = async ({ candidatePids, timeoutMs }) => {
 
   const xprop = await findExecutable(["xprop"]);
   if (xprop && xwininfo) {
-    const root = await captureCommand(xprop, ["-root", "_NET_CLIENT_LIST_STACKING"], { timeoutMs });
-    const ids = root.stdout.match(/0x[0-9a-f]+/giu) ?? [];
+    let ids = [];
+    try {
+      const root = await captureCommand(xprop, ["-root", "_NET_CLIENT_LIST_STACKING"], { timeoutMs });
+      ids = root.stdout.match(/0x[0-9a-f]+/giu) ?? [];
+    } catch {
+      ids = [];
+    }
     const windows = [];
     for (const id of ids) {
       try {
@@ -237,9 +254,11 @@ const captureLinuxWindowPng = async ({ window, session, pngPath, tempDir, timeou
     }
   }
 
-  // XWayland windows can still use these X11 paths inside a Wayland session.
+  // XWayland windows can still use these X11 paths inside a Wayland session,
+  // but native compositor node/address IDs are not X11 window IDs.
+  const compositorWindow = window.backend === "sway" || window.backend === "hyprland";
   const maim = await findExecutable(["maim"]);
-  if (maim && window.id) {
+  if (maim && window.id && !compositorWindow) {
     try {
       return {
         image: await capturePng(maim, ["-i", String(window.id), pngPath], pngPath, { cwd: tempDir, timeoutMs }),
@@ -250,7 +269,7 @@ const captureLinuxWindowPng = async ({ window, session, pngPath, tempDir, timeou
     }
   }
   const importTool = await findExecutable(["import"]);
-  if (importTool && window.id) {
+  if (importTool && window.id && !compositorWindow) {
     try {
       return {
         image: await capturePng(importTool, ["-window", String(window.id), pngPath], pngPath, { cwd: tempDir, timeoutMs }),

--- a/src/linux-screen-capture.js
+++ b/src/linux-screen-capture.js
@@ -1,0 +1,344 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+
+import { config } from "./config.js";
+import { HostCommandError, assertHostExecEnabled } from "./host-tools.js";
+import { captureCommand, finalizeImageCapture, findExecutable, getPosixProcessTreePids, isPngBuffer } from "./screen-capture-utils.js";
+
+export const detectLinuxDisplaySession = (env = process.env) => {
+  const sessionType = String(env.XDG_SESSION_TYPE ?? "").trim().toLowerCase();
+  const wayland = Boolean(env.WAYLAND_DISPLAY) || sessionType === "wayland";
+  const x11 = Boolean(env.DISPLAY) || sessionType === "x11";
+  return { wayland, x11, sessionType: wayland ? "wayland" : x11 ? "x11" : sessionType || "headless" };
+};
+
+export const parseWmctrlWindows = (text) => {
+  const windows = [];
+  for (const line of String(text ?? "").split(/\r?\n/u)) {
+    const match = line.match(/^\s*(0x[0-9a-f]+)\s+(-?\d+)\s+(\d+)\s+(-?\d+)\s+(-?\d+)\s+(\d+)\s+(\d+)\s+\S+\s*(.*)$/iu);
+    if (!match) continue;
+    windows.push({
+      id: match[1],
+      desktop: Number(match[2]),
+      pid: Number(match[3]),
+      left: Number(match[4]),
+      top: Number(match[5]),
+      width: Number(match[6]),
+      height: Number(match[7]),
+      title: match[8] ?? "",
+    });
+  }
+  return windows;
+};
+
+export const parseXwininfoGeometry = (text) => {
+  const read = (pattern) => Number(String(text).match(pattern)?.[1]);
+  const left = read(/Absolute upper-left X:\s*(-?\d+)/u);
+  const top = read(/Absolute upper-left Y:\s*(-?\d+)/u);
+  const width = read(/Width:\s*(\d+)/u);
+  const height = read(/Height:\s*(\d+)/u);
+  if (![left, top, width, height].every(Number.isFinite)) return null;
+  return { left, top, width, height };
+};
+
+export const selectLargestWindow = (windows, candidatePids) => {
+  const pids = new Set(candidatePids.map(Number));
+  return windows
+    .filter((window) => pids.has(Number(window.pid)) && window.width >= 32 && window.height >= 32)
+    .sort((a, b) => b.width * b.height - a.width * a.height)[0] ?? null;
+};
+
+const walkSwayTree = (node, candidatePids, output = []) => {
+  if (!node || typeof node !== "object") return output;
+  if (candidatePids.has(Number(node.pid)) && node.rect?.width >= 32 && node.rect?.height >= 32 && node.visible !== false) {
+    output.push({
+      id: node.id,
+      pid: Number(node.pid),
+      left: Number(node.rect.x),
+      top: Number(node.rect.y),
+      width: Number(node.rect.width),
+      height: Number(node.rect.height),
+      title: node.name ?? "",
+      backend: "sway",
+    });
+  }
+  for (const child of [...(node.nodes ?? []), ...(node.floating_nodes ?? [])]) walkSwayTree(child, candidatePids, output);
+  return output;
+};
+
+export const parseSwayWindows = (text, candidatePids) => {
+  const root = JSON.parse(text);
+  return walkSwayTree(root, new Set(candidatePids.map(Number)));
+};
+
+export const parseHyprlandWindows = (text, candidatePids) => {
+  const pids = new Set(candidatePids.map(Number));
+  const clients = JSON.parse(text);
+  return clients
+    .filter((client) => pids.has(Number(client.pid)) && client.mapped !== false && client.hidden !== true)
+    .map((client) => ({
+      id: client.address,
+      pid: Number(client.pid),
+      left: Number(client.at?.[0] ?? 0),
+      top: Number(client.at?.[1] ?? 0),
+      width: Number(client.size?.[0] ?? 0),
+      height: Number(client.size?.[1] ?? 0),
+      title: client.title ?? "",
+      backend: "hyprland",
+    }));
+};
+
+const assertLinux = () => {
+  assertHostExecEnabled();
+  if (!config.platform.isLinux || config.platform.isTermux || process.platform !== "linux") {
+    throw new HostCommandError("Linux desktop capture is available only on a non-Termux Linux host.");
+  }
+};
+
+const noDisplayError = (session) =>
+  new HostCommandError(
+    `No capturable Linux graphical session was detected (session=${session.sessionType}). Set DISPLAY for X11 or WAYLAND_DISPLAY for Wayland and run Devbox inside the logged-in desktop session.`,
+  );
+
+const missingDisplayBackendError = (session) =>
+  new HostCommandError(
+    session.wayland
+      ? "No supported Wayland screenshot backend was found. Install grim (wlroots), gnome-screenshot (GNOME), or spectacle (KDE)."
+      : "No supported X11 screenshot backend was found. Install maim, scrot, gnome-screenshot, spectacle, or ImageMagick's import command.",
+  );
+
+const capturePng = async (file, args, pngPath, { cwd, timeoutMs }) => {
+  await captureCommand(file, args, { cwd, timeoutMs });
+  const image = await readFile(pngPath);
+  if (!isPngBuffer(image)) throw new HostCommandError(`${path.basename(file)} did not produce a valid PNG image.`);
+  return image;
+};
+
+const captureLinuxFullPng = async ({ session, pngPath, tempDir, timeoutMs }) => {
+  const candidates = session.wayland
+    ? [
+        ["grim", (file) => [file], "grim(full-display)"],
+        ["gnome-screenshot", (file) => ["-f", file], "gnome-screenshot(full-display)"],
+        ["spectacle", (file) => ["-b", "-n", "-f", "-o", file], "spectacle(full-display)"],
+      ]
+    : [
+        ["maim", (file) => [file], "maim(root)"],
+        ["scrot", (file) => [file], "scrot(root)"],
+        ["gnome-screenshot", (file) => ["-f", file], "gnome-screenshot(full-display)"],
+        ["spectacle", (file) => ["-b", "-n", "-f", "-o", file], "spectacle(full-display)"],
+        ["import", (file) => ["-window", "root", file], "ImageMagick-import(root)"],
+      ];
+
+  for (const [name, argsFor, method] of candidates) {
+    const executable = await findExecutable([name]);
+    if (!executable) continue;
+    try {
+      return { image: await capturePng(executable, argsFor(pngPath), pngPath, { cwd: tempDir, timeoutMs }), method };
+    } catch {
+      // Try another compositor-compatible backend before surfacing failure.
+    }
+  }
+  throw missingDisplayBackendError(session);
+};
+
+const discoverX11Window = async ({ candidatePids, timeoutMs }) => {
+  const wmctrl = await findExecutable(["wmctrl"]);
+  if (wmctrl) {
+    const result = await captureCommand(wmctrl, ["-lpG"], { timeoutMs });
+    const selected = selectLargestWindow(parseWmctrlWindows(result.stdout), candidatePids);
+    if (selected) return { ...selected, discovery: "wmctrl" };
+  }
+
+  const xdotool = await findExecutable(["xdotool"]);
+  const xwininfo = await findExecutable(["xwininfo"]);
+  if (xdotool && xwininfo) {
+    const windows = [];
+    for (const pid of candidatePids) {
+      let ids;
+      try {
+        ids = (await captureCommand(xdotool, ["search", "--onlyvisible", "--pid", String(pid)], { timeoutMs })).stdout
+          .split(/\r?\n/u)
+          .map((value) => value.trim())
+          .filter(Boolean);
+      } catch {
+        ids = [];
+      }
+      for (const id of ids) {
+        try {
+          const info = await captureCommand(xwininfo, ["-id", id], { timeoutMs });
+          const geometry = parseXwininfoGeometry(info.stdout);
+          if (geometry) windows.push({ id, pid, title: "", ...geometry });
+        } catch {
+        }
+      }
+    }
+    const selected = selectLargestWindow(windows, candidatePids);
+    if (selected) return { ...selected, discovery: "xdotool+xwininfo" };
+  }
+
+  const xprop = await findExecutable(["xprop"]);
+  if (xprop && xwininfo) {
+    const root = await captureCommand(xprop, ["-root", "_NET_CLIENT_LIST_STACKING"], { timeoutMs });
+    const ids = root.stdout.match(/0x[0-9a-f]+/giu) ?? [];
+    const windows = [];
+    for (const id of ids) {
+      try {
+        const props = await captureCommand(xprop, ["-id", id, "_NET_WM_PID", "_NET_WM_NAME", "WM_NAME"], { timeoutMs });
+        const pid = Number(props.stdout.match(/_NET_WM_PID\([^)]*\)\s*=\s*(\d+)/u)?.[1]);
+        if (!candidatePids.includes(pid)) continue;
+        const info = await captureCommand(xwininfo, ["-id", id], { timeoutMs });
+        const geometry = parseXwininfoGeometry(info.stdout);
+        if (!geometry) continue;
+        const title = props.stdout.match(/(?:_NET_WM_NAME|WM_NAME)\([^)]*\)\s*=\s*"([^"]*)"/u)?.[1] ?? "";
+        windows.push({ id, pid, title, ...geometry });
+      } catch {
+      }
+    }
+    const selected = selectLargestWindow(windows, candidatePids);
+    if (selected) return { ...selected, discovery: "xprop+xwininfo" };
+  }
+
+  return null;
+};
+
+const discoverWaylandWindow = async ({ candidatePids, timeoutMs }) => {
+  const swaymsg = await findExecutable(["swaymsg"]);
+  if (swaymsg) {
+    try {
+      const result = await captureCommand(swaymsg, ["-t", "get_tree", "-r"], { timeoutMs });
+      const selected = selectLargestWindow(parseSwayWindows(result.stdout, candidatePids), candidatePids);
+      if (selected) return { ...selected, discovery: "swaymsg" };
+    } catch {
+    }
+  }
+  const hyprctl = await findExecutable(["hyprctl"]);
+  if (hyprctl) {
+    try {
+      const result = await captureCommand(hyprctl, ["clients", "-j"], { timeoutMs });
+      const selected = selectLargestWindow(parseHyprlandWindows(result.stdout, candidatePids), candidatePids);
+      if (selected) return { ...selected, discovery: "hyprctl" };
+    } catch {
+    }
+  }
+  return null;
+};
+
+const captureLinuxWindowPng = async ({ window, session, pngPath, tempDir, timeoutMs }) => {
+  if (session.wayland && (window.backend === "sway" || window.backend === "hyprland")) {
+    const grim = await findExecutable(["grim"]);
+    if (grim) {
+      const geometry = `${window.left},${window.top} ${window.width}x${window.height}`;
+      return {
+        image: await capturePng(grim, ["-g", geometry, pngPath], pngPath, { cwd: tempDir, timeoutMs }),
+        method: `grim(${window.backend}-window-bounds)`,
+        visibleRegionFallback: true,
+      };
+    }
+  }
+
+  // XWayland windows can still use these X11 paths inside a Wayland session.
+  const maim = await findExecutable(["maim"]);
+  if (maim && window.id) {
+    try {
+      return {
+        image: await capturePng(maim, ["-i", String(window.id), pngPath], pngPath, { cwd: tempDir, timeoutMs }),
+        method: "maim(window-id)",
+        visibleRegionFallback: false,
+      };
+    } catch {
+    }
+  }
+  const importTool = await findExecutable(["import"]);
+  if (importTool && window.id) {
+    try {
+      return {
+        image: await capturePng(importTool, ["-window", String(window.id), pngPath], pngPath, { cwd: tempDir, timeoutMs }),
+        method: "ImageMagick-import(window-id)",
+        visibleRegionFallback: false,
+      };
+    } catch {
+    }
+  }
+
+  if (session.wayland) {
+    throw new HostCommandError(
+      "This Wayland compositor does not expose a non-interactive PID-selected window screenshot path. Devbox supports wlroots/Sway/Hyprland via grim and XWayland windows via X11 tools; GNOME/KDE may require a user-approved xdg-desktop-portal screenshot instead.",
+    );
+  }
+  throw new HostCommandError("The window was found on X11, but no window-capable capture backend is installed. Install maim or ImageMagick.");
+};
+
+export const captureLinuxDisplay = async ({ quality = 85, timeoutMs = 30000 } = {}) => {
+  assertLinux();
+  const session = detectLinuxDisplaySession();
+  if (!session.wayland && !session.x11) throw noDisplayError(session);
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "devbox-linux-capture-"));
+  const pngPath = path.join(tempDir, "display.png");
+  try {
+    const capture = await captureLinuxFullPng({ session, pngPath, tempDir, timeoutMs });
+    return finalizeImageCapture({
+      image: capture.image,
+      mimeType: "image/png",
+      metadata: {
+        capture_mode: "full_display",
+        capture_method: capture.method,
+        display_server: session.sessionType,
+        requested_quality: quality,
+        lossless_png: true,
+      },
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+};
+
+export const captureLinuxProgram = async ({ pid, quality = 85, timeoutMs = 30000, includeProcessTree = true } = {}) => {
+  assertLinux();
+  if (!Number.isInteger(pid) || pid <= 0) throw new HostCommandError("pid must be a positive Linux process ID.");
+  const session = detectLinuxDisplaySession();
+  if (!session.wayland && !session.x11) throw noDisplayError(session);
+  const candidatePids = includeProcessTree ? await getPosixProcessTreePids(pid) : [pid];
+  let window = null;
+  if (session.wayland) window = await discoverWaylandWindow({ candidatePids, timeoutMs });
+  if (!window && session.x11) window = await discoverX11Window({ candidatePids, timeoutMs });
+  if (!window) {
+    if (session.wayland && !session.x11) {
+      throw new HostCommandError(
+        "No PID-selected window could be discovered on this Wayland compositor. Sway and Hyprland are supported directly; other compositors may intentionally hide window/PID enumeration and require an interactive desktop portal.",
+      );
+    }
+    throw new HostCommandError(`No visible X11/XWayland window was found for PID ${pid} or its child processes.`);
+  }
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "devbox-linux-window-capture-"));
+  const pngPath = path.join(tempDir, "window.png");
+  try {
+    const capture = await captureLinuxWindowPng({ window, session, pngPath, tempDir, timeoutMs });
+    return finalizeImageCapture({
+      image: capture.image,
+      mimeType: "image/png",
+      metadata: {
+        capture_mode: "program_pid",
+        pid,
+        window_owner_pid: window.pid,
+        process_tree_fallback: window.pid !== pid,
+        candidate_pid_count: candidatePids.length,
+        window_id: window.id,
+        window_title: window.title,
+        capture_method: capture.method,
+        window_discovery: window.discovery,
+        display_server: session.sessionType,
+        left: window.left,
+        top: window.top,
+        width: window.width,
+        height: window.height,
+        requested_quality: quality,
+        lossless_png: true,
+        screen_fallback_may_include_occluders: capture.visibleRegionFallback,
+      },
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+};

--- a/src/macos-screen-capture.js
+++ b/src/macos-screen-capture.js
@@ -50,8 +50,8 @@ for info in windows {
     let layer = info[kCGWindowLayer as String] as? Int ?? -1
     let alpha = info[kCGWindowAlpha as String] as? Double ?? 1.0
     guard layer == 0, alpha > 0 else { continue }
-    guard let boundsDict = info[kCGWindowBounds as String] as? CFDictionary,
-          let rect = CGRect(dictionaryRepresentation: boundsDict),
+    guard let boundsValues = info[kCGWindowBounds as String] as? [String: Any],
+          let rect = CGRect(dictionaryRepresentation: boundsValues as CFDictionary),
           rect.width >= 32, rect.height >= 32 else { continue }
     let area = rect.width * rect.height
     guard area > bestArea else { continue }

--- a/src/macos-screen-capture.js
+++ b/src/macos-screen-capture.js
@@ -1,0 +1,197 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+
+import { config } from "./config.js";
+import { HostCommandError, assertHostExecEnabled } from "./host-tools.js";
+import { captureCommand, finalizeImageCapture, findExecutable, getPosixProcessTreePids, isPngBuffer } from "./screen-capture-utils.js";
+
+const windowQuerySwift = String.raw`
+import Foundation
+import CoreGraphics
+
+func emit(_ value: [String: Any]) {
+    let data = try! JSONSerialization.data(withJSONObject: value, options: [])
+    FileHandle.standardOutput.write(data)
+}
+
+func rectValue(_ rect: CGRect) -> [String: Any] {
+    return [
+        "left": Int(floor(rect.minX)),
+        "top": Int(floor(rect.minY)),
+        "width": Int(ceil(rect.width)),
+        "height": Int(ceil(rect.height))
+    ]
+}
+
+let args = CommandLine.arguments
+let mode = args.count > 1 ? args[1] : ""
+if mode == "display" {
+    var count: UInt32 = 0
+    CGGetActiveDisplayList(0, nil, &count)
+    if count == 0 { fputs("No active macOS displays.\n", stderr); exit(2) }
+    var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+    CGGetActiveDisplayList(count, &ids, &count)
+    var union = CGRect.null
+    for id in ids.prefix(Int(count)) { union = union.union(CGDisplayBounds(id)) }
+    var result = rectValue(union)
+    result["display_count"] = Int(count)
+    emit(result)
+    exit(0)
+}
+
+let pids = Set((args.count > 2 ? args[2] : "").split(separator: ",").compactMap { Int($0) })
+let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
+var best: [String: Any]? = nil
+var bestArea: Double = 0
+for info in windows {
+    guard let ownerPid = info[kCGWindowOwnerPID as String] as? Int, pids.contains(ownerPid) else { continue }
+    let layer = info[kCGWindowLayer as String] as? Int ?? -1
+    let alpha = info[kCGWindowAlpha as String] as? Double ?? 1.0
+    guard layer == 0, alpha > 0 else { continue }
+    guard let boundsDict = info[kCGWindowBounds as String] as? CFDictionary,
+          let rect = CGRect(dictionaryRepresentation: boundsDict),
+          rect.width >= 32, rect.height >= 32 else { continue }
+    let area = rect.width * rect.height
+    guard area > bestArea else { continue }
+    bestArea = area
+    var candidate = rectValue(rect)
+    candidate["window_id"] = info[kCGWindowNumber as String] as? Int ?? 0
+    candidate["window_owner_pid"] = ownerPid
+    candidate["window_owner_name"] = info[kCGWindowOwnerName as String] as? String ?? ""
+    candidate["window_title"] = info[kCGWindowName as String] as? String ?? ""
+    best = candidate
+}
+
+guard let selected = best else {
+    fputs("No on-screen CoreGraphics window matched the requested process tree.\n", stderr)
+    exit(3)
+}
+emit(selected)
+`;
+
+const assertMacOS = () => {
+  assertHostExecEnabled();
+  if (!config.platform.isMacOS || process.platform !== "darwin") {
+    throw new HostCommandError("macOS screen capture is available only on a macOS host.");
+  }
+};
+
+const macPermissionHint = (error) =>
+  new HostCommandError(
+    "macOS screen capture failed. Grant Screen Recording permission to the terminal/Node host in System Settings > Privacy & Security > Screen Recording, then restart that host process. " +
+      (error instanceof Error ? error.message : String(error)),
+    { exitCode: error?.exitCode, stdout: error?.stdout, stderr: error?.stderr },
+  );
+
+const runWindowQuery = async ({ mode, pids = [], tempDir, timeoutMs }) => {
+  const swift = await findExecutable(["swift", "/usr/bin/swift"]);
+  if (!swift) {
+    if (mode === "display") return null;
+    throw new HostCommandError(
+      "macOS PID-selected window capture requires the Swift tool from Xcode Command Line Tools. Install it with: xcode-select --install",
+    );
+  }
+  const scriptPath = path.join(tempDir, "devbox-window-query.swift");
+  await writeFile(scriptPath, windowQuerySwift, "utf8");
+  const result = await captureCommand(swift, [scriptPath, mode, pids.join(",")], { cwd: tempDir, timeoutMs });
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new HostCommandError("macOS window discovery returned invalid metadata.", {
+      stdout: result.stdout,
+      stderr: result.stderr,
+    });
+  }
+};
+
+const readPngCapture = async (pngPath, metadata) => {
+  const image = await readFile(pngPath);
+  if (!isPngBuffer(image)) {
+    throw new HostCommandError("macOS screencapture did not produce a valid PNG image.");
+  }
+  return finalizeImageCapture({ image, mimeType: "image/png", metadata });
+};
+
+export const captureMacOSDisplay = async ({ quality = 85, timeoutMs = 30000 } = {}) => {
+  assertMacOS();
+  const screencapture = await findExecutable(["screencapture", "/usr/sbin/screencapture", "/usr/bin/screencapture"]);
+  if (!screencapture) throw new HostCommandError("macOS /usr/sbin/screencapture was not found.");
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "devbox-macos-capture-"));
+  const pngPath = path.join(tempDir, "display.png");
+  try {
+    const bounds = await runWindowQuery({ mode: "display", tempDir, timeoutMs }).catch(() => null);
+    const args = ["-x"];
+    if (bounds?.width > 0 && bounds?.height > 0) {
+      args.push(`-R${bounds.left},${bounds.top},${bounds.width},${bounds.height}`);
+    }
+    args.push(pngPath);
+    try {
+      await captureCommand(screencapture, args, { cwd: tempDir, timeoutMs });
+    } catch (error) {
+      throw macPermissionHint(error);
+    }
+    return await readPngCapture(pngPath, {
+      capture_mode: "full_display",
+      capture_method: bounds ? "screencapture(CoreGraphics-virtual-bounds)" : "screencapture(default)",
+      display_count: bounds?.display_count ?? null,
+      left: bounds?.left ?? null,
+      top: bounds?.top ?? null,
+      requested_quality: quality,
+      lossless_png: true,
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+};
+
+export const captureMacOSProgram = async ({ pid, quality = 85, timeoutMs = 30000, includeProcessTree = true } = {}) => {
+  assertMacOS();
+  if (!Number.isInteger(pid) || pid <= 0) throw new HostCommandError("pid must be a positive macOS process ID.");
+  const screencapture = await findExecutable(["screencapture", "/usr/sbin/screencapture", "/usr/bin/screencapture"]);
+  if (!screencapture) throw new HostCommandError("macOS /usr/sbin/screencapture was not found.");
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "devbox-macos-window-capture-"));
+  const pngPath = path.join(tempDir, "window.png");
+  try {
+    const pids = includeProcessTree ? await getPosixProcessTreePids(pid) : [pid];
+    const window = await runWindowQuery({ mode: "window", pids, tempDir, timeoutMs });
+    let method = "screencapture(window-id)";
+    try {
+      await captureCommand(screencapture, ["-x", "-o", "-l", String(window.window_id), pngPath], { cwd: tempDir, timeoutMs });
+    } catch (windowError) {
+      // Region capture goes through the visible compositor and is useful for
+      // accelerated/video surfaces if a direct window snapshot is unavailable.
+      try {
+        await captureCommand(
+          screencapture,
+          ["-x", `-R${window.left},${window.top},${window.width},${window.height}`, pngPath],
+          { cwd: tempDir, timeoutMs },
+        );
+        method = "screencapture(visible-window-bounds-fallback)";
+      } catch {
+        throw macPermissionHint(windowError);
+      }
+    }
+    return await readPngCapture(pngPath, {
+      capture_mode: "program_pid",
+      pid,
+      window_owner_pid: window.window_owner_pid,
+      process_tree_fallback: window.window_owner_pid !== pid,
+      candidate_pid_count: pids.length,
+      window_id: window.window_id,
+      window_title: window.window_title,
+      process_name: window.window_owner_name,
+      capture_method: method,
+      left: window.left,
+      top: window.top,
+      requested_quality: quality,
+      lossless_png: true,
+      screen_fallback_may_include_occluders: method.includes("fallback"),
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+};
+
+export { windowQuerySwift as macOSWindowQuerySwift };

--- a/src/screen-capture-utils.js
+++ b/src/screen-capture-utils.js
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import { access } from "node:fs/promises";
+import path from "node:path";
+
+import { HostCommandError } from "./host-tools.js";
+import { spawnProcess } from "./process-utils.js";
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+export const isPngBuffer = (buffer) =>
+  Buffer.isBuffer(buffer) && buffer.length >= 24 && buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE);
+
+export const getPngDimensions = (buffer) => {
+  if (!isPngBuffer(buffer) || buffer.toString("ascii", 12, 16) !== "IHDR") {
+    return null;
+  }
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+};
+
+export const finalizeImageCapture = ({ image, mimeType, metadata = {} }) => {
+  if (!Buffer.isBuffer(image) || image.length === 0) {
+    throw new HostCommandError("Screen capture did not return image bytes.");
+  }
+  const dimensions = mimeType === "image/png" ? getPngDimensions(image) : null;
+  return {
+    image,
+    mimeType,
+    metadata: {
+      ...metadata,
+      ...(dimensions ?? {}),
+      mime_type: mimeType,
+      bytes: image.length,
+      sha256: createHash("sha256").update(image).digest("hex"),
+    },
+  };
+};
+
+export const findExecutable = async (names, env = process.env) => {
+  const pathValue = String(env.PATH ?? "");
+  const directories = pathValue.split(path.delimiter).filter(Boolean);
+  for (const name of names) {
+    if (path.isAbsolute(name)) {
+      try {
+        await access(name, fsConstants.X_OK);
+        return name;
+      } catch {
+        continue;
+      }
+    }
+    for (const directory of directories) {
+      const candidate = path.join(directory, name);
+      try {
+        await access(candidate, fsConstants.X_OK);
+        return candidate;
+      } catch {
+      }
+    }
+  }
+  return null;
+};
+
+export const parsePsProcessTable = (text) => {
+  const rows = [];
+  for (const line of String(text ?? "").split(/\r?\n/u)) {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s*$/u);
+    if (!match) continue;
+    rows.push({ pid: Number.parseInt(match[1], 10), ppid: Number.parseInt(match[2], 10) });
+  }
+  return rows;
+};
+
+export const collectProcessTreePids = (rows, rootPid) => {
+  const root = Number(rootPid);
+  const seen = new Set([root]);
+  const queue = [root];
+  while (queue.length > 0) {
+    const parent = queue.shift();
+    for (const row of rows) {
+      if (row.ppid === parent && !seen.has(row.pid)) {
+        seen.add(row.pid);
+        queue.push(row.pid);
+      }
+    }
+  }
+  return [...seen];
+};
+
+export const getPosixProcessTreePids = async (rootPid, { timeoutMs = 5000 } = {}) => {
+  try {
+    const result = await spawnProcess("ps", ["-axo", "pid=,ppid="], { timeoutMs, maxCaptureChars: 2_000_000 });
+    return collectProcessTreePids(parsePsProcessTable(result.stdout), rootPid);
+  } catch {
+    return [rootPid];
+  }
+};
+
+export const captureCommand = async (file, args, { cwd, timeoutMs = 30000, env = process.env } = {}) => {
+  try {
+    return await spawnProcess(file, args, { cwd, timeoutMs, env, maxCaptureChars: 200_000 });
+  } catch (error) {
+    throw new HostCommandError(error instanceof Error ? error.message : `Failed to run ${file}.`, {
+      exitCode: error?.exitCode,
+      stdout: error?.stdout,
+      stderr: error?.stderr,
+      data: { file, args },
+    });
+  }
+};

--- a/src/screen-capture.js
+++ b/src/screen-capture.js
@@ -1,0 +1,55 @@
+import { config } from "./config.js";
+import { HostCommandError } from "./host-tools.js";
+import { captureLinuxDisplay, captureLinuxProgram } from "./linux-screen-capture.js";
+import { captureMacOSDisplay, captureMacOSProgram } from "./macos-screen-capture.js";
+import { captureFullDisplayJpeg, captureProgramWindowJpeg } from "./windows-screen-capture.js";
+
+export const resolveScreenCaptureBackend = (platform = config.platform) => {
+  if (platform?.isWindows) return "windows";
+  if (platform?.isMacOS) return "macos";
+  if (platform?.isLinux && !platform?.isTermux) return "linux";
+  if (platform?.isTermux) return "termux-unsupported";
+  return "unsupported";
+};
+
+const normalizeWindowsCapture = (capture) => ({
+  image: capture.image ?? capture.jpeg,
+  mimeType: capture.mimeType ?? "image/jpeg",
+  metadata: capture.metadata,
+});
+
+export const captureHostDisplay = async (options = {}) => {
+  switch (resolveScreenCaptureBackend()) {
+    case "windows":
+      return normalizeWindowsCapture(await captureFullDisplayJpeg(options));
+    case "macos":
+      return captureMacOSDisplay(options);
+    case "linux":
+      return captureLinuxDisplay(options);
+    case "termux-unsupported":
+      throw new HostCommandError(
+        "Termux/Android does not expose a desktop screenshot API to ordinary terminal apps. Use Android's platform screenshot/MediaProjection APIs outside Devbox or capture the desktop from the host running the emulator.",
+      );
+    default:
+      throw new HostCommandError(`Screen capture is not supported on host platform ${config.platform.displayName}.`);
+  }
+};
+
+export const captureHostProgram = async ({ pid, quality = 85, timeoutMs = 30000, includeProcessTree = true } = {}) => {
+  if (!Number.isInteger(pid) || pid <= 0) throw new HostCommandError("pid must be a positive host process ID.");
+  const options = { pid, quality, timeoutMs, includeProcessTree };
+  switch (resolveScreenCaptureBackend()) {
+    case "windows":
+      return normalizeWindowsCapture(await captureProgramWindowJpeg(options));
+    case "macos":
+      return captureMacOSProgram(options);
+    case "linux":
+      return captureLinuxProgram(options);
+    case "termux-unsupported":
+      throw new HostCommandError(
+        "Termux/Android cannot capture another app's window by PID from a terminal process. Android requires MediaProjection/user consent for cross-app screen capture.",
+      );
+    default:
+      throw new HostCommandError(`Program-window capture is not supported on host platform ${config.platform.displayName}.`);
+  }
+};

--- a/src/server.js
+++ b/src/server.js
@@ -46,7 +46,7 @@ import {
   runHostShellCommand,
   writeLargeFileOnHost,
 } from "./host-tools.js";
-import { captureFullDisplayJpeg, captureProgramWindowJpeg } from "./windows-screen-capture.js";
+import { captureHostDisplay, captureHostProgram } from "./screen-capture.js";
 import { CloudflareAccessOAuthProvider, DemoOAuthProvider } from "./oauth.js";
 import {
   normalizeLargeWritePayload,
@@ -506,15 +506,16 @@ const successResult = (summary, extra = {}) => {
   };
 };
 
-const jpegImageResult = (summary, { jpeg, metadata }) => {
+const imageCaptureResult = (summary, { image, jpeg, mimeType = "image/jpeg", metadata }) => {
+  const bytes = image ?? jpeg;
   const result = successResult(summary, {
     data: metadata,
     text: textFromResult(summary, metadata),
   });
   result.content.push({
     type: "image",
-    data: jpeg.toString("base64"),
-    mimeType: "image/jpeg",
+    data: bytes.toString("base64"),
+    mimeType,
   });
   return result;
 };
@@ -1260,55 +1261,86 @@ const buildServer = ({ requestSignal } = {}) => {
     hostStatusHandler,
   );
 
+  const captureDisplayHandler = async ({ quality }) => {
+    try {
+      const capture = await captureHostDisplay({ quality });
+      return imageCaptureResult(`Captured the ${hostTitle.toLowerCase()} display.`, capture);
+    } catch (error) {
+      return errorResult(error, `Failed to capture the ${hostTitle.toLowerCase()} display.`);
+    }
+  };
+
+  const captureWindowHandler = async ({ pid, quality, include_process_tree: includeProcessTree }) => {
+    try {
+      const capture = await captureHostProgram({ pid, quality, includeProcessTree });
+      return imageCaptureResult(`Captured ${hostTitle} window for PID ${pid}.`, capture);
+    } catch (error) {
+      return errorResult(error, `Failed to capture ${hostTitle} window for PID ${pid}.`);
+    }
+  };
+
+  const displayCaptureTool = {
+    title: `Capture ${hostTitle} Display`,
+    description:
+      `Capture the complete ${hostTitle.toLowerCase()} desktop using the native compositor/screenshot backend and return an MCP image content block. Windows returns JPEG; macOS/Linux use lossless PNG when their native tools do.`,
+    inputSchema: {
+      quality: z.number().int().min(1).max(100).default(85).describe("Requested image quality from 1 through 100. Native lossless PNG backends record but do not apply JPEG quality."),
+    },
+    outputSchema,
+  };
+
+  const windowCaptureTool = {
+    title: `Capture ${hostTitle} Window by PID`,
+    description:
+      "Capture the largest visible window owned by a host PID or one of its child processes. The Windows backend detects black PrintWindow frames from GPU/DirectComposition surfaces and falls back to compositor-visible pixels. macOS uses CoreGraphics window discovery plus screencapture; Linux supports X11 and compositor-specific Wayland paths.",
+    inputSchema: {
+      pid: z.number().int().min(1).describe("Host process ID whose visible application window should be captured."),
+      quality: z.number().int().min(1).max(100).default(85).describe("Requested image quality from 1 through 100."),
+      include_process_tree: z.boolean().default(true).describe("Also consider visible windows owned by child processes, useful for launchers, browsers, emulators, and multi-process GUI applications."),
+    },
+    outputSchema,
+  };
+
+  server.registerTool(
+    "host_capture_display",
+    safeReadOnlyTool(displayCaptureTool, `Capturing ${hostTitle.toLowerCase()} display`, `${hostTitle} display captured`),
+    captureDisplayHandler,
+  );
+
+  server.registerTool(
+    "host_capture_window",
+    safeReadOnlyTool(windowCaptureTool, `Capturing ${hostTitle.toLowerCase()} window`, `${hostTitle} window captured`),
+    captureWindowHandler,
+  );
+
+  server.registerTool(
+    "host_capture_program",
+    safeReadOnlyTool(
+      { ...windowCaptureTool, description: "Compatibility alias for host_capture_window." },
+      `Capturing ${hostTitle.toLowerCase()} window`,
+      `${hostTitle} window captured`,
+    ),
+    captureWindowHandler,
+  );
+
   server.registerTool(
     "windows_host_capture_display",
     safeReadOnlyTool(
-      {
-        title: "Capture Full Windows Display as JPEG",
-        description:
-          "Capture the complete Windows virtual desktop, including all attached displays, and return the actual screenshot as an image/jpeg MCP content block.",
-        inputSchema: {
-          quality: z.number().int().min(1).max(100).default(85).describe("JPEG quality from 1 through 100."),
-        },
-        outputSchema,
-      },
-      "Capturing full Windows display",
-      "Full Windows display captured",
+      { ...displayCaptureTool, description: "Compatibility alias for host_capture_display. On Windows this retains the original PR tool name." },
+      `Capturing ${hostTitle.toLowerCase()} display`,
+      `${hostTitle} display captured`,
     ),
-    async ({ quality }) => {
-      try {
-        const capture = await captureFullDisplayJpeg({ quality });
-        return jpegImageResult("Captured the full Windows display as JPEG.", capture);
-      } catch (error) {
-        return errorResult(error, "Failed to capture the full Windows display.");
-      }
-    },
+    captureDisplayHandler,
   );
 
   server.registerTool(
     "windows_host_capture_program",
     safeReadOnlyTool(
-      {
-        title: "Capture Windows Program by PID as JPEG",
-        description:
-          "Capture the largest visible, non-minimized top-level window owned by a specific Windows host process ID and return the actual screenshot as an image/jpeg MCP content block.",
-        inputSchema: {
-          pid: z.number().int().min(1).describe("Windows host process ID whose visible program window should be captured."),
-          quality: z.number().int().min(1).max(100).default(85).describe("JPEG quality from 1 through 100."),
-        },
-        outputSchema,
-      },
-      "Capturing Windows program window",
-      "Windows program window captured",
+      { ...windowCaptureTool, description: "Compatibility alias for host_capture_window. On Windows this retains the original PR tool name." },
+      `Capturing ${hostTitle.toLowerCase()} window`,
+      `${hostTitle} window captured`,
     ),
-    async ({ pid, quality }) => {
-      try {
-        const capture = await captureProgramWindowJpeg({ pid, quality });
-        return jpegImageResult(`Captured Windows program PID ${pid} as JPEG.`, capture);
-      } catch (error) {
-        return errorResult(error, `Failed to capture Windows program PID ${pid}.`);
-      }
-    },
+    captureWindowHandler,
   );
 
   server.registerTool(

--- a/src/windows-screen-capture.js
+++ b/src/windows-screen-capture.js
@@ -5,7 +5,6 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 
 import { config } from "./config.js";
 import { HostCommandError, assertHostExecEnabled, buildWindowsPowerShellFileArgs, spawnPowerShellProcess } from "./host-tools.js";
-import { spawnProcess } from "./process-utils.js";
 
 const JPEG_START = Buffer.from([0xff, 0xd8, 0xff]);
 const JPEG_END = Buffer.from([0xff, 0xd9]);
@@ -15,7 +14,8 @@ param(
   [Parameter(Mandatory = $true)][ValidateSet('display', 'pid')][string]$Mode,
   [Parameter(Mandatory = $true)][string]$OutputPath,
   [Parameter(Mandatory = $true)][ValidateRange(1, 100)][int]$Quality,
-  [int]$TargetPid = 0
+  [int]$TargetPid = 0,
+  [ValidateSet('0', '1')][string]$IncludeProcessTree = '1'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -32,6 +32,8 @@ using System.Text;
 
 public static class DevboxCaptureNative {
     public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+    private const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+    private const int DWMWA_CLOAKED = 14;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct RECT {
@@ -43,6 +45,9 @@ public static class DevboxCaptureNative {
 
     [DllImport("user32.dll")]
     public static extern bool SetProcessDPIAware();
+
+    [DllImport("user32.dll")]
+    public static extern bool SetProcessDpiAwarenessContext(IntPtr dpiContext);
 
     [DllImport("user32.dll")]
     public static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
@@ -72,31 +77,67 @@ public static class DevboxCaptureNative {
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool PrintWindow(IntPtr hWnd, IntPtr hdcBlt, uint flags);
 
-    public static IntPtr FindLargestVisibleWindow(uint targetPid) {
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out RECT pvAttribute, int cbAttribute);
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out int pvAttribute, int cbAttribute);
+
+    [DllImport("dwmapi.dll")]
+    public static extern int DwmFlush();
+
+    public static bool IsCloaked(IntPtr hWnd) {
+        try {
+            int cloaked;
+            return DwmGetWindowAttribute(hWnd, DWMWA_CLOAKED, out cloaked, Marshal.SizeOf(typeof(int))) == 0 && cloaked != 0;
+        } catch {
+            return false;
+        }
+    }
+
+    public static bool GetVisualWindowRect(IntPtr hWnd, out RECT rect) {
+        try {
+            if (DwmGetWindowAttribute(hWnd, DWMWA_EXTENDED_FRAME_BOUNDS, out rect, Marshal.SizeOf(typeof(RECT))) == 0 &&
+                rect.Right > rect.Left && rect.Bottom > rect.Top) {
+                return true;
+            }
+        } catch {
+        }
+        return GetWindowRect(hWnd, out rect);
+    }
+
+    public static IntPtr FindLargestVisibleWindow(uint[] targetPids) {
+        var pids = new HashSet<uint>(targetPids ?? new uint[0]);
         IntPtr best = IntPtr.Zero;
         long bestArea = 0;
         EnumWindows((hWnd, lParam) => {
             uint ownerPid;
             GetWindowThreadProcessId(hWnd, out ownerPid);
-            if (ownerPid != targetPid || !IsWindowVisible(hWnd) || IsIconic(hWnd)) {
+            if (!pids.Contains(ownerPid) || !IsWindowVisible(hWnd) || IsIconic(hWnd) || IsCloaked(hWnd)) {
                 return true;
             }
 
             RECT rect;
-            if (!GetWindowRect(hWnd, out rect)) {
+            if (!GetVisualWindowRect(hWnd, out rect)) {
                 return true;
             }
 
             long width = Math.Max(0, rect.Right - rect.Left);
             long height = Math.Max(0, rect.Bottom - rect.Top);
             long area = width * height;
-            if (area > bestArea) {
+            if (width >= 32 && height >= 32 && area > bestArea) {
                 best = hWnd;
                 bestArea = area;
             }
             return true;
         }, IntPtr.Zero);
         return best;
+    }
+
+    public static uint ReadWindowPid(IntPtr hWnd) {
+        uint pid;
+        GetWindowThreadProcessId(hWnd, out pid);
+        return pid;
     }
 
     public static string ReadWindowTitle(IntPtr hWnd) {
@@ -108,7 +149,11 @@ public static class DevboxCaptureNative {
 }
 '@
 
-[DevboxCaptureNative]::SetProcessDPIAware() | Out-Null
+try {
+  [DevboxCaptureNative]::SetProcessDpiAwarenessContext([IntPtr](-4)) | Out-Null
+} catch {
+  [DevboxCaptureNative]::SetProcessDPIAware() | Out-Null
+}
 
 function Save-Jpeg {
   param(
@@ -136,6 +181,96 @@ function Save-Jpeg {
   }
 }
 
+function Measure-BitmapFrame {
+  param([Parameter(Mandatory = $true)][System.Drawing.Bitmap]$Bitmap)
+
+  $sampleColumns = [Math]::Min(32, [Math]::Max(1, $Bitmap.Width))
+  $sampleRows = [Math]::Min(32, [Math]::Max(1, $Bitmap.Height))
+  $count = 0
+  $sum = 0.0
+  $minLuma = 255.0
+  $maxLuma = 0.0
+  $nearBlack = 0
+  $interiorCount = 0
+  $interiorSum = 0.0
+  $interiorNearBlack = 0
+
+  for ($row = 0; $row -lt $sampleRows; $row++) {
+    $normalizedY = ($row + 0.5) / $sampleRows
+    $y = [Math]::Min($Bitmap.Height - 1, [int](($row + 0.5) * $Bitmap.Height / $sampleRows))
+    for ($column = 0; $column -lt $sampleColumns; $column++) {
+      $normalizedX = ($column + 0.5) / $sampleColumns
+      $x = [Math]::Min($Bitmap.Width - 1, [int](($column + 0.5) * $Bitmap.Width / $sampleColumns))
+      $pixel = $Bitmap.GetPixel($x, $y)
+      $luma = 0.2126 * $pixel.R + 0.7152 * $pixel.G + 0.0722 * $pixel.B
+      $isNearBlack = ($pixel.R -le 8 -and $pixel.G -le 8 -and $pixel.B -le 8)
+      $sum += $luma
+      $minLuma = [Math]::Min($minLuma, $luma)
+      $maxLuma = [Math]::Max($maxLuma, $luma)
+      if ($isNearBlack) { $nearBlack++ }
+      $count++
+
+      # Ignore borders/title chrome when deciding whether the application
+      # renderer itself is blank. GPU video/emulator surfaces commonly leave
+      # non-black non-client pixels while the central DirectComposition client
+      # surface returned by PrintWindow is entirely black.
+      if ($normalizedX -ge 0.08 -and $normalizedX -le 0.92 -and $normalizedY -ge 0.18 -and $normalizedY -le 0.92) {
+        $interiorSum += $luma
+        if ($isNearBlack) { $interiorNearBlack++ }
+        $interiorCount++
+      }
+    }
+  }
+
+  $mean = if ($count -gt 0) { $sum / $count } else { 0.0 }
+  $nearBlackRatio = if ($count -gt 0) { $nearBlack / $count } else { 1.0 }
+  $interiorMean = if ($interiorCount -gt 0) { $interiorSum / $interiorCount } else { $mean }
+  $interiorNearBlackRatio = if ($interiorCount -gt 0) { $interiorNearBlack / $interiorCount } else { $nearBlackRatio }
+  $suspicious = ($nearBlackRatio -ge 0.985 -and $mean -le 12.0) -or ($interiorNearBlackRatio -ge 0.94 -and $interiorMean -le 16.0)
+  [pscustomobject]@{
+    MeanLuma = [Math]::Round($mean, 3)
+    LumaRange = [Math]::Round($maxLuma - $minLuma, 3)
+    NearBlackRatio = [Math]::Round($nearBlackRatio, 4)
+    InteriorMeanLuma = [Math]::Round($interiorMean, 3)
+    InteriorNearBlackRatio = [Math]::Round($interiorNearBlackRatio, 4)
+    Suspicious = $suspicious
+  }
+}
+
+function Get-ProcessTreePids {
+  param([Parameter(Mandatory = $true)][uint32]$RootPid, [bool]$IncludeTree)
+
+  $result = [System.Collections.Generic.HashSet[uint32]]::new()
+  [void]$result.Add($RootPid)
+  if (-not $IncludeTree) { return [uint32[]]$result }
+
+  try {
+    $all = @(Get-CimInstance Win32_Process -ErrorAction Stop | Select-Object ProcessId, ParentProcessId)
+    $queue = [System.Collections.Generic.Queue[uint32]]::new()
+    $queue.Enqueue($RootPid)
+    while ($queue.Count -gt 0) {
+      $parent = $queue.Dequeue()
+      foreach ($candidate in $all) {
+        if ([uint32]$candidate.ParentProcessId -eq $parent) {
+          $child = [uint32]$candidate.ProcessId
+          if ($result.Add($child)) { $queue.Enqueue($child) }
+        }
+      }
+    }
+  } catch {
+  }
+
+  return [uint32[]]$result
+}
+
+function New-CaptureBitmap {
+  param([int]$Width, [int]$Height)
+  $bmp = [System.Drawing.Bitmap]::new($Width, $Height, [System.Drawing.Imaging.PixelFormat]::Format24bppRgb)
+  $gfx = [System.Drawing.Graphics]::FromImage($bmp)
+  $gfx.Clear([System.Drawing.Color]::Black)
+  [pscustomobject]@{ Bitmap = $bmp; Graphics = $gfx }
+}
+
 $bitmap = $null
 $graphics = $null
 try {
@@ -145,13 +280,15 @@ try {
       throw 'Windows reported an empty virtual display.'
     }
 
-    $bitmap = [System.Drawing.Bitmap]::new($bounds.Width, $bounds.Height, [System.Drawing.Imaging.PixelFormat]::Format24bppRgb)
-    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    $capture = New-CaptureBitmap -Width $bounds.Width -Height $bounds.Height
+    $bitmap = $capture.Bitmap
+    $graphics = $capture.Graphics
     $graphics.CopyFromScreen($bounds.Left, $bounds.Top, 0, 0, $bounds.Size, [System.Drawing.CopyPixelOperation]::SourceCopy)
     Save-Jpeg -Bitmap $bitmap -Path $OutputPath -JpegQuality $Quality
 
     $metadata = @{
       capture_mode = 'full_display'
+      capture_method = 'DesktopCompositorCopy'
       left = $bounds.Left
       top = $bounds.Top
       width = $bounds.Width
@@ -164,14 +301,16 @@ try {
     }
 
     $process = Get-Process -Id $TargetPid -ErrorAction Stop
-    $window = [DevboxCaptureNative]::FindLargestVisibleWindow([uint32]$TargetPid)
+    $candidatePids = Get-ProcessTreePids -RootPid ([uint32]$TargetPid) -IncludeTree ($IncludeProcessTree -eq '1')
+    $window = [DevboxCaptureNative]::FindLargestVisibleWindow($candidatePids)
     if ($window -eq [IntPtr]::Zero) {
-      throw "Process $TargetPid ($($process.ProcessName)) has no visible, non-minimized top-level window to capture."
+      throw "Process $TargetPid ($($process.ProcessName)) and its visible child processes have no non-minimized, non-cloaked top-level window to capture."
     }
 
+    $ownerPid = [int][DevboxCaptureNative]::ReadWindowPid($window)
     $rect = [DevboxCaptureNative+RECT]::new()
-    if (-not [DevboxCaptureNative]::GetWindowRect($window, [ref]$rect)) {
-      throw "Could not read the window bounds for process $TargetPid."
+    if (-not [DevboxCaptureNative]::GetVisualWindowRect($window, [ref]$rect)) {
+      throw "Could not read the visual window bounds for process $TargetPid."
     }
 
     $width = $rect.Right - $rect.Left
@@ -180,31 +319,99 @@ try {
       throw "Process $TargetPid has invalid window bounds ($width x $height)."
     }
 
-    $bitmap = [System.Drawing.Bitmap]::new($width, $height, [System.Drawing.Imaging.PixelFormat]::Format24bppRgb)
-    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
-    $hdc = $graphics.GetHdc()
-    try {
-      $printed = [DevboxCaptureNative]::PrintWindow($window, $hdc, 2)
-    } finally {
-      $graphics.ReleaseHdc($hdc)
+    $capture = New-CaptureBitmap -Width $width -Height $height
+    $bitmap = $capture.Bitmap
+    $graphics = $capture.Graphics
+    $captureMethod = $null
+    $printAnalysis = $null
+    $printFlags = $null
+    $printRejected = $false
+
+    foreach ($flags in @(2, 0)) {
+      $graphics.Clear([System.Drawing.Color]::Black)
+      $hdc = $graphics.GetHdc()
+      try {
+        $printed = [DevboxCaptureNative]::PrintWindow($window, $hdc, [uint32]$flags)
+      } finally {
+        $graphics.ReleaseHdc($hdc)
+      }
+
+      if (-not $printed) { continue }
+      $analysis = Measure-BitmapFrame -Bitmap $bitmap
+      $printAnalysis = $analysis
+      $printFlags = $flags
+      if (-not $analysis.Suspicious) {
+        $captureMethod = $(if ($flags -eq 2) { 'PrintWindow(PW_RENDERFULLCONTENT)' } else { 'PrintWindow(default)' })
+        break
+      }
+      $printRejected = $true
     }
 
-    if (-not $printed) {
-      $graphics.CopyFromScreen($rect.Left, $rect.Top, 0, 0, [System.Drawing.Size]::new($width, $height), [System.Drawing.CopyPixelOperation]::SourceCopy)
+    $capturedLeft = $rect.Left
+    $capturedTop = $rect.Top
+    $capturedWidth = $width
+    $capturedHeight = $height
+    $clippedToDisplay = $false
+
+    if ($null -eq $captureMethod) {
+      try { [void][DevboxCaptureNative]::DwmFlush() } catch {}
+      $virtual = [System.Windows.Forms.SystemInformation]::VirtualScreen
+      $capturedLeft = [Math]::Max($rect.Left, $virtual.Left)
+      $capturedTop = [Math]::Max($rect.Top, $virtual.Top)
+      $capturedRight = [Math]::Min($rect.Right, $virtual.Right)
+      $capturedBottom = [Math]::Min($rect.Bottom, $virtual.Bottom)
+      $capturedWidth = $capturedRight - $capturedLeft
+      $capturedHeight = $capturedBottom - $capturedTop
+      if ($capturedWidth -le 0 -or $capturedHeight -le 0) {
+        throw "The window is completely outside the visible virtual desktop and PrintWindow did not return usable pixels."
+      }
+
+      $clippedToDisplay = ($capturedLeft -ne $rect.Left -or $capturedTop -ne $rect.Top -or $capturedWidth -ne $width -or $capturedHeight -ne $height)
+      $graphics.Dispose()
+      $bitmap.Dispose()
+      $capture = New-CaptureBitmap -Width $capturedWidth -Height $capturedHeight
+      $bitmap = $capture.Bitmap
+      $graphics = $capture.Graphics
+      $graphics.CopyFromScreen(
+        $capturedLeft,
+        $capturedTop,
+        0,
+        0,
+        [System.Drawing.Size]::new($capturedWidth, $capturedHeight),
+        [System.Drawing.CopyPixelOperation]::SourceCopy
+      )
+      $captureMethod = 'DesktopCompositorCopy(window-bounds)'
     }
+
     Save-Jpeg -Bitmap $bitmap -Path $OutputPath -JpegQuality $Quality
 
     $metadata = @{
       capture_mode = 'program_pid'
       pid = $TargetPid
       process_name = $process.ProcessName
+      window_owner_pid = $ownerPid
+      process_tree_fallback = ($ownerPid -ne $TargetPid)
+      candidate_pid_count = @($candidatePids).Count
       window_handle = $window.ToInt64()
       window_title = [DevboxCaptureNative]::ReadWindowTitle($window)
-      capture_method = $(if ($printed) { 'PrintWindow' } else { 'CopyFromScreen' })
-      left = $rect.Left
-      top = $rect.Top
-      width = $width
-      height = $height
+      capture_method = $captureMethod
+      print_window_rejected = $printRejected
+      print_window_flags = $printFlags
+      print_window_mean_luma = $(if ($null -ne $printAnalysis) { $printAnalysis.MeanLuma } else { $null })
+      print_window_luma_range = $(if ($null -ne $printAnalysis) { $printAnalysis.LumaRange } else { $null })
+      print_window_near_black_ratio = $(if ($null -ne $printAnalysis) { $printAnalysis.NearBlackRatio } else { $null })
+      print_window_interior_mean_luma = $(if ($null -ne $printAnalysis) { $printAnalysis.InteriorMeanLuma } else { $null })
+      print_window_interior_near_black_ratio = $(if ($null -ne $printAnalysis) { $printAnalysis.InteriorNearBlackRatio } else { $null })
+      requested_left = $rect.Left
+      requested_top = $rect.Top
+      requested_width = $width
+      requested_height = $height
+      left = $capturedLeft
+      top = $capturedTop
+      width = $capturedWidth
+      height = $capturedHeight
+      clipped_to_display = $clippedToDisplay
+      screen_fallback_may_include_occluders = ($captureMethod -like 'DesktopCompositorCopy*')
       quality = $Quality
     }
   }
@@ -222,7 +429,7 @@ export const isJpegBuffer = (buffer) =>
   buffer.subarray(0, JPEG_START.length).equals(JPEG_START) &&
   buffer.subarray(buffer.length - JPEG_END.length).equals(JPEG_END);
 
-const captureWindowsJpeg = async ({ mode, pid = 0, quality = 85, timeoutMs = 30000 }) => {
+const captureWindowsJpeg = async ({ mode, pid = 0, quality = 85, timeoutMs = 30000, includeProcessTree = true }) => {
   assertHostExecEnabled();
   if (!config.platform.isWindows || process.platform !== "win32") {
     throw new HostCommandError("Windows display capture is available only on a Windows host.");
@@ -245,6 +452,8 @@ const captureWindowsJpeg = async ({ mode, pid = 0, quality = 85, timeoutMs = 300
         String(quality),
         "-TargetPid",
         String(pid),
+        "-IncludeProcessTree",
+        includeProcessTree ? "1" : "0",
       ],
       {
         cwd: tempDir,
@@ -273,6 +482,8 @@ const captureWindowsJpeg = async ({ mode, pid = 0, quality = 85, timeoutMs = 300
 
     return {
       jpeg,
+      image: jpeg,
+      mimeType: "image/jpeg",
       metadata: {
         ...metadata,
         mime_type: "image/jpeg",
@@ -297,9 +508,9 @@ const captureWindowsJpeg = async ({ mode, pid = 0, quality = 85, timeoutMs = 300
 export const captureFullDisplayJpeg = ({ quality = 85, timeoutMs = 30000 } = {}) =>
   captureWindowsJpeg({ mode: "display", quality, timeoutMs });
 
-export const captureProgramWindowJpeg = ({ pid, quality = 85, timeoutMs = 30000 }) => {
+export const captureProgramWindowJpeg = ({ pid, quality = 85, timeoutMs = 30000, includeProcessTree = true }) => {
   if (!Number.isInteger(pid) || pid <= 0) {
     throw new HostCommandError("pid must be a positive Windows process ID.");
   }
-  return captureWindowsJpeg({ mode: "pid", pid, quality, timeoutMs });
+  return captureWindowsJpeg({ mode: "pid", pid, quality, timeoutMs, includeProcessTree });
 };

--- a/src/windows-screen-capture.js
+++ b/src/windows-screen-capture.js
@@ -150,7 +150,9 @@ public static class DevboxCaptureNative {
 '@
 
 try {
-  [DevboxCaptureNative]::SetProcessDpiAwarenessContext([IntPtr](-4)) | Out-Null
+  if (-not [DevboxCaptureNative]::SetProcessDpiAwarenessContext([IntPtr](-4))) {
+    [DevboxCaptureNative]::SetProcessDPIAware() | Out-Null
+  }
 } catch {
   [DevboxCaptureNative]::SetProcessDPIAware() | Out-Null
 }
@@ -501,7 +503,7 @@ const captureWindowsJpeg = async ({ mode, pid = 0, quality = 85, timeoutMs = 300
       stderr: error?.stderr,
     });
   } finally {
-    await rm(tempDir, { recursive: true, force: true });
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 }).catch(() => {});
   }
 };
 

--- a/test/mcp-http.test.js
+++ b/test/mcp-http.test.js
@@ -197,6 +197,98 @@ $form.Add_Shown({ [Console]::Out.WriteLine('ready'); [Console]::Out.Flush() })
   return child;
 };
 
+const terminateWindowsProcessTree = async (pid) => {
+  if (process.platform !== "win32") return;
+  const killer = spawn("taskkill.exe", ["/pid", String(pid), "/t", "/f"], {
+    cwd: projectRoot,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  await Promise.race([once(killer, "exit"), wait(5000)]);
+};
+
+const startChildOwnedTestWindow = async (t) => {
+  const script = String.raw`
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$form = [System.Windows.Forms.Form]::new()
+$form.Text = 'Devbox Child PID Capture Test'
+$form.StartPosition = 'Manual'
+$form.Location = [System.Drawing.Point]::new(180, 180)
+$form.Size = [System.Drawing.Size]::new(700, 400)
+$form.BackColor = [System.Drawing.Color]::DarkBlue
+$form.Add_Shown({ [Console]::Out.WriteLine('ready'); [Console]::Out.Flush() })
+[void]$form.ShowDialog()
+`;
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  const command = `powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encoded}`;
+  const launcher = spawn("cmd.exe", ["/d", "/s", "/c", command], {
+    cwd: projectRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: false,
+  });
+  const stderr = [];
+  collectStream(launcher.stderr, stderr);
+  await Promise.race([
+    new Promise((resolve) => {
+      launcher.stdout.setEncoding("utf8");
+      launcher.stdout.on("data", (chunk) => {
+        if (chunk.includes("ready")) resolve();
+      });
+    }),
+    (async () => {
+      await wait(10000);
+      throw new Error(`Timed out waiting for child-owned capture window. stderr:\\n${stderr.join("")}`);
+    })(),
+  ]);
+  t.after(async () => terminateWindowsProcessTree(launcher.pid));
+  return launcher;
+};
+
+const startBlackPrintWindow = async (t) => {
+  const script = String.raw`
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$form = [System.Windows.Forms.Form]::new()
+$form.Text = 'Devbox Black PrintWindow Test'
+$form.FormBorderStyle = [System.Windows.Forms.FormBorderStyle]::None
+$form.StartPosition = 'Manual'
+$form.Location = [System.Drawing.Point]::new(120, 120)
+$form.Size = [System.Drawing.Size]::new(720, 420)
+$form.TopMost = $true
+$form.BackColor = [System.Drawing.Color]::Black
+$header = [System.Windows.Forms.Panel]::new()
+$header.Dock = [System.Windows.Forms.DockStyle]::Top
+$header.Height = 60
+$header.BackColor = [System.Drawing.Color]::Magenta
+$form.Controls.Add($header)
+$form.Add_Shown({ [Console]::Out.WriteLine('ready'); [Console]::Out.Flush() })
+[void]$form.ShowDialog()
+`;
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  const child = spawn(
+    "powershell.exe",
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", encoded],
+    { cwd: projectRoot, stdio: ["ignore", "pipe", "pipe"], windowsHide: false },
+  );
+  const stderr = [];
+  collectStream(child.stderr, stderr);
+  await Promise.race([
+    new Promise((resolve) => {
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => {
+        if (chunk.includes("ready")) resolve();
+      });
+    }),
+    (async () => {
+      await wait(10000);
+      throw new Error(`Timed out waiting for black PrintWindow test window. stderr:\\n${stderr.join("")}`);
+    })(),
+  ]);
+  t.after(async () => terminateChild(child));
+  return child;
+};
+
 test("Windows display capture returns actual JPEG bytes through MCP", { skip: process.platform !== "win32" }, async (t) => {
   const { port } = await startServer(t);
   const client = await connectClient(t, port);
@@ -222,6 +314,58 @@ test("Windows PID program capture returns its actual window as JPEG through MCP"
   assert.equal(result.structuredContent.data.capture_mode, "program_pid");
   assert.equal(result.structuredContent.data.pid, windowProcess.pid);
   assert.equal(result.structuredContent.data.window_title, "Devbox PID Capture Test");
+});
+
+
+test("generic host capture tools expose the Windows capture backend", { skip: process.platform !== "win32" }, async (t) => {
+  const windowProcess = await startVisibleTestWindow(t);
+  const { port } = await startServer(t);
+  const client = await connectClient(t, port);
+  const tools = await client.listTools();
+  const names = new Set(tools.tools.map((tool) => tool.name));
+  assert.equal(names.has("host_capture_display"), true);
+  assert.equal(names.has("host_capture_window"), true);
+  assert.equal(names.has("windows_host_capture_program"), true);
+
+  const result = await client.callTool({
+    name: "host_capture_window",
+    arguments: { pid: windowProcess.pid, quality: 80, include_process_tree: true },
+  });
+  assertJpegToolResult(result);
+  assert.equal(result.structuredContent.data.pid, windowProcess.pid);
+});
+
+test("Windows window capture follows child processes when the launcher PID owns no GUI", { skip: process.platform !== "win32" }, async (t) => {
+  const launcher = await startChildOwnedTestWindow(t);
+  const { port } = await startServer(t);
+  const client = await connectClient(t, port);
+  const result = await client.callTool({
+    name: "host_capture_window",
+    arguments: { pid: launcher.pid, include_process_tree: true, quality: 80 },
+  });
+
+  assertJpegToolResult(result);
+  assert.equal(result.structuredContent.data.pid, launcher.pid);
+  assert.equal(result.structuredContent.data.process_tree_fallback, true);
+  assert.notEqual(result.structuredContent.data.window_owner_pid, launcher.pid);
+  assert.equal(result.structuredContent.data.window_title, "Devbox Child PID Capture Test");
+});
+
+test("Windows capture rejects a successful black PrintWindow frame and falls back to compositor pixels", { skip: process.platform !== "win32" }, async (t) => {
+  const windowProcess = await startBlackPrintWindow(t);
+  const { port } = await startServer(t);
+  const client = await connectClient(t, port);
+  const result = await client.callTool({
+    name: "host_capture_window",
+    arguments: { pid: windowProcess.pid, quality: 82 },
+  });
+
+  assertJpegToolResult(result);
+  assert.equal(result.structuredContent.data.print_window_rejected, true);
+  assert.ok(result.structuredContent.data.print_window_near_black_ratio < 0.985);
+  assert.ok(result.structuredContent.data.print_window_interior_near_black_ratio >= 0.94);
+  assert.equal(result.structuredContent.data.capture_method, "DesktopCompositorCopy(window-bounds)");
+  assert.equal(result.structuredContent.data.screen_fallback_may_include_occluders, true);
 });
 
 const assertSseProbeResponse = async (response, errorMessage) => {

--- a/test/mcp-http.test.js
+++ b/test/mcp-http.test.js
@@ -227,21 +227,25 @@ $form.Add_Shown({ [Console]::Out.WriteLine('ready'); [Console]::Out.Flush() })
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: false,
   });
+  t.after(async () => terminateWindowsProcessTree(launcher.pid));
   const stderr = [];
   collectStream(launcher.stderr, stderr);
-  await Promise.race([
-    new Promise((resolve) => {
+  let readinessTimer;
+  try {
+    await new Promise((resolve, reject) => {
       launcher.stdout.setEncoding("utf8");
       launcher.stdout.on("data", (chunk) => {
         if (chunk.includes("ready")) resolve();
       });
-    }),
-    (async () => {
-      await wait(10000);
-      throw new Error(`Timed out waiting for child-owned capture window. stderr:\\n${stderr.join("")}`);
-    })(),
-  ]);
-  t.after(async () => terminateWindowsProcessTree(launcher.pid));
+      readinessTimer = setTimeout(
+        () => reject(new Error(`Timed out waiting for child-owned capture window. stderr:
+${stderr.join("")}`)),
+        10000,
+      );
+    });
+  } finally {
+    clearTimeout(readinessTimer);
+  }
   return launcher;
 };
 
@@ -271,21 +275,25 @@ $form.Add_Shown({ [Console]::Out.WriteLine('ready'); [Console]::Out.Flush() })
     ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", encoded],
     { cwd: projectRoot, stdio: ["ignore", "pipe", "pipe"], windowsHide: false },
   );
+  t.after(async () => terminateChild(child));
   const stderr = [];
   collectStream(child.stderr, stderr);
-  await Promise.race([
-    new Promise((resolve) => {
+  let readinessTimer;
+  try {
+    await new Promise((resolve, reject) => {
       child.stdout.setEncoding("utf8");
       child.stdout.on("data", (chunk) => {
         if (chunk.includes("ready")) resolve();
       });
-    }),
-    (async () => {
-      await wait(10000);
-      throw new Error(`Timed out waiting for black PrintWindow test window. stderr:\\n${stderr.join("")}`);
-    })(),
-  ]);
-  t.after(async () => terminateChild(child));
+      readinessTimer = setTimeout(
+        () => reject(new Error(`Timed out waiting for black PrintWindow test window. stderr:
+${stderr.join("")}`)),
+        10000,
+      );
+    });
+  } finally {
+    clearTimeout(readinessTimer);
+  }
   return child;
 };
 

--- a/test/screen-capture.test.js
+++ b/test/screen-capture.test.js
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  collectProcessTreePids,
+  getPngDimensions,
+  isPngBuffer,
+  parsePsProcessTable,
+} from "../src/screen-capture-utils.js";
+import {
+  detectLinuxDisplaySession,
+  parseHyprlandWindows,
+  parseSwayWindows,
+  parseWmctrlWindows,
+  parseXwininfoGeometry,
+  selectLargestWindow,
+} from "../src/linux-screen-capture.js";
+import { macOSWindowQuerySwift } from "../src/macos-screen-capture.js";
+import { resolveScreenCaptureBackend } from "../src/screen-capture.js";
+
+const pngHeader = (width, height) => {
+  const buffer = Buffer.alloc(24);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buffer, 0);
+  buffer.write("IHDR", 12, "ascii");
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  return buffer;
+};
+
+test("PNG validation extracts IHDR dimensions without an image dependency", () => {
+  const png = pngHeader(1920, 1080);
+  assert.equal(isPngBuffer(png), true);
+  assert.deepEqual(getPngDimensions(png), { width: 1920, height: 1080 });
+  assert.equal(isPngBuffer(Buffer.from("not png")), false);
+});
+
+test("POSIX process-tree collection includes descendants but not siblings", () => {
+  const rows = parsePsProcessTable(" 10 1\n 11 10\n 12 11\n 20 1\n");
+  assert.deepEqual(collectProcessTreePids(rows, 10), [10, 11, 12]);
+});
+
+test("screen capture backend follows the detected host platform", () => {
+  assert.equal(resolveScreenCaptureBackend({ isWindows: true }), "windows");
+  assert.equal(resolveScreenCaptureBackend({ isMacOS: true }), "macos");
+  assert.equal(resolveScreenCaptureBackend({ isLinux: true, isTermux: false }), "linux");
+  assert.equal(resolveScreenCaptureBackend({ isLinux: true, isTermux: true }), "termux-unsupported");
+});
+
+test("Linux session detection distinguishes Wayland, X11 and headless", () => {
+  assert.deepEqual(detectLinuxDisplaySession({ WAYLAND_DISPLAY: "wayland-0" }), {
+    wayland: true,
+    x11: false,
+    sessionType: "wayland",
+  });
+  assert.deepEqual(detectLinuxDisplaySession({ DISPLAY: ":0" }), {
+    wayland: false,
+    x11: true,
+    sessionType: "x11",
+  });
+  assert.equal(detectLinuxDisplaySession({}).sessionType, "headless");
+});
+
+test("wmctrl parser and selector choose the largest child-process window", () => {
+  const windows = parseWmctrlWindows([
+    "0x01  0 100 10 20 200 100 host Parent",
+    "0x02  0 101 30 40 1280 720 host GPU Child",
+    "0x03  0 999 0 0 1920 1080 host Unrelated",
+  ].join("\n"));
+  const selected = selectLargestWindow(windows, [100, 101]);
+  assert.equal(selected.id, "0x02");
+  assert.equal(selected.pid, 101);
+  assert.equal(selected.title, "GPU Child");
+});
+
+test("xwininfo geometry accepts negative multi-monitor coordinates", () => {
+  assert.deepEqual(
+    parseXwininfoGeometry("Absolute upper-left X:  -1920\nAbsolute upper-left Y:  25\nWidth: 1920\nHeight: 1080\n"),
+    { left: -1920, top: 25, width: 1920, height: 1080 },
+  );
+});
+
+test("Sway and Hyprland parsers resolve compositor-native PID windows", () => {
+  const sway = parseSwayWindows(JSON.stringify({
+    nodes: [{ pid: 42, name: "Emulator", visible: true, rect: { x: 4, y: 5, width: 800, height: 600 }, nodes: [], floating_nodes: [] }],
+    floating_nodes: [],
+  }), [42]);
+  assert.equal(sway[0].backend, "sway");
+  assert.equal(sway[0].width, 800);
+
+  const hypr = parseHyprlandWindows(JSON.stringify([
+    { pid: 42, address: "0xabc", mapped: true, hidden: false, at: [8, 9], size: [900, 700], title: "Emulator" },
+  ]), [42]);
+  assert.equal(hypr[0].backend, "hyprland");
+  assert.equal(hypr[0].id, "0xabc");
+});
+
+test("macOS window discovery uses CoreGraphics compositor metadata", () => {
+  assert.match(macOSWindowQuerySwift, /CGWindowListCopyWindowInfo/);
+  assert.match(macOSWindowQuerySwift, /CGGetActiveDisplayList/);
+  assert.match(macOSWindowQuerySwift, /optionOnScreenOnly/);
+});


### PR DESCRIPTION
## Summary

- harden Windows PID-selected capture for GPU/DirectComposition/video/emulator surfaces that make `PrintWindow` return a successful but black renderer frame
- use DWM visual bounds, per-monitor DPI awareness, cloaked/minimized filtering, and compositor-visible bounds fallback
- follow child processes so launcher PIDs can resolve the actual GUI/render-process window
- add preferred cross-platform `host_capture_display` and `host_capture_window` / `host_capture_program` tools while retaining the original `windows_host_capture_*` aliases
- add native macOS CoreGraphics window discovery plus `screencapture`, including Screen Recording diagnostics and visible-bounds fallback
- add Linux X11 and Wayland capture backends, including Sway/Hyprland/wlroots paths, XWayland fallback, and explicit portal limitations on restrictive compositors
- add platform backend tests and real macOS/Linux runtime-CI wiring

## Windows edge cases covered

- `PrintWindow` reports success but the application renderer/client area is black
- visible non-client chrome with a black accelerated renderer interior
- launcher PID owns no top-level window but a child render process does
- DWM visual frame bounds and mixed-DPI/multi-monitor coordinates
- compositor fallback metadata explicitly warns that visible-region capture may include occluders

## Validation

- `npm test`: 88 unit tests (87 pass + 1 expected platform skip), 15/15 MCP tests
- Windows black-renderer fallback regression: pass
- Windows parent-PID -> child-window regression: pass
- JS syntax and shell syntax checks: pass
- `git diff --check`: pass
- Platform runtime CI additionally exercises macOS CoreGraphics helper compilation and Linux fake Wayland/X11 backend wiring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cross-platform screen capture for full displays and individual application windows.
  - Added canonical display and window capture tools, with compatibility aliases retained.
  - Supports process and child-process window selection.
  - Added platform-specific capture support for Windows, macOS, Linux, and supported desktop environments.
  - Improved Windows capture with DPI-aware bounds and compositor fallback.

- **Documentation**
  - Documented platform compatibility, permissions, limitations, and fallback behavior.

- **Tests**
  - Added comprehensive unit, integration, and platform-specific capture coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->