### PR TITLE
Add cross-platform Cloudflare Tunnel setup guidance

### DIFF
--- a/.github/workflows/bootstrap-binaries.yml
+++ b/.github/workflows/bootstrap-binaries.yml
@@ -33,24 +33,28 @@ jobs:
             rust_output: devbox-setup-linux-x86_64
             tui_binary: setup-tui/build/devbox-tui
             tui_output: devbox-tui-linux-x86_64
+            cloudflare_hint: pkg.cloudflare.com/cloudflare-main.gpg
           - os: windows-latest
             artifact: devbox-setup-windows-x86_64
             rust_binary: bootstrap/target/release/devbox-setup.exe
             rust_output: devbox-setup-windows-x86_64.exe
             tui_binary: setup-tui/build/Release/devbox-tui.exe
             tui_output: devbox-tui-windows-x86_64.exe
+            cloudflare_hint: winget install --id Cloudflare.cloudflared --exact
           - os: macos-15-intel
             artifact: devbox-setup-macos-x86_64
             rust_binary: bootstrap/target/release/devbox-setup
             rust_output: devbox-setup-macos-x86_64
             tui_binary: setup-tui/build/devbox-tui
             tui_output: devbox-tui-macos-x86_64
+            cloudflare_hint: brew install cloudflared
           - os: macos-15
             artifact: devbox-setup-macos-aarch64
             rust_binary: bootstrap/target/release/devbox-setup
             rust_output: devbox-setup-macos-aarch64
             tui_binary: setup-tui/build/devbox-tui
             tui_output: devbox-tui-macos-aarch64
+            cloudflare_hint: brew install cloudflared
 
     runs-on: ${{ matrix.os }}
 
@@ -80,6 +84,8 @@ jobs:
           "./${{ matrix.rust_output }}" --version
           "./${{ matrix.tui_output }}" --version
           "./${{ matrix.tui_output }}" --diagnostics --no-color
+          "./${{ matrix.tui_output }}" --cloudflare-help --no-color | tee cloudflare-help.txt
+          grep -F "${{ matrix.cloudflare_hint }}" cloudflare-help.txt
       - name: Upload binaries
         uses: actions/upload-artifact@v7
         with:
@@ -111,6 +117,8 @@ jobs:
           ./devbox-setup-linux-aarch64 --version
           ./devbox-tui-linux-aarch64 --version
           ./devbox-tui-linux-aarch64 --diagnostics --no-color
+          ./devbox-tui-linux-aarch64 --cloudflare-help --no-color | tee cloudflare-help-arm64.txt
+          grep -F "pkg.cloudflare.com/cloudflare-main.gpg" cloudflare-help-arm64.txt
       - name: Upload ARM64 binaries
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Typical local connector settings:
 - **MCP Server URL**: `http://127.0.0.1:8100/mcp`
 - **Authentication**: server modes are `none`, `demo-oauth`, or `cloudflare-access`; the setup TUI/CLI presents these as `none`, `oauth`, and `cloudflare`.
 
-Authentication and transport are separate. Selecting `oauth` or `cloudflare` configures MCP authentication and requires a public HTTPS base URL; it does not require Cloudflare Tunnel specifically. `cloudflared` is shown as an optional setup preflight tool when you want Cloudflare Tunnel transport.
+Authentication and transport are separate. Selecting `oauth` or `cloudflare` configures MCP authentication and requires a public HTTPS base URL; it does not require Cloudflare Tunnel specifically. `cloudflared` is shown as an optional setup preflight tool when you want Cloudflare Tunnel transport. For platform-specific installation, persistence, and troubleshooting on Windows, Linux, macOS, and Termux, see [Cloudflare Tunnel setup](./docs/CLOUDFLARE_TUNNEL.md) or run `devbox-tui --cloudflare-help`.
 
 For commands likely to exceed the connector request lifetime, use the persistent async job tools instead of holding one MCP request open:
 

--- a/bootstrap/Cargo.lock
+++ b/bootstrap/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "devbox-setup"
-version = "0.4.0"
+version = "0.4.1"

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devbox-setup"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.74"
 description = "Cross-platform bootstrap installer for Devbox MCP"

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,6 +1,6 @@
 # Devbox setup binary
 
-`devbox-setup` v0.4 is the automation-friendly Rust bootstrap for Devbox MCP on Windows, Linux, macOS, and Termux/Android. It is also the backend used by the C++ `devbox-tui`, so there is one setup implementation rather than separate interactive and CLI installers.
+`devbox-setup` v0.4.1 is the automation-friendly Rust bootstrap for Devbox MCP on Windows, Linux, macOS, and Termux/Android. It is also the backend used by the C++ `devbox-tui`, so there is one setup implementation rather than separate interactive and CLI installers.
 
 It can configure an existing checkout or clone the official repository, then:
 
@@ -64,5 +64,7 @@ devbox-setup --repo . --auth cloudflare \
 # Automation preview
 devbox-setup --repo . --runtime host --no-start --dry-run
 ```
+
+For Cloudflare Tunnel transport, use `docs/CLOUDFLARE_TUNNEL.md`. If public auth is selected and `cloudflared` is missing, the bootstrap prints the correct installation command for Windows, macOS, Termux, or the detected Linux package manager.
 
 Use `devbox-setup --help` for all options. For interactive setup, keep `devbox-tui` beside this binary and run the TUI instead.

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -464,6 +464,74 @@ fn first_available_command(candidates: &[&str], arguments: &[&str]) -> Option<St
         .map(|candidate| (*candidate).to_string())
 }
 
+fn cloudflared_install_hint_for(platform: PlatformKind, linux_manager: Option<&str>) -> String {
+    match platform {
+        PlatformKind::Windows =>
+            "winget install --id Cloudflare.cloudflared --exact".to_string(),
+        PlatformKind::MacOS => "brew install cloudflared".to_string(),
+        PlatformKind::Termux =>
+            "pkg update && pkg install cloudflared termux-services".to_string(),
+        PlatformKind::Linux => match linux_manager.unwrap_or_default() {
+            "apt-get" => concat!(
+                "sudo mkdir -p --mode=0755 /usr/share/keyrings\n",
+                "curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null\n",
+                "echo \"deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main\" | sudo tee /etc/apt/sources.list.d/cloudflared.list\n",
+                "sudo apt-get update && sudo apt-get install cloudflared"
+            ).to_string(),
+            "dnf" | "yum" => concat!(
+                "curl -fsSL https://pkg.cloudflare.com/cloudflared.repo | sudo tee /etc/yum.repos.d/cloudflared.repo\n",
+                "sudo dnf install cloudflared  # use yum instead of dnf on yum-based systems"
+            ).to_string(),
+            "pacman" => "sudo pacman -Syu cloudflared".to_string(),
+            "apk" => concat!(
+                "Cloudflare does not document an apk repository for cloudflared. ",
+                "Install the matching official Linux binary and put it on PATH; see docs/CLOUDFLARE_TUNNEL.md."
+            ).to_string(),
+            _ => concat!(
+                "Install the matching official cloudflared Linux package/binary and put it on PATH; ",
+                "see docs/CLOUDFLARE_TUNNEL.md."
+            ).to_string(),
+        },
+        PlatformKind::Other =>
+            "See docs/CLOUDFLARE_TUNNEL.md for a supported cloudflared installation path.".to_string(),
+    }
+}
+
+fn cloudflared_install_hint() -> String {
+    let platform = platform_kind();
+    let linux_manager = if platform == PlatformKind::Linux {
+        first_available_command(
+            &["apt-get", "dnf", "yum", "pacman", "zypper", "apk"],
+            &["--version"],
+        )
+        .or_else(|| {
+            first_available_command(
+                &["apt-get", "dnf", "yum", "pacman", "zypper", "apk"],
+                &["--help"],
+            )
+        })
+        .and_then(|value| {
+            Path::new(&value)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+        })
+    } else {
+        None
+    };
+    cloudflared_install_hint_for(platform, linux_manager.as_deref())
+}
+
+fn cloudflare_transport_next_step(platform: PlatformKind) -> &'static str {
+    match platform {
+        PlatformKind::Windows =>
+            "Set CLOUDFLARED_TUNNEL_TOKEN/CLOUDFLARED_PUBLIC_HOSTNAME in .env, then restart Devbox.",
+        PlatformKind::MacOS | PlatformKind::Linux | PlatformKind::Termux =>
+            "Set CLOUDFLARED_TUNNEL_TOKEN/CLOUDFLARED_PUBLIC_HOSTNAME in .env, then run: sh scripts/install-cloudflare-tunnel.sh auto",
+        PlatformKind::Other => "See docs/CLOUDFLARE_TUNNEL.md.",
+    }
+}
+
 fn termux_package_arguments() -> Vec<&'static str> {
     let mut arguments = vec!["install", "-y"];
     arguments.extend_from_slice(TERMUX_PACKAGES);
@@ -1128,9 +1196,17 @@ fn setup(options: Options) -> SetupResult<()> {
     warn_if_docker_unavailable(prepared.runtime);
     if options.auth.is_some_and(|auth| auth != AuthChoice::None) {
         match capture_command("cloudflared", &["--version"], None) {
-            Ok(version) => println!("cloudflared: {version}"),
+            Ok(version) => {
+                println!("cloudflared: {version}");
+                println!(
+                    "Cloudflare Tunnel setup: {}",
+                    cloudflare_transport_next_step(platform_kind())
+                );
+            }
             Err(_) => eprintln!(
-                "note: cloudflared is not installed. Authentication still works behind another HTTPS reverse proxy; install cloudflared only if you want Cloudflare Tunnel transport."
+                "note: cloudflared is not installed. Authentication still works behind another HTTPS reverse proxy.\nIf you want Cloudflare Tunnel transport on this platform, install it with:\n{}\nThen: {}\nFull guide: docs/CLOUDFLARE_TUNNEL.md",
+                cloudflared_install_hint(),
+                cloudflare_transport_next_step(platform_kind()),
             ),
         }
     }
@@ -1331,6 +1407,33 @@ mod tests {
             "cloudflare-access"
         );
         assert!(AuthChoice::parse("invalid").is_err());
+    }
+
+    #[test]
+    fn cloudflared_install_hints_are_platform_specific() {
+        assert!(
+            cloudflared_install_hint_for(PlatformKind::Windows, None).contains("winget install")
+        );
+        assert!(cloudflared_install_hint_for(PlatformKind::MacOS, None)
+            .contains("brew install cloudflared"));
+        assert!(cloudflared_install_hint_for(PlatformKind::Termux, None)
+            .contains("pkg install cloudflared termux-services"));
+        assert!(
+            cloudflared_install_hint_for(PlatformKind::Linux, Some("apt-get"))
+                .contains("pkg.cloudflare.com/cloudflare-main.gpg")
+        );
+        assert!(
+            cloudflared_install_hint_for(PlatformKind::Linux, Some("dnf"))
+                .contains("cloudflared.repo")
+        );
+        assert!(
+            cloudflared_install_hint_for(PlatformKind::Linux, Some("pacman"))
+                .contains("pacman -Syu cloudflared")
+        );
+        assert!(
+            cloudflared_install_hint_for(PlatformKind::Linux, Some("apk"))
+                .contains("does not document an apk repository")
+        );
     }
 
     #[test]

--- a/docs/CLOUDFLARE_TUNNEL.md
+++ b/docs/CLOUDFLARE_TUNNEL.md
@@ -1,0 +1,296 @@
+# Cloudflare Tunnel setup
+
+Devbox authentication and Cloudflare Tunnel are separate layers:
+
+- **Authentication** decides who may call the MCP server (`none`, the built-in connector/test OAuth flow, or Cloudflare Access).
+- **Cloudflare Tunnel** is an optional transport that publishes the local Devbox origin without opening an inbound port.
+
+For a public deployment, Cloudflare Access plus Cloudflare Tunnel is the recommended Cloudflare-backed combination. The built-in `oauth` option is useful for connector/protocol testing but does **not** perform an external human identity check.
+
+## Recommended layout
+
+```text
+ChatGPT / MCP client
+        |
+        v
+https://mcp.example.com
+        |
+Cloudflare Access (optional identity policy)
+        |
+Cloudflare Tunnel
+        |
+http://127.0.0.1:8100
+        |
+Devbox MCP
+```
+
+The commands below assume Devbox listens on `127.0.0.1:8100`. Change the port if your `.env` uses a different `PORT`.
+
+## 1. Create the tunnel in Cloudflare
+
+The simplest Devbox setup is a **remotely-managed tunnel** created in the Cloudflare Zero Trust dashboard.
+
+1. Put your domain on Cloudflare.
+2. Open **Cloudflare Zero Trust -> Networks -> Tunnels**.
+3. Create a Cloudflared tunnel.
+4. Add a **Public Hostname**, for example `mcp.example.com`.
+5. Set its service/origin to `http://127.0.0.1:8100`.
+6. Copy the tunnel token Cloudflare shows for the connector.
+7. Add these values to Devbox `.env`:
+
+```env
+CLOUDFLARED_TUNNEL_TOKEN=<secret tunnel token>
+CLOUDFLARED_PUBLIC_HOSTNAME=mcp.example.com
+PUBLIC_BASE_URL=https://mcp.example.com
+```
+
+Never commit the tunnel token. Devbox copies it to `run/host-cloudflared.tunnel-token.txt` with user-only permissions when installing a persistent POSIX service.
+
+If you selected Cloudflare Access authentication in the TUI, also configure:
+
+```env
+MCP_AUTH_MODE=cloudflare-access
+CLOUDFLARE_ACCESS_TEAM_DOMAIN=https://<team>.cloudflareaccess.com
+CLOUDFLARE_ACCESS_AUD=<Access application AUD>
+CLOUDFLARE_ACCESS_JWKS_URL=https://<team>.cloudflareaccess.com/cdn-cgi/access/certs
+```
+
+## 2. Install cloudflared
+
+### Windows
+
+```powershell
+winget install --id Cloudflare.cloudflared --exact
+cloudflared --version
+```
+
+Windows Devbox host mode can launch the configured named tunnel itself when `CLOUDFLARED_TUNNEL_TOKEN` and `CLOUDFLARED_PUBLIC_HOSTNAME` are set. Restart Devbox after editing `.env`.
+
+Windows installations of `cloudflared` do not self-update; use `winget upgrade --id Cloudflare.cloudflared --exact` periodically.
+
+### macOS
+
+```bash
+brew install cloudflared
+cloudflared --version
+```
+
+Then from the Devbox checkout:
+
+```bash
+sh scripts/install-cloudflare-tunnel.sh auto
+```
+
+Devbox installs a per-user LaunchAgent named `com.adybag14.devbox.cloudflared`. Inspect it with:
+
+```bash
+launchctl print "gui/$(id -u)/com.adybag14.devbox.cloudflared"
+tail -n 100 run/cloudflared-launchd.stderr.log
+```
+
+### Ubuntu / Debian
+
+Add Cloudflare's package repository and install the package:
+
+```bash
+sudo mkdir -p --mode=0755 /usr/share/keyrings
+curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+sudo apt-get update
+sudo apt-get install cloudflared
+```
+
+Then install the Devbox user service:
+
+```bash
+sh scripts/install-cloudflare-tunnel.sh auto
+systemctl --user status devbox-cloudflared.service
+```
+
+Logs:
+
+```bash
+journalctl --user -u devbox-cloudflared.service -n 100 --no-pager
+```
+
+### Fedora / RHEL / yum-based Linux
+
+```bash
+curl -fsSL https://pkg.cloudflare.com/cloudflared.repo | sudo tee /etc/yum.repos.d/cloudflared.repo
+sudo dnf install cloudflared
+# On older yum-based distributions: sudo yum install cloudflared
+```
+
+Then:
+
+```bash
+sh scripts/install-cloudflare-tunnel.sh auto
+systemctl --user status devbox-cloudflared.service
+```
+
+### Arch Linux
+
+```bash
+sudo pacman -Syu cloudflared
+sh scripts/install-cloudflare-tunnel.sh auto
+systemctl --user status devbox-cloudflared.service
+```
+
+### openSUSE and other Linux distributions
+
+Cloudflare's current package-repository instructions explicitly cover apt/yum families and Arch. On openSUSE or another distribution without a documented Cloudflare repository, install the matching official Linux binary from Cloudflare's downloads page and place it on `PATH`. Then run:
+
+```bash
+cloudflared --version
+sh scripts/install-cloudflare-tunnel.sh auto
+```
+
+If your system does not run a user systemd session, use `foreground` mode and supervise it with the distribution's normal service manager.
+
+### Alpine Linux
+
+Cloudflare's current installation documentation does not provide an Alpine `apk` repository. Download the matching Linux `cloudflared` binary from Cloudflare's official downloads page, mark it executable, and put it on `PATH`, for example `/usr/local/bin/cloudflared`. Then run:
+
+```bash
+cloudflared --version
+sh scripts/install-cloudflare-tunnel.sh auto
+```
+
+If the environment does not have a usable user systemd session, run:
+
+```bash
+sh scripts/install-cloudflare-tunnel.sh foreground
+```
+
+and supervise that command with the service manager used by your Alpine installation.
+
+### Termux / Android
+
+Install both the tunnel daemon and Termux's runit service integration:
+
+```bash
+pkg update
+pkg install cloudflared termux-services
+```
+
+After installing `termux-services`, **close and reopen Termux** so its runit supervision environment starts. Then, from the Devbox checkout:
+
+```bash
+sh scripts/install-cloudflare-tunnel.sh termux
+sv status devbox-cloudflared
+```
+
+The service definition is stored under:
+
+```text
+$PREFIX/var/service/devbox-cloudflared/
+```
+
+Useful recovery commands:
+
+```bash
+sv restart devbox-cloudflared
+sv status devbox-cloudflared
+```
+
+For startup after an Android reboot, also install/configure Termux:Boot as described in `docs/TERMUX.md`; Devbox Guardian and the runit-managed tunnel can then be restored when the Termux environment starts.
+
+## 3. Check the tunnel
+
+First verify Devbox locally:
+
+```bash
+curl -f http://127.0.0.1:8100/healthz
+```
+
+Then verify DNS/public routing:
+
+```bash
+curl -i https://mcp.example.com/healthz
+```
+
+If Cloudflare Access protects the hostname, an unauthenticated public `curl` may receive an Access login/authorization response instead of the origin response. That is not the same as the tunnel being down.
+
+The Cloudflare Tunnel metrics endpoint used by Devbox Guardian defaults to:
+
+```text
+http://127.0.0.1:20241/metrics
+```
+
+`devbox_status` surfaces HA connection count, tunnel request errors, total requests, and QUIC closed-connection information when that endpoint is reachable.
+
+## Common errors
+
+### `cloudflared: command not found`
+
+Install `cloudflared` using the platform section above. You can also run:
+
+```bash
+devbox-tui --cloudflare-help
+```
+
+for a platform-specific install hint.
+
+### `CLOUDFLARED_TUNNEL_TOKEN is missing`
+
+Copy the connector token from **Zero Trust -> Networks -> Tunnels -> your tunnel** and place it in `.env`. Do not commit it.
+
+### Public hostname is missing
+
+Set both:
+
+```env
+CLOUDFLARED_PUBLIC_HOSTNAME=mcp.example.com
+PUBLIC_BASE_URL=https://mcp.example.com
+```
+
+and ensure the public-hostname route in Cloudflare points to `http://127.0.0.1:8100` (or your configured Devbox port).
+
+### Tunnel runs but the hostname returns `502 Bad Gateway`
+
+Check the origin first:
+
+```bash
+curl -f http://127.0.0.1:8100/healthz
+```
+
+If that fails, Devbox itself is not ready. Run `devbox status` and inspect `run/devbox.log`.
+
+If local health succeeds, inspect the tunnel service/logs and confirm the Cloudflare public-hostname origin uses the same port as Devbox.
+
+### Linux: `systemctl --user` fails
+
+Some containers/minimal distros do not provide a user systemd session. Use:
+
+```bash
+sh scripts/install-cloudflare-tunnel.sh foreground
+```
+
+and supervise it with the platform's normal process manager, or install/configure a user systemd session.
+
+### Termux: `sv: command not found` or service will not start
+
+```bash
+pkg install termux-services
+```
+
+Then close and reopen Termux before running the installer again. `termux-services` needs its runit supervision environment active.
+
+### macOS: LaunchAgent fails to load
+
+```bash
+plutil -lint ~/Library/LaunchAgents/com.adybag14.devbox.cloudflared.plist
+launchctl print "gui/$(id -u)/com.adybag14.devbox.cloudflared"
+tail -n 100 run/cloudflared-launchd.stderr.log
+```
+
+## Advanced: locally-managed tunnels
+
+Cloudflare also supports locally-managed tunnels created with `cloudflared tunnel login`, `cloudflared tunnel create`, a credentials JSON file, and a local `config.yml`. Devbox's helper above intentionally uses the dashboard/token flow because it is easier to reproduce across Windows, Linux, macOS, and Termux. If you prefer local management, follow Cloudflare's locally-managed tunnel documentation and point the ingress service at the Devbox loopback URL.
+
+## Official Cloudflare references
+
+- Cloudflare Tunnel downloads: <https://developers.cloudflare.com/tunnel/downloads/>
+- Create a locally-managed tunnel: <https://developers.cloudflare.com/tunnel/advanced/local-management/create-local-tunnel/>
+- Run as a Linux service: <https://developers.cloudflare.com/tunnel/advanced/local-management/as-a-service/linux/>
+- Run as a macOS service: <https://developers.cloudflare.com/tunnel/advanced/local-management/as-a-service/macos/>

--- a/docs/HOST_COMPATIBILITY.md
+++ b/docs/HOST_COMPATIBILITY.md
@@ -1,5 +1,7 @@
 # Host Compatibility
 
+For public deployments, `devbox-tui --cloudflare-help` prints platform-specific Cloudflare Tunnel installation/setup guidance; the complete guide is [CLOUDFLARE_TUNNEL.md](./CLOUDFLARE_TUNNEL.md).
+
 Devbox host mode is supported on Windows, Linux, macOS, and Termux/Android. Docker remains optional where available.
 
 ## Native setup binaries

--- a/docs/TERMUX.md
+++ b/docs/TERMUX.md
@@ -66,7 +66,7 @@ ENABLE_HOST_EXEC=true
 - Use `HOST=127.0.0.1` for loopback-only access.
 - Host mode runs with Termux app permissions and is not a container sandbox.
 - Shared Android storage requires the relevant Android permission and `termux-setup-storage`.
-- The TUI supports `none`, `oauth`, and `cloudflare` authentication on Termux. Public OAuth deployments require `PUBLIC_BASE_URL`; Cloudflare Access additionally requires the team domain and audience. Authentication is independent of the tunnel provider.
+- The TUI supports `none`, `oauth`, and `cloudflare` authentication on Termux. Public OAuth deployments require `PUBLIC_BASE_URL`; Cloudflare Access additionally requires the team domain and audience. Authentication is independent of the tunnel provider. To publish Devbox through Cloudflare Tunnel, install `cloudflared` plus `termux-services` and follow [Cloudflare Tunnel setup](./CLOUDFLARE_TUNNEL.md); `sh scripts/install-cloudflare-tunnel.sh termux` installs the persistent runit service.
 
 
 ## Full Termux Docker CI validation

--- a/scripts/ci/run-posix-runtime-e2e.sh
+++ b/scripts/ci/run-posix-runtime-e2e.sh
@@ -24,6 +24,8 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 cd "$ROOT_DIR"
+sh -n scripts/install-cloudflare-tunnel.sh
+sh scripts/ci/test-cloudflare-tunnel-errors.sh
 rm -rf "$WORKSPACE"
 mkdir -p "$WORKSPACE"
 node bin/devbox.js stop >/dev/null 2>&1 || true

--- a/scripts/ci/run-termux-docker-e2e.sh
+++ b/scripts/ci/run-termux-docker-e2e.sh
@@ -44,6 +44,10 @@ docker run --rm \
     clang++ -std=c++17 -O2 -DNDEBUG setup-tui/src/main.cpp -o devbox-tui-termux-ci
     ./devbox-tui-termux-ci --version
     ./devbox-tui-termux-ci --diagnostics --no-color
+    ./devbox-tui-termux-ci --cloudflare-help --no-color | tee cloudflare-help-termux.txt
+    grep -F 'pkg update && pkg install cloudflared termux-services' cloudflare-help-termux.txt
+    sh -n scripts/install-cloudflare-tunnel.sh
+    sh scripts/ci/test-cloudflare-tunnel-errors.sh
 
     echo '=== Full bootstrap -> launcher -> MCP workflow ==='
     ./bootstrap/target/release/devbox-setup \

--- a/scripts/ci/test-cloudflare-tunnel-errors.sh
+++ b/scripts/ci/test-cloudflare-tunnel-errors.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+: > "$TMP_DIR/empty.env"
+
+cat > "$TMP_DIR/cloudflared" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+chmod +x "$TMP_DIR/cloudflared"
+
+set +e
+CLOUDFLARED_TUNNEL_TOKEN= CLOUDFLARED_PUBLIC_HOSTNAME= PUBLIC_BASE_URL= \
+  PATH="$TMP_DIR:/usr/bin:/bin" DEVBOX_ENV_FILE="$TMP_DIR/empty.env" \
+  sh "$ROOT_DIR/scripts/install-cloudflare-tunnel.sh" foreground >"$TMP_DIR/token.out" 2>&1
+code=$?
+set -e
+[ "$code" -eq 2 ]
+grep -F "CLOUDFLARED_TUNNEL_TOKEN is missing" "$TMP_DIR/token.out" >/dev/null
+
+after_path="/usr/bin:/bin"
+set +e
+TERMUX_VERSION=ci PREFIX=/data/data/com.termux/files/usr CLOUDFLARED_TUNNEL_TOKEN= \
+  PATH="$after_path" DEVBOX_ENV_FILE="$TMP_DIR/empty.env" \
+  sh "$ROOT_DIR/scripts/install-cloudflare-tunnel.sh" auto >"$TMP_DIR/termux.out" 2>&1
+code=$?
+set -e
+[ "$code" -eq 2 ]
+grep -F "pkg install cloudflared termux-services" "$TMP_DIR/termux.out" >/dev/null
+
+printf 'Cloudflare tunnel error guidance checks passed.\n'

--- a/scripts/install-cloudflare-tunnel.sh
+++ b/scripts/install-cloudflare-tunnel.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ENV_FILE=${DEVBOX_ENV_FILE:-"$ROOT_DIR/.env"}
+MODE=${1:-auto}
+RUN_DIR="$ROOT_DIR/run"
+TOKEN_FILE="$RUN_DIR/host-cloudflared.tunnel-token.txt"
+METRICS_URL=${CLOUDFLARED_METRICS_URL:-http://127.0.0.1:20241/metrics}
+DOC_URL="https://github.com/adybag14-cyber/devbox/blob/main/docs/CLOUDFLARE_TUNNEL.md"
+
+log() { printf '%s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 2; }
+
+read_env_value() {
+  key=$1
+  [ -f "$ENV_FILE" ] || return 0
+  value=$(awk -v key="$key" '
+    index($0, key "=") == 1 {
+      value = substr($0, length(key) + 2)
+    }
+    END { print value }
+  ' "$ENV_FILE")
+  case "$value" in
+    \"*\") value=${value#\"}; value=${value%\"} ;;
+    \'*\') value=${value#\'}; value=${value%\'} ;;
+  esac
+  printf '%s' "$value"
+}
+
+is_termux() {
+  [ -n "${TERMUX_VERSION:-}" ] || case "${PREFIX:-}" in *com.termux/files/usr*) return 0 ;; *) return 1 ;; esac
+}
+
+install_hint() {
+  if is_termux; then
+    cat <<'EOF'
+Termux install:
+  pkg update
+  pkg install cloudflared termux-services
+Then close/reopen Termux (or start the termux-services supervision environment) and rerun this script.
+EOF
+    return
+  fi
+  case "$(uname -s 2>/dev/null || true)" in
+    Darwin)
+      cat <<'EOF'
+macOS install:
+  brew install cloudflared
+EOF
+      ;;
+    Linux)
+      if command -v apt-get >/dev/null 2>&1; then
+        cat <<'EOF'
+Debian/Ubuntu install (Cloudflare package repository):
+  sudo mkdir -p --mode=0755 /usr/share/keyrings
+  curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+  echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+  sudo apt-get update && sudo apt-get install cloudflared
+EOF
+      elif command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+        cat <<'EOF'
+Fedora/RHEL install (Cloudflare package repository):
+  curl -fsSL https://pkg.cloudflare.com/cloudflared.repo | sudo tee /etc/yum.repos.d/cloudflared.repo
+  sudo dnf install cloudflared
+# On yum-based systems use: sudo yum install cloudflared
+EOF
+      elif command -v pacman >/dev/null 2>&1; then
+        cat <<'EOF'
+Arch Linux install:
+  sudo pacman -Syu cloudflared
+EOF
+      elif command -v apk >/dev/null 2>&1; then
+        cat <<EOF
+Alpine Linux: Cloudflare does not document an apk repository for cloudflared.
+Install the matching Linux binary from Cloudflare's official downloads page, place it on PATH, then rerun:
+  $DOC_URL
+EOF
+      else
+        cat <<EOF
+Install the matching cloudflared Linux binary/package from Cloudflare's official downloads page, then rerun:
+  $DOC_URL
+EOF
+      fi
+      ;;
+    *) log "See $DOC_URL" ;;
+  esac
+}
+
+if ! command -v cloudflared >/dev/null 2>&1; then
+  printf 'ERROR: cloudflared is not installed or is not on PATH.\n' >&2
+  install_hint >&2
+  exit 2
+fi
+
+TOKEN=${CLOUDFLARED_TUNNEL_TOKEN:-$(read_env_value CLOUDFLARED_TUNNEL_TOKEN)}
+HOSTNAME=${CLOUDFLARED_PUBLIC_HOSTNAME:-$(read_env_value CLOUDFLARED_PUBLIC_HOSTNAME)}
+PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-$(read_env_value PUBLIC_BASE_URL)}
+PORT=${PORT:-$(read_env_value PORT)}
+PORT=${PORT:-8100}
+
+if [ -z "$TOKEN" ]; then
+  cat >&2 <<EOF
+ERROR: CLOUDFLARED_TUNNEL_TOKEN is missing.
+
+Create a remotely-managed tunnel in Cloudflare Zero Trust -> Networks -> Tunnels,
+add a public hostname that points to http://127.0.0.1:$PORT, copy the tunnel token,
+and add it to $ENV_FILE:
+
+  CLOUDFLARED_TUNNEL_TOKEN=<token>
+  CLOUDFLARED_PUBLIC_HOSTNAME=mcp.example.com
+  PUBLIC_BASE_URL=https://mcp.example.com
+
+Do not commit the token. Full guide:
+  $DOC_URL
+EOF
+  exit 2
+fi
+
+if [ -z "$HOSTNAME" ] && [ -z "$PUBLIC_BASE_URL" ]; then
+  cat >&2 <<EOF
+ERROR: the public hostname is missing.
+Set CLOUDFLARED_PUBLIC_HOSTNAME and PUBLIC_BASE_URL in $ENV_FILE after creating the hostname in Cloudflare:
+
+  CLOUDFLARED_PUBLIC_HOSTNAME=mcp.example.com
+  PUBLIC_BASE_URL=https://mcp.example.com
+
+The Cloudflare public hostname must route to http://127.0.0.1:$PORT.
+Guide: $DOC_URL
+EOF
+  exit 2
+fi
+
+mkdir -p "$RUN_DIR"
+umask 077
+printf '%s' "$TOKEN" > "$TOKEN_FILE"
+chmod 600 "$TOKEN_FILE" 2>/dev/null || true
+
+CLOUDFLARED=$(command -v cloudflared)
+METRICS_ADDRESS=${METRICS_URL#http://}
+METRICS_ADDRESS=${METRICS_ADDRESS%%/*}
+
+if [ "$MODE" = auto ]; then
+  if is_termux; then MODE=termux
+  elif [ "$(uname -s)" = Darwin ]; then MODE=launchd
+  elif command -v systemctl >/dev/null 2>&1; then MODE=systemd
+  else MODE=foreground
+  fi
+fi
+
+case "$MODE" in
+  termux)
+    is_termux || fail "termux mode requested outside Termux"
+    if ! command -v sv >/dev/null 2>&1 || ! command -v sv-enable >/dev/null 2>&1; then
+      cat >&2 <<'EOF'
+ERROR: termux-services is required for persistent tunnel supervision.
+Install it with:
+  pkg install termux-services
+Then close and reopen Termux so runit supervision starts, and rerun this command.
+EOF
+      exit 2
+    fi
+    SERVICE_DIR="$PREFIX/var/service/devbox-cloudflared"
+    mkdir -p "$SERVICE_DIR/log"
+    cat > "$SERVICE_DIR/run" <<EOF
+#!/data/data/com.termux/files/usr/bin/sh
+exec "$CLOUDFLARED" tunnel --no-autoupdate --metrics "$METRICS_ADDRESS" run --token-file "$TOKEN_FILE"
+EOF
+    chmod 700 "$SERVICE_DIR/run"
+    if [ -x "$PREFIX/share/termux-services/svlogger" ]; then
+      ln -sf "$PREFIX/share/termux-services/svlogger" "$SERVICE_DIR/log/run"
+    fi
+    sv-enable devbox-cloudflared >/dev/null 2>&1 || true
+    if ! sv up devbox-cloudflared; then
+      cat >&2 <<'EOF'
+ERROR: runit could not start devbox-cloudflared.
+If termux-services was just installed, close/reopen Termux and rerun this script.
+Inspect with:
+  sv status devbox-cloudflared
+  logcat | tail
+EOF
+      exit 2
+    fi
+    log "Cloudflare Tunnel installed as Termux service: devbox-cloudflared"
+    log "Status: sv status devbox-cloudflared"
+    ;;
+
+  systemd)
+    command -v systemctl >/dev/null 2>&1 || fail "systemctl is unavailable; use '$0 foreground' or see $DOC_URL"
+    UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+    UNIT_FILE="$UNIT_DIR/devbox-cloudflared.service"
+    mkdir -p "$UNIT_DIR"
+    cat > "$UNIT_FILE" <<EOF
+[Unit]
+Description=Devbox Cloudflare Tunnel
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart="$CLOUDFLARED" tunnel --no-autoupdate --metrics "$METRICS_ADDRESS" run --token-file "$TOKEN_FILE"
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+    systemctl --user daemon-reload
+    systemctl --user enable --now devbox-cloudflared.service
+    if ! systemctl --user is-active --quiet devbox-cloudflared.service; then
+      cat >&2 <<'EOF'
+ERROR: devbox-cloudflared.service did not become active.
+Inspect it with:
+  systemctl --user status devbox-cloudflared.service
+  journalctl --user -u devbox-cloudflared.service -n 100 --no-pager
+If your distro has no user systemd session, use foreground mode or another service manager.
+EOF
+      exit 2
+    fi
+    log "Cloudflare Tunnel installed as systemd user service: devbox-cloudflared.service"
+    log "Status: systemctl --user status devbox-cloudflared.service"
+    ;;
+
+  launchd)
+    [ "$(uname -s)" = Darwin ] || fail "launchd mode is only available on macOS"
+    LABEL="com.adybag14.devbox.cloudflared"
+    PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+    mkdir -p "$HOME/Library/LaunchAgents" "$RUN_DIR"
+    xml_escape() { printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g'; }
+    CF_XML=$(xml_escape "$CLOUDFLARED")
+    TOKEN_XML=$(xml_escape "$TOKEN_FILE")
+    METRICS_XML=$(xml_escape "$METRICS_ADDRESS")
+    OUT_XML=$(xml_escape "$RUN_DIR/cloudflared-launchd.stdout.log")
+    ERR_XML=$(xml_escape "$RUN_DIR/cloudflared-launchd.stderr.log")
+    cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key><array>
+    <string>$CF_XML</string><string>tunnel</string><string>--no-autoupdate</string>
+    <string>--metrics</string><string>$METRICS_XML</string>
+    <string>run</string><string>--token-file</string><string>$TOKEN_XML</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>$OUT_XML</string>
+  <key>StandardErrorPath</key><string>$ERR_XML</string>
+</dict></plist>
+EOF
+    DOMAIN="gui/$(id -u)"
+    launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+    if ! launchctl bootstrap "$DOMAIN" "$PLIST"; then
+      cat >&2 <<EOF
+ERROR: launchd could not bootstrap $PLIST.
+Inspect the plist with:
+  plutil -lint "$PLIST"
+Then inspect launchd with:
+  launchctl print "$DOMAIN/$LABEL"
+Guide: $DOC_URL
+EOF
+      exit 2
+    fi
+    launchctl enable "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+    launchctl kickstart -k "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+    log "Cloudflare Tunnel installed as macOS LaunchAgent: $LABEL"
+    log "Status: launchctl print '$DOMAIN/$LABEL'"
+    ;;
+
+  foreground)
+    log "Starting cloudflared in the foreground. Press Ctrl-C to stop it."
+    log "For persistent setup see: $DOC_URL"
+    exec "$CLOUDFLARED" tunnel --no-autoupdate --metrics "$METRICS_ADDRESS" run --token-file "$TOKEN_FILE"
+    ;;
+
+  *) fail "unknown mode '$MODE'; expected auto, systemd, launchd, termux, or foreground" ;;
+esac
+
+log "Tunnel token is stored with user-only permissions at: $TOKEN_FILE"
+log "Expected origin: http://127.0.0.1:$PORT"
+[ -n "$PUBLIC_BASE_URL" ] && log "Configured public MCP base URL: $PUBLIC_BASE_URL"
+log "If the hostname does not resolve/reach Devbox, confirm the Cloudflare Tunnel public-hostname route targets http://127.0.0.1:$PORT."
+log "Full troubleshooting guide: $DOC_URL"

--- a/setup-tui/CMakeLists.txt
+++ b/setup-tui/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(devbox_tui VERSION 0.4.0 LANGUAGES CXX)
+project(devbox_tui VERSION 0.4.1 LANGUAGES CXX)
 
 add_executable(devbox-tui src/main.cpp)
 target_compile_features(devbox-tui PRIVATE cxx_std_17)

--- a/setup-tui/README.md
+++ b/setup-tui/README.md
@@ -7,6 +7,7 @@ It provides:
 - platform and architecture detection
 - Node/npm/Git/Docker/PowerShell/cloudflared preflight
 - package-manager visibility
+- platform-specific Cloudflare Tunnel help and recovery instructions
 - repository and runtime selection
 - authentication selection: `none`, `oauth`, or `cloudflare`
 - public base URL prompt for OAuth modes
@@ -36,6 +37,7 @@ Useful noninteractive checks:
 ```bash
 devbox-tui --version
 devbox-tui --diagnostics --no-color
+devbox-tui --cloudflare-help --no-color
 ```
 
 For CI or automation, call `devbox-setup` directly rather than driving the TUI.

--- a/setup-tui/src/main.cpp
+++ b/setup-tui/src/main.cpp
@@ -26,7 +26,7 @@ namespace fs = std::filesystem;
 
 namespace {
 
-constexpr const char* kVersion = "0.4.0";
+constexpr const char* kVersion = "0.4.1";
 constexpr const char* kRepoUrl = "https://github.com/adybag14-cyber/devbox.git";
 
 struct Theme {
@@ -459,6 +459,63 @@ bool has_tool(const std::vector<ToolStatus>& tools, const std::string& name) {
     return it != tools.end() && it->available;
 }
 
+std::string cloudflared_install_hint(const PlatformInfo& platform) {
+    if (platform.termux) return "pkg update && pkg install cloudflared termux-services";
+#ifdef _WIN32
+    return "winget install --id Cloudflare.cloudflared --exact";
+#elif defined(__APPLE__)
+    return "brew install cloudflared";
+#else
+    const std::string manager = package_manager(platform);
+    if (manager == "apt-get") {
+        return "sudo mkdir -p --mode=0755 /usr/share/keyrings\n"
+               "curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null\n"
+               "echo \"deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main\" | sudo tee /etc/apt/sources.list.d/cloudflared.list\n"
+               "sudo apt-get update && sudo apt-get install cloudflared";
+    }
+    if (manager == "dnf" || manager == "yum") {
+        return "curl -fsSL https://pkg.cloudflare.com/cloudflared.repo | sudo tee /etc/yum.repos.d/cloudflared.repo\n"
+               "sudo dnf install cloudflared  # use yum on yum-based systems";
+    }
+    if (manager == "pacman") return "sudo pacman -Syu cloudflared";
+    if (manager == "apk") {
+        return "Alpine: install the matching official cloudflared Linux binary and put it on PATH; see docs/CLOUDFLARE_TUNNEL.md";
+    }
+    return "Install the matching official cloudflared package/binary and put it on PATH; see docs/CLOUDFLARE_TUNNEL.md";
+#endif
+}
+
+void print_cloudflare_help(const Theme& theme, const PlatformInfo& platform) {
+    header(theme, platform);
+    std::cout << theme.paint(theme.bold, "Cloudflare Tunnel transport") << "\n"
+              << "Authentication and tunnel transport are separate. Cloudflare Tunnel publishes the local Devbox origin without opening an inbound port.\n\n"
+              << theme.paint(theme.bold, "Install cloudflared") << "\n"
+              << cloudflared_install_hint(platform) << "\n\n"
+              << theme.paint(theme.bold, "Create the tunnel") << "\n"
+              << "  Cloudflare Zero Trust -> Networks -> Tunnels -> create a Cloudflared tunnel\n"
+              << "  Add a public hostname such as mcp.example.com\n"
+              << "  Route it to http://127.0.0.1:8100 (or your configured Devbox port)\n"
+              << "  Copy the connector tunnel token\n\n"
+              << theme.paint(theme.bold, "Configure Devbox .env") << "\n"
+              << "  CLOUDFLARED_TUNNEL_TOKEN=<secret token>\n"
+              << "  CLOUDFLARED_PUBLIC_HOSTNAME=mcp.example.com\n"
+              << "  PUBLIC_BASE_URL=https://mcp.example.com\n\n";
+#ifdef _WIN32
+    std::cout << "Restart Devbox; Windows host mode starts the configured named tunnel automatically.\n";
+#else
+    if (platform.termux) {
+        std::cout << "Install persistent Termux service:\n"
+                  << "  sh scripts/install-cloudflare-tunnel.sh termux\n"
+                  << "  sv status devbox-cloudflared\n";
+    } else {
+        std::cout << "Install persistent tunnel service:\n"
+                  << "  sh scripts/install-cloudflare-tunnel.sh auto\n";
+    }
+#endif
+    std::cout << "\nFull guide: docs/CLOUDFLARE_TUNNEL.md\n"
+              << "Online: https://github.com/adybag14-cyber/devbox/blob/main/docs/CLOUDFLARE_TUNNEL.md\n";
+}
+
 void print_diagnostics(const Theme& theme, const PlatformInfo& platform) {
     header(theme, platform);
     const auto tools = collect_tools(platform);
@@ -582,6 +639,26 @@ int interactive_setup(const Theme& theme, const PlatformInfo& platform, const st
         config.cloudflare_jwks_url = prompt_text("Cloudflare Access JWKS URL", default_jwks);
     }
 
+    if (config.auth != AuthChoice::None) {
+        std::cout << "\n" << theme.paint(theme.bold, "Public transport check") << "\n";
+        if (!has_tool(tools, "cloudflared")) {
+            std::cout << theme.paint(theme.yellow, "cloudflared is not installed.") << "\n"
+                      << "Authentication can still work behind another HTTPS reverse proxy.\n"
+                      << "For Cloudflare Tunnel transport on this machine, install it with:\n"
+                      << cloudflared_install_hint(platform) << "\n"
+                      << "Then run `devbox-tui --cloudflare-help` or read docs/CLOUDFLARE_TUNNEL.md.\n\n";
+        } else {
+            std::cout << theme.paint(theme.green, "cloudflared is available.") << "\n";
+#ifndef _WIN32
+            std::cout << "After setup, add the tunnel token/hostname to .env and run:\n"
+                      << (platform.termux ? "  sh scripts/install-cloudflare-tunnel.sh termux\n" : "  sh scripts/install-cloudflare-tunnel.sh auto\n")
+                      << "See docs/CLOUDFLARE_TUNNEL.md for the dashboard and troubleshooting steps.\n\n";
+#else
+            std::cout << "Windows host mode can start the token-based named tunnel after the token/hostname are present in .env.\n\n";
+#endif
+        }
+    }
+
     config.host = prompt_text("Bind address", "127.0.0.1");
     config.port = prompt_port(8100);
     const std::string workspace = prompt_text("Workspace (blank uses <repo>/workspace)", "");
@@ -632,6 +709,7 @@ void print_help() {
               << "Usage: devbox-tui [options]\n\n"
               << "  --bootstrap <path>  Explicit devbox-setup binary\n"
               << "  --diagnostics       Print platform/tool diagnostics and exit\n"
+              << "  --cloudflare-help   Print platform-specific Cloudflare Tunnel setup instructions\n"
               << "  --dry-run           Guide through setup but make the Rust bootstrap print its plan only\n"
               << "  --no-color          Disable ANSI color\n"
               << "  -h, --help          Show this help\n"
@@ -647,6 +725,7 @@ int main(int argc, char** argv) {
     const PlatformInfo platform = detect_platform();
     std::optional<std::string> bootstrap;
     bool diagnostics = false;
+    bool cloudflare_help = false;
     bool dry_run = false;
 
     for (int i = 1; i < argc; ++i) {
@@ -659,6 +738,8 @@ int main(int argc, char** argv) {
             bootstrap = argv[++i];
         } else if (arg == "--diagnostics") {
             diagnostics = true;
+        } else if (arg == "--cloudflare-help") {
+            cloudflare_help = true;
         } else if (arg == "--dry-run") {
             dry_run = true;
         } else if (arg == "--no-color") {
@@ -678,6 +759,10 @@ int main(int argc, char** argv) {
 
     if (diagnostics) {
         print_diagnostics(theme, platform);
+        return 0;
+    }
+    if (cloudflare_help) {
+        print_cloudflare_help(theme, platform);
         return 0;
     }
     if (!stdin_is_tty()) {


### PR DESCRIPTION
Adds platform-specific Cloudflare Tunnel setup and troubleshooting for Windows, Linux, macOS, and Termux; a supported POSIX persistence helper for systemd/launchd/runit; actionable Rust/TUI errors and devbox-tui --cloudflare-help; and CI assertions for platform-specific guidance. Bumps the setup bundle to 0.4.1.