### PR TITLE
Add full Termux and cross-platform runtime E2E CI

### DIFF
--- a/.github/workflows/platform-runtime-e2e.yml
+++ b/.github/workflows/platform-runtime-e2e.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/platform-runtime-e2e.yml
+++ b/.github/workflows/platform-runtime-e2e.yml
@@ -1,0 +1,86 @@
+name: Platform runtime E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "src/**"
+      - "bin/**"
+      - "scripts/**"
+      - "bootstrap/**"
+      - "setup-tui/**"
+      - "test/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".env.example"
+      - ".github/workflows/platform-runtime-e2e.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  macos-native:
+    name: Native macOS E2E (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            arch: arm64
+          - os: macos-15-intel
+            arch: x86_64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Validate native macOS runtime and MCP bridge
+        env:
+          DEVBOX_E2E_EXPECT_PLATFORM: macos
+          DEVBOX_E2E_PORT: 18180
+        run: sh scripts/ci/run-posix-runtime-e2e.sh
+
+  linux-distros:
+    name: Linux E2E (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu 26.04 LTS
+            image: ubuntu:26.04
+            family: apt
+          - name: Debian 13
+            image: debian:13
+            family: apt
+          - name: Fedora 44
+            image: fedora:44
+            family: dnf
+          - name: Alpine 3.23
+            image: alpine:3.23
+            family: apk
+          - name: Arch Linux rolling
+            image: archlinux:base
+            family: pacman
+    steps:
+      - uses: actions/checkout@v7
+      - name: Validate distro runtime and MCP bridge
+        run: sh scripts/ci/run-linux-distro-container-e2e.sh "${{ matrix.image }}" "${{ matrix.family }}"
+
+  termux-docker:
+    name: Official Termux Docker full E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v7
+      - name: Validate full Termux bootstrap, TUI, launcher, Guardian and MCP bridge
+        env:
+          TERMUX_DOCKER_IMAGE: termux/termux-docker:x86_64
+          DEVBOX_E2E_PORT: 18182
+        run: sh scripts/ci/run-termux-docker-e2e.sh

--- a/docs/HOST_COMPATIBILITY.md
+++ b/docs/HOST_COMPATIBILITY.md
@@ -66,3 +66,21 @@ DEVBOX_RUNTIME_MODE=host node bin/devbox.js start
 curl --fail http://127.0.0.1:8100/healthz
 node bin/devbox.js stop
 ```
+
+
+## Runtime E2E CI
+
+The `Platform runtime E2E` workflow validates the real host-mode MCP runtime, not only compilation. It runs the launcher, negotiates MCP over Streamable HTTP, verifies the tool registry, exercises read-only and mutating shell execution, text and exact-byte file round-trips, recursive listing/search, `host_exec`, `host_run_program`, and a Guardian health probe.
+
+Current native/container coverage:
+
+- macOS 15 Apple Silicon (`macos-15`)
+- macOS 15 Intel (`macos-15-intel`)
+- Ubuntu 26.04 LTS
+- Debian 13
+- Fedora 44
+- Alpine 3.23
+- Arch Linux rolling
+- official `termux/termux-docker:x86_64`
+
+The Linux distribution jobs run inside their upstream container images on a GitHub Ubuntu runner. The macOS jobs run directly on GitHub-hosted macOS machines.

--- a/docs/TERMUX.md
+++ b/docs/TERMUX.md
@@ -67,3 +67,10 @@ ENABLE_HOST_EXEC=true
 - Host mode runs with Termux app permissions and is not a container sandbox.
 - Shared Android storage requires the relevant Android permission and `termux-setup-storage`.
 - Public OAuth deployments still require `PUBLIC_BASE_URL` and the appropriate authentication variables.
+
+
+## Full Termux Docker CI validation
+
+The `Platform runtime E2E` workflow uses the official `termux/termux-docker:x86_64` userspace image. Inside that Termux environment CI installs the current Termux packages required by Devbox, builds and tests the Rust bootstrap natively, builds the C++ TUI natively, runs `devbox-setup` to perform the actual npm setup and launcher startup, connects through MCP, exercises the Devbox and host bridges, runs Guardian's read-only health check, checks launcher status, and shuts the service down cleanly.
+
+This is materially stronger than Android cross-compilation. It still does not replace an Android emulator/device test because `termux-docker` cannot reproduce every Android framework or system-library behavior.

--- a/scripts/ci/platform-runtime-e2e.mjs
+++ b/scripts/ci/platform-runtime-e2e.mjs
@@ -30,10 +30,28 @@ const requireSuccess = (name, result) => {
   return result.structuredContent;
 };
 
+const waitForHealth = async (baseUrl, timeoutMs = 20000) => {
+  const healthUrl = new URL("/healthz", baseUrl).toString();
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(healthUrl);
+      if (response.ok) return healthUrl;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Runtime did not become healthy at ${healthUrl}: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+};
+
 const transport = new StreamableHTTPClientTransport(new URL(url));
 const client = new Client({ name: "platform-runtime-e2e", version: "1.0.0" });
 
 try {
+  await waitForHealth(url);
   await client.connect(transport);
 
   const listed = await client.listTools();

--- a/scripts/ci/platform-runtime-e2e.mjs
+++ b/scripts/ci/platform-runtime-e2e.mjs
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const args = process.argv.slice(2);
+const option = (name, fallback = "") => {
+  const index = args.indexOf(name);
+  return index >= 0 && index + 1 < args.length ? args[index + 1] : fallback;
+};
+
+const url = option("--url", process.env.DEVBOX_E2E_URL || "http://127.0.0.1:18180/");
+const workspace = path.resolve(option("--workspace", process.env.DEVBOX_E2E_WORKSPACE || process.cwd()));
+const expectedPlatform = option("--expect-platform", process.env.DEVBOX_E2E_EXPECT_PLATFORM || "");
+const marker = `DEVBOX_PLATFORM_E2E_${randomUUID().replaceAll("-", "")}`;
+const testDir = path.join(workspace, ".platform-e2e");
+const textFile = path.join(testDir, "bridge.txt");
+const execFile = path.join(testDir, "exec.txt");
+const largeFile = path.join(testDir, "large.bin");
+
+const shellQuote = (value) => `'${String(value).replaceAll("'", `'"'"'`)}'`;
+const requireSuccess = (name, result) => {
+  assert.equal(
+    result?.structuredContent?.ok,
+    true,
+    `${name} failed:\n${JSON.stringify(result, null, 2)}`,
+  );
+  return result.structuredContent;
+};
+
+const transport = new StreamableHTTPClientTransport(new URL(url));
+const client = new Client({ name: "platform-runtime-e2e", version: "1.0.0" });
+
+try {
+  await client.connect(transport);
+
+  const listed = await client.listTools();
+  const toolNames = new Set((listed.tools || []).map((tool) => tool.name));
+  const requiredTools = [
+    "devbox_status",
+    "devbox_exec_readonly",
+    "devbox_exec",
+    "devbox_list_files",
+    "devbox_read_file",
+    "devbox_write_file",
+    "devbox_read_large_file",
+    "devbox_write_large_file",
+    "devbox_search_files",
+    "host_status",
+    "host_exec",
+    "host_run_program",
+  ];
+  for (const name of requiredTools) {
+    assert.ok(toolNames.has(name), `Expected MCP tool ${name} to be registered.`);
+  }
+
+  const status = requireSuccess("devbox_status", await client.callTool({ name: "devbox_status", arguments: {} }));
+  assert.equal(status.data?.mode, "host");
+  assert.equal(status.data?.status, "ready");
+  if (expectedPlatform) {
+    assert.equal(status.data?.platform, expectedPlatform, `Expected platform ${expectedPlatform}.`);
+  }
+
+  const hostStatus = requireSuccess("host_status", await client.callTool({ name: "host_status", arguments: {} }));
+  assert.equal(hostStatus.data?.enabled, true, "Host execution must be enabled in runtime E2E.");
+  if (expectedPlatform) {
+    assert.equal(hostStatus.data?.platform, expectedPlatform);
+  }
+
+  const readonly = requireSuccess(
+    "devbox_exec_readonly",
+    await client.callTool({
+      name: "devbox_exec_readonly",
+      arguments: {
+        command: "printf '%s' 'DEVBOX_E2E_READONLY_OK'",
+        working_dir: workspace,
+        timeout_seconds: 30,
+      },
+    }),
+  );
+  assert.match(readonly.stdout || "", /DEVBOX_E2E_READONLY_OK/u);
+
+  requireSuccess(
+    "devbox_write_file",
+    await client.callTool({
+      name: "devbox_write_file",
+      arguments: { path: textFile, content: `${marker}\n`, append: false, create_dirs: true },
+    }),
+  );
+
+  const readText = requireSuccess(
+    "devbox_read_file",
+    await client.callTool({ name: "devbox_read_file", arguments: { path: textFile, max_bytes: 65536 } }),
+  );
+  assert.match(readText.stdout || "", new RegExp(marker, "u"));
+
+  const listedFiles = requireSuccess(
+    "devbox_list_files",
+    await client.callTool({
+      name: "devbox_list_files",
+      arguments: { path: testDir, recursive: true, max_depth: 3, max_entries: 100, timeout_seconds: 30 },
+    }),
+  );
+  assert.match(listedFiles.stdout || "", /bridge\.txt/u);
+
+  const searched = requireSuccess(
+    "devbox_search_files",
+    await client.callTool({
+      name: "devbox_search_files",
+      arguments: {
+        pattern: marker,
+        path: testDir,
+        glob: "*",
+        case_sensitive: true,
+        max_matches: 20,
+        max_depth: 3,
+        max_file_bytes: 1048576,
+        timeout_seconds: 30,
+      },
+    }),
+  );
+  assert.match(searched.stdout || "", new RegExp(marker, "u"));
+
+  const largePayload = Buffer.from(`${marker}\n${"0123456789abcdef".repeat(8192)}\n`, "utf8");
+  const largeSha = createHash("sha256").update(largePayload).digest("hex");
+  const largeWrite = requireSuccess(
+    "devbox_write_large_file",
+    await client.callTool({
+      name: "devbox_write_large_file",
+      arguments: {
+        path: largeFile,
+        content_base64: largePayload.toString("base64"),
+        append: false,
+        create_dirs: true,
+        expected_sha256: largeSha,
+      },
+    }),
+  );
+  assert.equal(largeWrite.data?.bytes_written, largePayload.length);
+
+  const largeRead = requireSuccess(
+    "devbox_read_large_file",
+    await client.callTool({
+      name: "devbox_read_large_file",
+      arguments: { path: largeFile, offset_bytes: 0, max_bytes: largePayload.length },
+    }),
+  );
+  assert.equal(largeRead.data?.content_sha256, largeSha);
+  assert.deepEqual(Buffer.from(largeRead.data?.content_base64 || "", "base64"), largePayload);
+
+  requireSuccess(
+    "devbox_exec",
+    await client.callTool({
+      name: "devbox_exec",
+      arguments: {
+        command: `mkdir -p ${shellQuote(testDir)} && printf '%s' '${marker}_EXEC' > ${shellQuote(execFile)}`,
+        working_dir: workspace,
+        timeout_seconds: 30,
+      },
+    }),
+  );
+  const execRead = requireSuccess(
+    "devbox_read_file after devbox_exec",
+    await client.callTool({ name: "devbox_read_file", arguments: { path: execFile, max_bytes: 65536 } }),
+  );
+  assert.match(execRead.stdout || "", new RegExp(`${marker}_EXEC`, "u"));
+
+  const hostExec = requireSuccess(
+    "host_exec",
+    await client.callTool({
+      name: "host_exec",
+      arguments: {
+        command: "printf '%s' 'DEVBOX_E2E_HOST_OK'",
+        working_dir: workspace,
+        timeout_seconds: 30,
+      },
+    }),
+  );
+  assert.match(hostExec.stdout || "", /DEVBOX_E2E_HOST_OK/u);
+
+  const hostProgram = requireSuccess(
+    "host_run_program",
+    await client.callTool({
+      name: "host_run_program",
+      arguments: { program: "node", args: ["--version"], working_dir: workspace, timeout_seconds: 30 },
+    }),
+  );
+  assert.match(hostProgram.stdout || "", /^v\d+/u);
+
+  console.log(JSON.stringify({
+    ok: true,
+    url,
+    workspace,
+    platform: status.data?.platform,
+    shell: hostStatus.data?.shell,
+    toolsVerified: requiredTools.length,
+    marker,
+  }, null, 2));
+} finally {
+  await client.close().catch(() => {});
+}

--- a/scripts/ci/run-linux-distro-container-e2e.sh
+++ b/scripts/ci/run-linux-distro-container-e2e.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+set -eu
+
+IMAGE=${1:?usage: run-linux-distro-container-e2e.sh IMAGE FAMILY}
+FAMILY=${2:?usage: run-linux-distro-container-e2e.sh IMAGE FAMILY}
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+
+case "$FAMILY" in
+  apt)
+    INSTALL='apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs npm git python3 ripgrep curl ca-certificates bash && rm -rf /var/lib/apt/lists/*'
+    ;;
+  dnf)
+    INSTALL='dnf -y install nodejs npm git python3 ripgrep curl ca-certificates bash && dnf clean all'
+    ;;
+  apk)
+    INSTALL='apk add --no-cache nodejs npm git python3 ripgrep curl ca-certificates bash'
+    ;;
+  pacman)
+    INSTALL='pacman -Syu --noconfirm --needed nodejs npm git python ripgrep curl ca-certificates bash'
+    ;;
+  *)
+    echo "Unsupported package family: $FAMILY" >&2
+    exit 2
+    ;;
+esac
+
+echo "Pulling runtime image: $IMAGE"
+docker pull "$IMAGE"
+docker image inspect "$IMAGE" --format 'image={{index .RepoDigests 0}} created={{.Created}}'
+
+docker run --rm \
+  -e DEVBOX_E2E_EXPECT_PLATFORM=linux \
+  -e DEVBOX_E2E_PORT=18180 \
+  -v "$ROOT_DIR:/source:ro" \
+  "$IMAGE" \
+  sh -lc "set -eu
+    $INSTALL
+    rm -rf /tmp/devbox-e2e
+    mkdir -p /tmp/devbox-e2e
+    cp -a /source/. /tmp/devbox-e2e/
+    cd /tmp/devbox-e2e
+    echo '=== distribution ==='
+    cat /etc/os-release || true
+    echo '=== toolchain ==='
+    node --version
+    npm --version
+    git --version
+    DEVBOX_E2E_EXPECT_PLATFORM=linux DEVBOX_E2E_PORT=18180 sh scripts/ci/run-posix-runtime-e2e.sh
+  "

--- a/scripts/ci/run-posix-runtime-e2e.sh
+++ b/scripts/ci/run-posix-runtime-e2e.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+PORT=${DEVBOX_E2E_PORT:-18180}
+EXPECT_PLATFORM=${DEVBOX_E2E_EXPECT_PLATFORM:-}
+WORKSPACE=${DEVBOX_E2E_WORKSPACE:-"$ROOT_DIR/.ci-platform-workspace"}
+HOST_SHELL_VALUE=${HOST_SHELL:-$(command -v bash 2>/dev/null || command -v sh)}
+
+export HOST=127.0.0.1
+export PORT
+export MCP_AUTH_MODE=none
+export PUBLIC_BASE_URL=
+export DEVBOX_RUNTIME_MODE=host
+export HOST_WORKSPACE_PATH="$WORKSPACE"
+export HOST_DEFAULT_WORKDIR="$WORKSPACE"
+export HOST_SHELL="$HOST_SHELL_VALUE"
+export ENABLE_HOST_EXEC=true
+
+cleanup() {
+  node "$ROOT_DIR/bin/devbox.js" stop >/dev/null 2>&1 || true
+  rm -rf "$WORKSPACE"
+}
+trap cleanup EXIT INT TERM
+
+cd "$ROOT_DIR"
+rm -rf "$WORKSPACE"
+mkdir -p "$WORKSPACE"
+node bin/devbox.js stop >/dev/null 2>&1 || true
+
+npm ci
+node bin/devbox.js start
+node scripts/ci/platform-runtime-e2e.mjs \
+  --url "http://127.0.0.1:$PORT/" \
+  --workspace "$WORKSPACE" \
+  --expect-platform "$EXPECT_PLATFORM"
+
+node scripts/devbox-guardian.mjs --once --no-repair
+node bin/devbox.js status

--- a/scripts/ci/run-termux-docker-e2e.sh
+++ b/scripts/ci/run-termux-docker-e2e.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+IMAGE=${TERMUX_DOCKER_IMAGE:-termux/termux-docker:x86_64}
+PORT=${DEVBOX_E2E_PORT:-18182}
+
+printf 'Pulling official Termux userspace image: %s\n' "$IMAGE"
+docker pull "$IMAGE"
+docker image inspect "$IMAGE" --format 'image={{index .RepoDigests 0}} created={{.Created}}'
+
+docker run --rm \
+  -v "$ROOT_DIR:/source:ro" \
+  "$IMAGE" \
+  bash -lc "set -eu
+    echo '=== Termux environment ==='
+    echo PREFIX=\"\$PREFIX\"
+    echo TERMUX_VERSION=\"\${TERMUX_VERSION:-unset}\"
+    uname -a
+    test -n \"\${PREFIX:-}\"
+    case \"\$PREFIX\" in *com.termux/files/usr*) ;; *) echo 'Not a Termux PREFIX' >&2; exit 1 ;; esac
+
+    pkg update -y
+    pkg install -y nodejs git python ripgrep curl ca-certificates rust clang
+
+    echo '=== Termux toolchain ==='
+    node --version
+    npm --version
+    git --version
+    rustc --version
+    clang++ --version | head -n 1
+
+    rm -rf \"\$HOME/devbox-e2e\" \"\$HOME/devbox-e2e-workspace\"
+    mkdir -p \"\$HOME/devbox-e2e\"
+    cp -a /source/. \"\$HOME/devbox-e2e/\"
+    cd \"\$HOME/devbox-e2e\"
+
+    echo '=== Rust bootstrap native Termux tests ==='
+    cargo test --manifest-path bootstrap/Cargo.toml
+    cargo build --release --manifest-path bootstrap/Cargo.toml
+    ./bootstrap/target/release/devbox-setup --version
+
+    echo '=== Native C++ TUI in Termux ==='
+    clang++ -std=c++17 -O2 -DNDEBUG setup-tui/src/main.cpp -o devbox-tui-termux-ci
+    ./devbox-tui-termux-ci --version
+    ./devbox-tui-termux-ci --diagnostics --no-color
+
+    echo '=== Full bootstrap -> launcher -> MCP workflow ==='
+    ./bootstrap/target/release/devbox-setup \
+      --repo . \
+      --runtime host \
+      --skip-system-packages \
+      --no-link \
+      --host 127.0.0.1 \
+      --port $PORT \
+      --workspace \"\$HOME/devbox-e2e-workspace\"
+
+    node scripts/ci/platform-runtime-e2e.mjs \
+      --url http://127.0.0.1:$PORT/ \
+      --workspace \"\$HOME/devbox-e2e-workspace\" \
+      --expect-platform termux
+
+    npm run guardian:check
+    node bin/devbox.js status
+    node bin/devbox.js stop
+  "

--- a/setup-tui/src/main.cpp
+++ b/setup-tui/src/main.cpp
@@ -192,6 +192,14 @@ bool command_available(const std::string& command, const std::string& version_ar
     return !capture_command(shell_quote(command) + " " + version_arg).empty();
 }
 
+bool command_exists(const std::string& command) {
+#ifdef _WIN32
+    return !capture_command("where " + shell_quote(command)).empty();
+#else
+    return !capture_command("command -v " + shell_quote(command)).empty();
+#endif
+}
+
 std::string first_line(std::string value) {
     const auto pos = value.find_first_of("\r\n");
     if (pos != std::string::npos) value.resize(pos);
@@ -204,7 +212,7 @@ ToolStatus probe_tool(const std::string& name, const std::string& command, bool 
 }
 
 std::string package_manager(const PlatformInfo& platform) {
-    if (platform.termux) return command_available("pkg", "--help") ? "pkg" : "not found";
+    if (platform.termux) return command_exists("pkg") ? "pkg" : "not found";
 #ifdef _WIN32
     if (command_available("winget", "--version")) return "winget";
     if (command_available("choco", "--version")) return "chocolatey";
@@ -214,7 +222,7 @@ std::string package_manager(const PlatformInfo& platform) {
     return "not found";
 #else
     for (const auto& item : {"apt-get", "dnf", "yum", "pacman", "zypper", "apk"}) {
-        if (command_available(item, "--help")) return item;
+        if (command_exists(item)) return item;
     }
     return "not found";
 #endif

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -38,6 +38,38 @@ export const buildServerUrl = ({ host = config.host, port = config.port } = {}) 
   return `http://${normalizedHost}:${port}`;
 };
 
+export const waitForServerReady = async ({
+  url = buildServerUrl(),
+  pid = null,
+  timeoutMs = 15000,
+  pollIntervalMs = 100,
+} = {}) => {
+  const healthUrl = `${String(url).replace(/\/$/u, "")}/healthz`;
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    if (pid !== null && !isProcessAlive(pid)) {
+      throw new Error(`Devbox process ${pid} exited before ${healthUrl} became ready.`);
+    }
+
+    try {
+      const response = await fetch(healthUrl);
+      if (response.ok) {
+        return { healthUrl, status: response.status };
+      }
+      lastError = new Error(`health endpoint returned HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  const detail = lastError instanceof Error && lastError.message ? ` Last error: ${lastError.message}` : "";
+  throw new Error(`Timed out after ${timeoutMs} ms waiting for ${healthUrl}.${detail}`);
+};
+
 export const isProcessAlive = (pid) => {
   if (!Number.isInteger(pid) || pid <= 0) {
     return false;
@@ -113,9 +145,33 @@ export const startServerProcess = async (root = projectRoot) => {
   await writeFile(paths.pidFile, `${child.pid}\n`, "utf8");
   await logHandle.close();
 
+  const spawnedStatus = await getServerStatus(root);
+  try {
+    await waitForServerReady({ url: spawnedStatus.url, pid: child.pid });
+  } catch (error) {
+    let logTail = "";
+    try {
+      const logText = await readFile(paths.logFile, "utf8");
+      logTail = logText.slice(-8000).trim();
+    } catch {
+      // The log may not have been created yet.
+    }
+    if (isProcessAlive(child.pid)) {
+      try {
+        process.kill(child.pid, "SIGTERM");
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+    await rm(paths.pidFile, { force: true });
+    const suffix = logTail ? `\nRecent ${paths.logFile}:\n${logTail}` : "";
+    throw new Error(`${error instanceof Error ? error.message : String(error)}${suffix}`);
+  }
+
   return {
     ...(await getServerStatus(root)),
     started: true,
+    ready: true,
   };
 };
 

--- a/src/platform.js
+++ b/src/platform.js
@@ -6,9 +6,13 @@ export const detectPlatform = (env = process.env, processPlatform = process.plat
   const isWindows = processPlatform === "win32";
   const isMacOS = processPlatform === "darwin";
   const isLinux = processPlatform === "linux";
-  const isTermux = isLinux && Boolean(env.TERMUX_VERSION || prefix.includes("com.termux/files/usr"));
-  const id = isTermux ? "termux" : isWindows ? "windows" : isMacOS ? "macos" : isLinux ? "linux" : processPlatform || "unknown";
-  const displayName = isTermux ? "Termux" : isWindows ? "Windows" : isMacOS ? "macOS" : isLinux ? "Linux" : processPlatform || "Unknown";
+  const isAndroid = processPlatform === "android";
+  // Node.js built for Termux reports process.platform === "android", while some
+  // emulated/test environments report "linux". PREFIX/TERMUX_VERSION are the
+  // authoritative Termux signals, so accept either POSIX platform value.
+  const isTermux = (isLinux || isAndroid) && Boolean(env.TERMUX_VERSION || prefix.includes("com.termux/files/usr"));
+  const id = isTermux ? "termux" : isWindows ? "windows" : isMacOS ? "macos" : isLinux ? "linux" : isAndroid ? "android" : processPlatform || "unknown";
+  const displayName = isTermux ? "Termux" : isWindows ? "Windows" : isMacOS ? "macOS" : isLinux ? "Linux" : isAndroid ? "Android" : processPlatform || "Unknown";
 
   return {
     id,
@@ -17,6 +21,7 @@ export const detectPlatform = (env = process.env, processPlatform = process.plat
     isWindows,
     isMacOS,
     isLinux,
+    isAndroid,
     nodePlatform: processPlatform,
   };
 };

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -3,8 +3,9 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
 
-import { buildServerUrl, getLauncherPaths, getServerStatus, parseLauncherArgs, stopServerProcess } from "../src/launcher.js";
+import { buildServerUrl, getLauncherPaths, getServerStatus, parseLauncherArgs, stopServerProcess, waitForServerReady } from "../src/launcher.js";
 
 test("parseLauncherArgs defaults to background start and supports explicit commands", () => {
   assert.deepEqual(parseLauncherArgs([]), { command: "start", background: true });
@@ -26,6 +27,30 @@ test("buildServerUrl normalizes wildcard hosts to loopback", () => {
   assert.equal(buildServerUrl({ host: "0.0.0.0", port: 8100 }), "http://127.0.0.1:8100");
   assert.equal(buildServerUrl({ host: "::", port: 8100 }), "http://127.0.0.1:8100");
   assert.equal(buildServerUrl({ host: "localhost", port: 8100 }), "http://localhost:8100");
+});
+
+test("waitForServerReady waits until the health endpoint is actually ready", async () => {
+  let ready = false;
+  const server = createServer((_request, response) => {
+    response.statusCode = ready ? 200 : 503;
+    response.end(ready ? "ok" : "starting");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.equal(typeof address, "object");
+  setTimeout(() => { ready = true; }, 80);
+
+  try {
+    const result = await waitForServerReady({
+      url: `http://127.0.0.1:${address.port}`,
+      timeoutMs: 2000,
+      pollIntervalMs: 20,
+    });
+    assert.equal(result.status, 200);
+    assert.match(result.healthUrl, /\/healthz$/u);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
 });
 
 test("status is read-only while stop records intentional-stop state", async () => {

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -49,6 +49,15 @@ test("Termux detection is a Linux subtype, never Windows", () => {
   assert.equal(platform.isWindows, false);
 });
 
+test("Termux detection accepts Node Android platform builds", () => {
+  const platform = detectPlatform({ PREFIX: "/data/data/com.termux/files/usr" }, "android");
+  assert.equal(platform.id, "termux");
+  assert.equal(platform.displayName, "Termux");
+  assert.equal(platform.isTermux, true);
+  assert.equal(platform.isAndroid, true);
+  assert.equal(platform.isWindows, false);
+});
+
 test("buildHostShellArgs supports PowerShell, cmd, and POSIX shells", () => {
   assert.deepEqual(
     buildHostShellArgs("powershell.exe", "Write-Output ok", detectPlatform({}, "win32")).slice(-2),


### PR DESCRIPTION
Adds real runtime validation for the official Termux Docker userspace, native macOS Intel/Apple Silicon runners, and current Ubuntu/Debian/Fedora/Alpine/Arch containers. The shared probe starts/attaches to the real MCP service and exercises tool registration, shell execution, file/list/search/large-file bridges, host_exec, host_run_program, launcher status, and Guardian health.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated end-to-end validation for platform runtime functionality across macOS, Linux distributions, and Termux environments.
  - Added coverage for tool availability, platform status, command execution, file operations, host execution, and service health checks.
  - Added full Termux workflow validation, including setup, native builds, MCP connectivity, launcher status, and clean shutdown.

- **Documentation**
  - Documented supported runtime environments and validation coverage.
  - Clarified that Termux Docker testing complements, but does not replace, Android device or emulator testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->