### PR TITLE
Harden Devbox startup and tunnel recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,9 @@ HOST_PROGRAM_ALLOWLIST=
 
 # Leave blank to use the current Node executable
 NODE_EXE=
+# Optional lifecycle deadline. Blank = 180s for Windows/host mode and 900s for Docker mode.
+# Set only when unusually slow startup/build preparation needs a different bounded deadline.
+DEVBOX_STARTUP_TIMEOUT_SECONDS=
 # Leave blank to default to <repo>/run/oauth-state.json
 OAUTH_STATE_FILE_PATH=
 
@@ -47,6 +50,8 @@ CLOUDFLARED_CONTAINER_NAME=chatgpt-devbox-cloudflared
 CLOUDFLARED_PUBLIC_HOSTNAME=
 CLOUDFLARED_TUNNEL_TOKEN=
 CLOUDFLARED_METRICS_URL=http://127.0.0.1:20241/metrics
+# Cloudflare Edge address family: auto, 4, or 6. Keep auto unless diagnosing an IP-family path issue.
+CLOUDFLARED_EDGE_IP_VERSION=auto
 CLOUDFLARE_ACCESS_TEAM_DOMAIN=
 CLOUDFLARE_ACCESS_AUD=
 CLOUDFLARE_ACCESS_JWKS_URL=

--- a/.github/workflows/bootstrap-binaries.yml
+++ b/.github/workflows/bootstrap-binaries.yml
@@ -12,6 +12,13 @@ on:
       - "scripts/install-devbox.sh"
       - "scripts/install-termux.sh"
       - "scripts/install-guardian.sh"
+      - "scripts/Start-ChatGptDevboxMcp.ps1"
+      - "scripts/Install-ChatGptDevboxGuardian.ps1"
+      - "scripts/Run-Start-ChatGptDevboxMcp.vbs"
+      - "scripts/ci/test-windows-startup-contract.ps1"
+      - "scripts/devbox-guardian.mjs"
+      - "src/guardian-core.js"
+      - "test/guardian-core.test.js"
       - "docs/TERMUX.md"
       - "docs/HOST_COMPATIBILITY.md"
       - ".github/workflows/bootstrap-binaries.yml"
@@ -68,6 +75,10 @@ jobs:
         run: cargo test --manifest-path bootstrap/Cargo.toml
       - name: Build Rust bootstrap
         run: cargo build --release --manifest-path bootstrap/Cargo.toml
+      - name: Validate Windows startup lifecycle contract
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/ci/test-windows-startup-contract.ps1
       - name: Build C++ setup TUI
         run: |
           cmake -S setup-tui -B setup-tui/build -DCMAKE_BUILD_TYPE=Release

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Guardian v2 monitors the MCP process, local and public health endpoints, the sel
 ./scripts/install-guardian.sh auto
 ```
 
-Docker mode includes stale-container start/replace repair plus exponential backoff and a persistent circuit breaker after repeated Docker Desktop failures. See [docs/GUARDIAN.md](./docs/GUARDIAN.md) for readiness fields, status commands, and service-manager setup.
+Docker mode includes stale-container start/replace repair plus exponential backoff and a persistent circuit breaker after repeated Docker Desktop failures. Windows/host startup also has single-owner lifecycle locking, a bounded startup deadline, immediate MCP PID ownership, cleanup-on-failure, and a machine-readable `run/startup-state.json` phase journal that Guardian uses to avoid racing an in-progress start. See [docs/GUARDIAN.md](./docs/GUARDIAN.md) for readiness fields, status commands, and service-manager setup.
 
 ## ChatGPT connector values
 
@@ -286,7 +286,8 @@ Authentication and transport are separate. Selecting `oauth` or `cloudflare` con
 
 For commands likely to exceed the connector request lifetime, use the persistent async job tools instead of holding one MCP request open:
 
-- `devbox_exec_start` starts a detached job and returns a job ID immediately.
+- Synchronous shell tools are intentionally capped at **90 seconds** because upstream MCP/connector requests can be aborted around the two-minute mark. Do not use a long synchronous timeout for builds, exports, sleeps, or soak tests.
+- `devbox_exec_start` starts a detached job and returns a job ID immediately; use it for work expected to approach or exceed 90 seconds.
 - `devbox_job_status` polls durable state under `run/jobs/`.
 - `devbox_job_logs` returns bounded log tails.
 - `devbox_job_cancel` cancels the detached process tree.

--- a/bin/devbox.js
+++ b/bin/devbox.js
@@ -7,12 +7,24 @@ const result = await runLauncher(process.argv.slice(2));
 if (result.command === "run") {
   console.log(`devbox running in foreground at ${result.url}`);
 } else if (result.running) {
-  console.log(`devbox ${result.command} ok`);
+  if (result.stopRefused) {
+    console.log(`devbox ${result.command} not performed`);
+    process.exitCode = 2;
+  } else {
+    console.log(`devbox ${result.command} ok`);
+  }
   console.log(`url: ${result.url}`);
   if (result.pid) {
     console.log(`pid: ${result.pid}`);
   }
+  if (result.manager) {
+    console.log(`manager: ${result.manager}`);
+  }
+  console.log(`health: ${result.healthy === false ? "unhealthy" : "healthy"}`);
   console.log(`log: ${result.logFile}`);
+  if (result.note) {
+    console.log(`note: ${result.note}`);
+  }
 } else {
   console.log(`devbox ${result.command} ok`);
   console.log(`url: ${result.url}`);

--- a/bootstrap/Cargo.lock
+++ b/bootstrap/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "devbox-setup"
-version = "0.4.1"
+version = "0.4.2"

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devbox-setup"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.74"
 description = "Cross-platform bootstrap installer for Devbox MCP"

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,6 +1,6 @@
 # Devbox setup binary
 
-`devbox-setup` v0.4.1 is the automation-friendly Rust bootstrap for Devbox MCP on Windows, Linux, macOS, and Termux/Android. It is also the backend used by the C++ `devbox-tui`, so there is one setup implementation rather than separate interactive and CLI installers.
+`devbox-setup` v0.4.2 is the automation-friendly Rust bootstrap for Devbox MCP on Windows, Linux, macOS, and Termux/Android. It is also the backend used by the C++ `devbox-tui`, so there is one setup implementation rather than separate interactive and CLI installers.
 
 It can configure an existing checkout or clone the official repository, then:
 

--- a/docs/CLOUDFLARE_TUNNEL.md
+++ b/docs/CLOUDFLARE_TUNNEL.md
@@ -294,3 +294,34 @@ Cloudflare also supports locally-managed tunnels created with `cloudflared tunne
 - Create a locally-managed tunnel: <https://developers.cloudflare.com/tunnel/advanced/local-management/create-local-tunnel/>
 - Run as a Linux service: <https://developers.cloudflare.com/tunnel/advanced/local-management/as-a-service/linux/>
 - Run as a macOS service: <https://developers.cloudflare.com/tunnel/advanced/local-management/as-a-service/macos/>
+
+## Transport resilience and IPv4/IPv6 selection
+
+Devbox leaves Cloudflare transport/protocol selection under `cloudflared` control, but it now monitors the live HA-connection gauge. If all HA connections collapse while the local MCP remains healthy, Guardian classifies the incident as a tunnel transport failure and performs a tunnel-only recovery instead of restarting the MCP or disturbing unrelated host/WSL workloads.
+
+The edge IP family is configurable on every supported platform:
+
+```env
+CLOUDFLARED_EDGE_IP_VERSION=auto
+```
+
+Allowed values are `auto`, `4`, and `6`. Keep `auto` unless diagnostics show a persistently unreliable IPv6 or IPv4 path. To temporarily force IPv4 while diagnosing a router/ISP IPv6 problem, set:
+
+```env
+CLOUDFLARED_EDGE_IP_VERSION=4
+```
+
+Then restart only the Cloudflare tunnel/service. Devbox writes the active Windows host selection to `run/host-cloudflared.transport.json`; POSIX service installers print the selected edge IP mode after setup.
+
+Guardian records these fields in `run/guardian/state.json` when metrics are available:
+
+- `CloudflaredMetrics.HaConnections`
+- `CloudflaredMetrics.RequestErrors`
+- `CloudflaredMetrics.TotalRequests`
+- `CloudflaredMetrics.QuicClosedConnections`
+- `CloudflaredMetricsDelta`
+- `TunnelTransportHealthy`
+- `TunnelTransportDegraded`
+- `TunnelTransportReasons`
+
+A rising QUIC-close counter is useful evidence but is not alone considered an outage. HA connections reaching zero is the stronger failure signal.

--- a/docs/GUARDIAN.md
+++ b/docs/GUARDIAN.md
@@ -44,6 +44,16 @@ The scheduled tasks run `Ensure-ChatGptDevboxGuardian.ps1`, which checks the hea
 
 Windows MCP elevation inspection is tri-state. A definitive medium-integrity result is unhealthy, but a PowerShell/token-query timeout is `unknown` rather than falsely treated as unelevated. A confirmed elevation result is cached for the lifetime of that MCP PID.
 
+### Startup ownership and recovery journal
+
+Windows/host lifecycle actions use a global single-owner mutex and **fail fast** if another start/restart is already active; they do not queue additional five-minute startup processes. `ChatGptDevboxMcp-ElevatedStart` now waits for the real PowerShell startup child, so Task Scheduler remains `Running` until startup actually succeeds or fails and `LastTaskResult` reflects that outcome.
+
+Every startup writes `run/startup-state.json` with an attempt ID, owner PID, phase, deadline, and status. Important phases include `preparing-runtime`, `starting-cloudflare-tunnel`, `writing-runtime-config`, `stopping-existing-mcp`, `starting-mcp`, `waiting-local-health`, `waiting-public-health`, and `ready`. The MCP PID file is written immediately after Node is spawned, before health validation. If later health/elevation validation fails, Devbox kills only that verified owned MCP process, removes its PID file, and (for a full Windows public start) tears down the tunnel it launched. This prevents an orphan `src/server.js` process from occupying port 8100 without `run/mcp.pid`.
+
+Guardian reads the same startup journal. While the journal says `running`, its owner PID is alive, and the journal is fresh, Guardian defers repair so it cannot race a legitimate startup. A dead owner or stale journal does not suppress recovery. Host startup defaults to a 180-second lifecycle deadline; Docker mode defaults to 900 seconds. Set `DEVBOX_STARTUP_TIMEOUT_SECONDS` only when a different bounded deadline is required.
+
+`node bin/devbox.js status` also recognizes the managed `run/mcp.pid` and reports `manager: managed-mcp` plus endpoint health, so portable status no longer says `stopped` while the Windows Guardian-managed MCP is healthy. This is observability only: the portable launcher refuses to stop/restart a `managed-mcp` process that it does not own and directs recovery through Guardian/platform lifecycle scripts instead.
+
 Inspect current status:
 
 ```powershell
@@ -101,7 +111,9 @@ npm run guardian:check
 
 ## Repair safety and circuit breaking
 
-Guardian waits for repeated failures before repair. A failed localhost MCP health probe uses a faster two-observation threshold; public-tunnel-only failures retain the configured threshold so normal QUIC/edge reconnect churn does not restart the MCP. Cloudflared Prometheus metrics (HA connections, request errors, total requests, and QUIC closed connections) are recorded in Guardian state when available. Docker repairs use exponential backoff and open a one-hour circuit after three consecutive failed attempts by default. The persistent decision state is in `run/guardian/repair-policy.json` and survives Guardian restarts.
+Guardian waits for repeated failures before repair. A failed localhost MCP health probe uses a faster two-observation threshold. A confirmed Cloudflare transport collapse (`cloudflared_tunnel_ha_connections == 0`) also uses the faster threshold, but selects a **public-tunnel-only** repair while the local MCP remains healthy. Generic public-health failures retain the configured threshold so ordinary edge/QUIC reconnect churn does not restart the MCP.
+
+Cloudflared Prometheus metrics (HA connections, request errors, total requests, and QUIC closed connections) are recorded in Guardian state when available. Guardian also records per-probe metric deltas plus `TunnelTransportHealthy`, `TunnelTransportDegraded`, and `TunnelTransportReasons`. QUIC-close deltas are diagnostic signals; they do not by themselves trigger a restart. Docker repairs use exponential backoff and open a one-hour circuit after three consecutive failed attempts by default. The persistent decision state is in `run/guardian/repair-policy.json` and survives Guardian restarts.
 
 Container repair first inspects the exact configured name. A stopped container is started. If it cannot start, it is replaced. A create race is re-inspected and started. An ambiguous Docker/inspect error never falls through to a conflicting `docker run`.
 

--- a/scripts/Install-ChatGptDevboxGuardian.ps1
+++ b/scripts/Install-ChatGptDevboxGuardian.ps1
@@ -294,7 +294,7 @@ $elevatedSettings = New-ScheduledTaskSettingsSet `
     -DontStopIfGoingOnBatteries `
     -StartWhenAvailable `
     -MultipleInstances IgnoreNew `
-    -ExecutionTimeLimit (New-TimeSpan -Hours 1)
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 10)
 Register-ScheduledTask -TaskName $elevatedStartTaskName -Action $elevatedAction -Settings $elevatedSettings -Principal $principal -Force | Out-Null
 
 & $powerShellExe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ensureScript | Out-Null

--- a/scripts/Run-Start-ChatGptDevboxMcp.vbs
+++ b/scripts/Run-Start-ChatGptDevboxMcp.vbs
@@ -53,4 +53,4 @@ For i = 0 To WScript.Arguments.Count - 1
     command = command & " " & Chr(34) & Replace(WScript.Arguments(i), Chr(34), Chr(34) & Chr(34)) & Chr(34)
 Next
 
-WScript.Quit shell.Run(command, 0, False)
+WScript.Quit shell.Run(command, 0, True)

--- a/scripts/Start-ChatGptDevboxMcp.ps1
+++ b/scripts/Start-ChatGptDevboxMcp.ps1
@@ -12,6 +12,14 @@ $ProgressPreference = 'SilentlyContinue'
 $InformationPreference = 'SilentlyContinue'
 $script:dockerExe = $null
 $script:dockerConfiguredPath = $null
+$script:lifecycleMutex = $null
+$script:lifecycleMutexHeld = $false
+$script:startupStatePath = $null
+$script:startupAttemptId = $null
+$script:startupStartedAtUtc = $null
+$script:startupDeadlineUtc = $null
+$script:startupMcpPid = $null
+$script:startupSucceeded = $false
 
 function Resolve-DockerExecutable {
     param([string]$ConfiguredPath)
@@ -293,11 +301,84 @@ function Get-DockerLogsText {
     return (Invoke-Docker -Arguments @('logs', $ContainerName) -IgnoreExitCode).Text
 }
 
+function Write-StartupPhase {
+    param(
+        [Parameter(Mandatory = $true)][string]$Phase,
+        [ValidateSet('running', 'ready', 'failed', 'timed-out')]
+        [string]$Status = 'running',
+        [string]$Details = '',
+        [hashtable]$Extra = @{}
+    )
+
+    if (-not $script:startupStatePath) {
+        return
+    }
+
+    $payload = [ordered]@{
+        AttemptId = $script:startupAttemptId
+        ProcessId = $PID
+        Phase = $Phase
+        Status = $Status
+        StartedAtUtc = $script:startupStartedAtUtc
+        UpdatedAtUtc = [DateTime]::UtcNow.ToString('o')
+        DeadlineUtc = if ($script:startupDeadlineUtc) { $script:startupDeadlineUtc.ToString('o') } else { $null }
+        Details = $Details
+    }
+    foreach ($key in $Extra.Keys) {
+        $payload[$key] = $Extra[$key]
+    }
+    Write-JsonStateFile -Path $script:startupStatePath -Value $payload
+}
+
+function Assert-StartupDeadline {
+    param([string]$Phase = 'startup')
+
+    if ($script:startupDeadlineUtc -and [DateTime]::UtcNow -gt $script:startupDeadlineUtc) {
+        $details = "Startup deadline exceeded while in phase '$Phase'."
+        Write-StartupPhase -Phase $Phase -Status 'timed-out' -Details $details
+        throw $details
+    }
+}
+
 function Enter-ChatGptDevboxLifecycleMutex {
+    param(
+        [Parameter(Mandatory = $true)][string]$RunDir,
+        [Parameter(Mandatory = $true)][string]$SelectedRuntime,
+        [int]$TimeoutSeconds = 180
+    )
+
+    Ensure-Directory -Path $RunDir
+    $script:startupStatePath = Join-Path $RunDir 'startup-state.json'
+    $script:startupAttemptId = [System.Guid]::NewGuid().ToString('N')
+    $script:startupStartedAtUtc = [DateTime]::UtcNow.ToString('o')
+    $script:startupDeadlineUtc = [DateTime]::UtcNow.AddSeconds([Math]::Max(30, $TimeoutSeconds))
+    $script:startupSucceeded = $false
+    $script:startupMcpPid = $null
+
     $script:lifecycleMutex = New-Object System.Threading.Mutex($false, 'Global\ChatGptDevboxMcpLifecycle')
-    $script:lifecycleMutexHeld = $script:lifecycleMutex.WaitOne(300000, $false)
+    try {
+        $script:lifecycleMutexHeld = $script:lifecycleMutex.WaitOne(0, $false)
+    } catch [System.Threading.AbandonedMutexException] {
+        $script:lifecycleMutexHeld = $true
+    }
+
     if (-not $script:lifecycleMutexHeld) {
-        throw "Timed out waiting for another ChatGPT Devbox lifecycle action to finish."
+        $ownerSummary = ''
+        if (Test-Path $script:startupStatePath) {
+            try {
+                $owner = Get-Content $script:startupStatePath -Raw | ConvertFrom-Json
+                $ownerSummary = " Existing owner PID=$($owner.ProcessId), phase=$($owner.Phase), status=$($owner.Status), updated=$($owner.UpdatedAtUtc)."
+            } catch {
+            }
+        }
+        $script:lifecycleMutex.Dispose()
+        $script:lifecycleMutex = $null
+        throw "Another ChatGPT Devbox lifecycle action is already running; refusing to queue a concurrent start.$ownerSummary"
+    }
+
+    Write-StartupPhase -Phase 'lifecycle-lock-acquired' -Extra @{
+        SelectedRuntime = $SelectedRuntime
+        TimeoutSeconds = [Math]::Max(30, $TimeoutSeconds)
     }
 }
 
@@ -826,6 +907,7 @@ function Wait-ForHealthyPublicEndpoint {
 
     $healthUrl = "$($PublicBaseUrl.TrimEnd('/'))/healthz"
     for ($i = 0; $i -lt 30; $i++) {
+        Assert-StartupDeadline -Phase 'waiting-public-health'
         Start-Sleep -Seconds 2
         if ($HostCloudflaredPidFile) {
             $hostPid = if (Test-Path $HostCloudflaredPidFile) { Get-Content $HostCloudflaredPidFile -ErrorAction SilentlyContinue | Select-Object -First 1 } else { '' }
@@ -864,6 +946,8 @@ function Start-CloudflaredNamedTunnel {
         [string]$PublicHostname,
         [int]$Port,
         [string]$RunDir,
+        [string]$MetricsUrl = '',
+        [string]$EdgeIpVersion = '',
         [bool]$DockerReady = $true
     )
 
@@ -883,13 +967,38 @@ function Start-CloudflaredNamedTunnel {
     $stdoutLog = Join-Path $RunDir 'host-cloudflared.stdout.log'
     $stderrLog = Join-Path $RunDir 'host-cloudflared.stderr.log'
     $metricsUrlFile = Join-Path $RunDir 'host-cloudflared.metrics-url.txt'
-    $metricsUrl = if (-not [string]::IsNullOrWhiteSpace($env:CLOUDFLARED_METRICS_URL)) { [string]$env:CLOUDFLARED_METRICS_URL } else { 'http://127.0.0.1:20241/metrics' }
+    $metricsUrl = if (-not [string]::IsNullOrWhiteSpace($MetricsUrl)) {
+        [string]$MetricsUrl
+    } elseif (-not [string]::IsNullOrWhiteSpace($env:CLOUDFLARED_METRICS_URL)) {
+        [string]$env:CLOUDFLARED_METRICS_URL
+    } else {
+        'http://127.0.0.1:20241/metrics'
+    }
     $metricsUri = [Uri]$metricsUrl
     if ($metricsUri.Scheme -ne 'http' -or -not $metricsUri.IsLoopback -or $metricsUri.Port -lt 1) {
         throw "CLOUDFLARED_METRICS_URL must be a loopback http URL such as http://127.0.0.1:20241/metrics."
     }
     $metricsAddress = "{0}:{1}" -f $metricsUri.Host, $metricsUri.Port
     [System.IO.File]::WriteAllText($metricsUrlFile, $metricsUrl, [System.Text.UTF8Encoding]::new($false))
+    $edgeIpVersion = if (-not [string]::IsNullOrWhiteSpace($EdgeIpVersion)) {
+        [string]$EdgeIpVersion
+    } elseif (-not [string]::IsNullOrWhiteSpace($env:CLOUDFLARED_EDGE_IP_VERSION)) {
+        [string]$env:CLOUDFLARED_EDGE_IP_VERSION
+    } else {
+        'auto'
+    }
+    $edgeIpVersion = $edgeIpVersion.Trim().ToLowerInvariant()
+    if ($edgeIpVersion -notin @('auto', '4', '6')) {
+        throw "CLOUDFLARED_EDGE_IP_VERSION must be one of: auto, 4, 6."
+    }
+    $transportStateFile = Join-Path $RunDir 'host-cloudflared.transport.json'
+    $transportState = [ordered]@{
+        EdgeIpVersion = $edgeIpVersion
+        ProtocolSelection = 'cloudflared-managed'
+        MetricsUrl = $metricsUrl
+        UpdatedAtUtc = [DateTime]::UtcNow.ToString('o')
+    } | ConvertTo-Json -Depth 4
+    [System.IO.File]::WriteAllText($transportStateFile, $transportState, [System.Text.UTF8Encoding]::new($false))
 
     Stop-ExistingHostCloudflared -PidFile $pidFile
     [System.IO.File]::WriteAllText($tokenFile, $TunnelToken, [System.Text.UTF8Encoding]::new($false))
@@ -902,7 +1011,7 @@ function Start-CloudflaredNamedTunnel {
     if (Test-Path $stderrLog) { Remove-Item $stderrLog -Force -ErrorAction SilentlyContinue }
 
     $process = Start-Process -FilePath $cloudflaredExe `
-        -ArgumentList @('tunnel', '--config', $configFile, '--no-autoupdate', '--loglevel', 'info', '--metrics', $metricsAddress, 'run', '--token-file', $tokenFile) `
+        -ArgumentList @('tunnel', '--config', $configFile, '--no-autoupdate', '--loglevel', 'info', '--metrics', $metricsAddress, '--edge-ip-version', $edgeIpVersion, 'run', '--token-file', $tokenFile) `
         -WorkingDirectory $RunDir `
         -RedirectStandardOutput $stdoutLog `
         -RedirectStandardError $stderrLog `
@@ -930,6 +1039,8 @@ function Start-CloudflaredPublicTunnel {
         [ValidateSet('host', 'docker')]
         [string]$SelectedRuntime,
         [string]$RunDir,
+        [string]$MetricsUrl = '',
+        [string]$EdgeIpVersion = '',
         [bool]$DockerReady = $false
     )
 
@@ -941,7 +1052,7 @@ function Start-CloudflaredPublicTunnel {
             throw "CLOUDFLARED_TUNNEL_TOKEN and CLOUDFLARED_PUBLIC_HOSTNAME must both be set to use the named Cloudflare tunnel."
         }
 
-        return Start-CloudflaredNamedTunnel -ContainerName $ContainerName -TunnelToken $TunnelToken -PublicHostname $PublicHostname -Port $Port -RunDir $RunDir -DockerReady:$DockerReady
+        return Start-CloudflaredNamedTunnel -ContainerName $ContainerName -TunnelToken $TunnelToken -PublicHostname $PublicHostname -Port $Port -RunDir $RunDir -MetricsUrl $MetricsUrl -EdgeIpVersion $EdgeIpVersion -DockerReady:$DockerReady
     }
 
     if ($SelectedRuntime -eq 'host') {
@@ -986,9 +1097,19 @@ if ($selectedRuntimeEarly -eq 'host') {
     }
 }
 
-Enter-ChatGptDevboxLifecycleMutex
+$startupTimeoutRaw = Get-EnvValue -FilePath $envFile -Name 'DEVBOX_STARTUP_TIMEOUT_SECONDS'
+$startupTimeoutSeconds = if ($startupTimeoutRaw -match '^\d+$') {
+    [Math]::Min(1800, [Math]::Max(30, [int]$startupTimeoutRaw))
+} elseif ($selectedRuntimeEarly -eq 'host') {
+    180
+} else {
+    900
+}
+
+Enter-ChatGptDevboxLifecycleMutex -RunDir $runDir -SelectedRuntime $selectedRuntimeEarly -TimeoutSeconds $startupTimeoutSeconds
 try {
 Ensure-Directory -Path $runDir
+Write-StartupPhase -Phase 'preparing-runtime'
 Write-GuardianDesiredState -RunDir $runDir -ShouldRun $true -Source "Start-ChatGptDevboxMcp.ps1"
 
 $nodeExe = Resolve-NodeExecutable -ConfiguredPath (Get-EnvValue -FilePath $envFile -Name "NODE_EXE")
@@ -1031,6 +1152,8 @@ if ([string]::IsNullOrWhiteSpace($cloudflaredContainerName)) {
 }
 $cloudflaredTunnelToken = Get-EnvValue -FilePath $envFile -Name "CLOUDFLARED_TUNNEL_TOKEN"
 $cloudflaredPublicHostname = Get-EnvValue -FilePath $envFile -Name "CLOUDFLARED_PUBLIC_HOSTNAME"
+$cloudflaredMetricsUrl = Get-EnvValue -FilePath $envFile -Name "CLOUDFLARED_METRICS_URL"
+$cloudflaredEdgeIpVersion = Get-EnvValue -FilePath $envFile -Name "CLOUDFLARED_EDGE_IP_VERSION"
 $configuredPublicBaseUrl = Normalize-PublicBaseUrl -Value (Get-EnvValue -FilePath $envFile -Name "PUBLIC_BASE_URL")
 if (-not $configuredPublicBaseUrl) {
     $configuredPublicBaseUrl = Normalize-PublicBaseUrl -Value $cloudflaredPublicHostname
@@ -1039,6 +1162,8 @@ if (-not $configuredPublicBaseUrl) {
 $dockerReady = $false
 Ensure-Directory -Path $hostWorkspace
 if ($selectedRuntime -eq 'docker') {
+    Write-StartupPhase -Phase 'preparing-docker-runtime'
+    Assert-StartupDeadline -Phase 'preparing-docker-runtime'
     if ($TunnelOnly) {
         $dockerReady = Test-DockerEngine -TimeoutSeconds 5
     } else {
@@ -1057,11 +1182,17 @@ if ($TunnelOnly -and -not $Public) {
     throw '-TunnelOnly requires -Public.'
 }
 if ($Public) {
-    $publicBaseUrl = Start-CloudflaredPublicTunnel -ContainerName $cloudflaredContainerName -TunnelToken $cloudflaredTunnelToken -PublicHostname $cloudflaredPublicHostname -Port $port -SelectedRuntime $selectedRuntime -RunDir $runDir -DockerReady:$dockerReady
+    Write-StartupPhase -Phase 'starting-cloudflare-tunnel'
+    Assert-StartupDeadline -Phase 'starting-cloudflare-tunnel'
+    $publicBaseUrl = Start-CloudflaredPublicTunnel -ContainerName $cloudflaredContainerName -TunnelToken $cloudflaredTunnelToken -PublicHostname $cloudflaredPublicHostname -Port $port -SelectedRuntime $selectedRuntime -RunDir $runDir -MetricsUrl $cloudflaredMetricsUrl -EdgeIpVersion $cloudflaredEdgeIpVersion -DockerReady:$dockerReady
+    Write-StartupPhase -Phase 'cloudflare-tunnel-started' -Extra @{ PublicBaseUrl = $publicBaseUrl }
 }
 if ($TunnelOnly) {
     $hostTunnelPidFile = if ($selectedRuntime -eq 'host') { Join-Path $runDir 'host-cloudflared.pid' } else { '' }
+    Write-StartupPhase -Phase 'waiting-public-health'
     Wait-ForHealthyPublicEndpoint -ContainerName $cloudflaredContainerName -PublicBaseUrl $publicBaseUrl -HostCloudflaredPidFile $hostTunnelPidFile
+    $script:startupSucceeded = $true
+    Write-StartupPhase -Phase 'ready' -Status 'ready' -Extra @{ PublicBaseUrl = $publicBaseUrl; TunnelOnly = $true }
     Write-Host "Public MCP URL: $publicBaseUrl"
     Write-Host "Selected runtime: $selectedRuntime (tunnel-only repair)"
     return
@@ -1107,12 +1238,17 @@ if ($selectedRuntime -eq 'host') {
     }
 }
 
+Write-StartupPhase -Phase 'writing-runtime-config'
 Write-RuntimeEnvFile -SourceEnvFile $envFile -RuntimeEnvFile $runtimeEnvFile -Overrides $overrides
+Assert-StartupDeadline -Phase 'stopping-existing-mcp'
+Write-StartupPhase -Phase 'stopping-existing-mcp'
 Stop-ExistingServerIfOwned -PidFile $pidFile -ProjectRoot $root
 
 if (Test-Path $stdoutLog) { Remove-Item $stdoutLog -Force -ErrorAction SilentlyContinue }
 if (Test-Path $stderrLog) { Remove-Item $stderrLog -Force -ErrorAction SilentlyContinue }
 
+Assert-StartupDeadline -Phase 'starting-mcp'
+Write-StartupPhase -Phase 'starting-mcp'
 $process = Start-Process -FilePath $nodeExe `
     -ArgumentList @("--env-file=.env.runtime", "src/server.js") `
     -WorkingDirectory $root `
@@ -1121,8 +1257,15 @@ $process = Start-Process -FilePath $nodeExe `
     -PassThru `
     -WindowStyle Hidden
 
+$script:startupMcpPid = [int]$process.Id
+# Establish ownership immediately. If health/elevation validation later fails,
+# the outer catch block removes this exact owned process and PID file.
+Set-Content -Path $pidFile -Value $process.Id -Encoding ASCII
+Write-StartupPhase -Phase 'waiting-local-health' -Extra @{ McpProcessId = [int]$process.Id; LocalUrl = "http://127.0.0.1:$port" }
+
 $localUrl = "http://127.0.0.1:$port"
 for ($i = 0; $i -lt 30; $i++) {
+    Assert-StartupDeadline -Phase 'waiting-local-health'
     Start-Sleep -Seconds 2
     try {
         $response = Invoke-WebRequest -Uri "$localUrl/healthz" -UseBasicParsing -TimeoutSec 5
@@ -1133,6 +1276,7 @@ for ($i = 0; $i -lt 30; $i++) {
     }
 }
 
+Assert-StartupDeadline -Phase 'waiting-local-health'
 try {
     $health = Invoke-WebRequest -Uri "$localUrl/healthz" -UseBasicParsing -TimeoutSec 5
     if ($health.Content -notmatch "ok") {
@@ -1150,15 +1294,23 @@ if ($process.HasExited) {
 }
 
 if ($selectedRuntime -eq 'host' -and -not (Test-IsProcessElevated -ProcessId ([int]$process.Id))) {
-    try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
     throw "MCP server PID $($process.Id) started without elevation. Host mode refuses medium-integrity MCP so host_exec cannot spam UAC. Start via elevated Guardian or ChatGptDevboxMcp-ElevatedStart."
 }
 
-Set-Content -Path $pidFile -Value $process.Id
+Write-StartupPhase -Phase 'local-health-ready' -Extra @{ McpProcessId = [int]$process.Id; LocalUrl = $localUrl }
 
 if ($Public) {
     $hostTunnelPidFile = if ($selectedRuntime -eq 'host') { Join-Path $runDir 'host-cloudflared.pid' } else { '' }
+    Write-StartupPhase -Phase 'waiting-public-health' -Extra @{ McpProcessId = [int]$process.Id; PublicBaseUrl = $publicBaseUrl }
     Wait-ForHealthyPublicEndpoint -ContainerName $cloudflaredContainerName -PublicBaseUrl $publicBaseUrl -HostCloudflaredPidFile $hostTunnelPidFile
+}
+
+$script:startupSucceeded = $true
+Write-StartupPhase -Phase 'ready' -Status 'ready' -Extra @{
+    McpProcessId = [int]$process.Id
+    LocalUrl = $localUrl
+    PublicBaseUrl = $publicBaseUrl
+    SelectedRuntime = $selectedRuntime
 }
 
 Write-Host "Local MCP URL: $localUrl"
@@ -1168,6 +1320,41 @@ if ($Public) {
 }
 Write-Host "Authentication mode: $(if ($authMode -eq 'none') { 'No Authentication' } else { 'OAuth' })"
 Write-Host "Selected runtime: $selectedRuntime (requested: $runtimeMode)"
+} catch {
+    $failureMessage = $_.Exception.Message
+    try {
+        Write-StartupPhase -Phase 'failed' -Status 'failed' -Details $failureMessage -Extra @{
+            McpProcessId = $script:startupMcpPid
+            SelectedRuntime = $selectedRuntime
+        }
+    } catch {
+    }
+
+    if ($script:startupMcpPid) {
+        try {
+            $candidate = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f [int]$script:startupMcpPid) -ErrorAction SilentlyContinue
+            if ($candidate -and (Test-IsOwnedServerCommandLine -CommandLine ([string]$candidate.CommandLine))) {
+                Stop-Process -Id ([int]$script:startupMcpPid) -Force -ErrorAction SilentlyContinue
+            }
+        } catch {
+        }
+        try {
+            if (Test-Path $pidFile) {
+                $pidText = Get-Content $pidFile -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($pidText -eq [string]$script:startupMcpPid) {
+                    Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+                }
+            }
+        } catch {
+        }
+    }
+
+    # A full Windows host startup owns the named tunnel it launched. Do not
+    # leave cloudflared advertising an origin that failed to become ready.
+    if (-not $TunnelOnly -and $selectedRuntime -eq 'host' -and $Public) {
+        try { Stop-ExistingHostCloudflared -PidFile (Join-Path $runDir 'host-cloudflared.pid') } catch {}
+    }
+    throw
 } finally {
     Exit-ChatGptDevboxLifecycleMutex
 }

--- a/scripts/ci/run-posix-runtime-e2e.sh
+++ b/scripts/ci/run-posix-runtime-e2e.sh
@@ -25,6 +25,7 @@ trap cleanup EXIT INT TERM
 
 cd "$ROOT_DIR"
 sh -n scripts/install-cloudflare-tunnel.sh
+sh -n scripts/restart-cloudflare-tunnel.sh
 sh scripts/ci/test-cloudflare-tunnel-errors.sh
 rm -rf "$WORKSPACE"
 mkdir -p "$WORKSPACE"

--- a/scripts/ci/run-termux-docker-e2e.sh
+++ b/scripts/ci/run-termux-docker-e2e.sh
@@ -47,6 +47,7 @@ docker run --rm \
     ./devbox-tui-termux-ci --cloudflare-help --no-color | tee cloudflare-help-termux.txt
     grep -F 'pkg update && pkg install cloudflared termux-services' cloudflare-help-termux.txt
     sh -n scripts/install-cloudflare-tunnel.sh
+    sh -n scripts/restart-cloudflare-tunnel.sh
     sh scripts/ci/test-cloudflare-tunnel-errors.sh
 
     echo '=== Full bootstrap -> launcher -> MCP workflow ==='

--- a/scripts/ci/test-cloudflare-tunnel-errors.sh
+++ b/scripts/ci/test-cloudflare-tunnel-errors.sh
@@ -8,8 +8,8 @@ TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
 : > "$TMP_DIR/empty.env"
 
-cat > "$TMP_DIR/cloudflared" <<'EOF'
-#!/usr/bin/env sh
+cat > "$TMP_DIR/cloudflared" <<EOF
+#!$SH_BIN
 exit 0
 EOF
 chmod +x "$TMP_DIR/cloudflared"
@@ -62,9 +62,9 @@ set -e
 [ "$code" -eq 2 ]
 grep -F "CLOUDFLARED_EDGE_IP_VERSION must be one of: auto, 4, 6" "$TMP_DIR/edge.out" >/dev/null
 
-cat > "$TMP_DIR/systemctl" <<'EOF'
-#!/usr/bin/env sh
-printf '%s\n' "$*" >> "$DEVBOX_FAKE_SYSTEMCTL_LOG"
+cat > "$TMP_DIR/systemctl" <<EOF
+#!$SH_BIN
+printf '%s\n' "\$*" >> "\$DEVBOX_FAKE_SYSTEMCTL_LOG"
 exit 0
 EOF
 chmod +x "$TMP_DIR/systemctl"

--- a/scripts/ci/test-cloudflare-tunnel-errors.sh
+++ b/scripts/ci/test-cloudflare-tunnel-errors.sh
@@ -31,4 +31,32 @@ set -e
 [ "$code" -eq 2 ]
 grep -F "pkg install cloudflared termux-services" "$TMP_DIR/termux.out" >/dev/null
 
+
+cat > "$TMP_DIR/edge.env" <<'EOF'
+CLOUDFLARED_TUNNEL_TOKEN=test-token
+CLOUDFLARED_PUBLIC_HOSTNAME=mcp.example.com
+PUBLIC_BASE_URL=https://mcp.example.com
+CLOUDFLARED_EDGE_IP_VERSION=bogus
+EOF
+set +e
+PATH="$TMP_DIR:/usr/bin:/bin" DEVBOX_ENV_FILE="$TMP_DIR/edge.env" \
+  sh "$ROOT_DIR/scripts/install-cloudflare-tunnel.sh" foreground >"$TMP_DIR/edge.out" 2>&1
+code=$?
+set -e
+[ "$code" -eq 2 ]
+grep -F "CLOUDFLARED_EDGE_IP_VERSION must be one of: auto, 4, 6" "$TMP_DIR/edge.out" >/dev/null
+
+cat > "$TMP_DIR/systemctl" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' "$*" >> "$DEVBOX_FAKE_SYSTEMCTL_LOG"
+exit 0
+EOF
+chmod +x "$TMP_DIR/systemctl"
+: > "$TMP_DIR/systemctl.calls"
+DEVBOX_FAKE_SYSTEMCTL_LOG="$TMP_DIR/systemctl.calls" PATH="$TMP_DIR:/usr/bin:/bin" \
+  sh "$ROOT_DIR/scripts/restart-cloudflare-tunnel.sh" systemd >"$TMP_DIR/restart.out" 2>&1
+grep -F -- "--user status devbox-cloudflared.service" "$TMP_DIR/systemctl.calls" >/dev/null
+grep -F -- "--user restart devbox-cloudflared.service" "$TMP_DIR/systemctl.calls" >/dev/null
+grep -F "Restarted Linux Cloudflare user service" "$TMP_DIR/restart.out" >/dev/null
+
 printf 'Cloudflare tunnel error guidance checks passed.\n'

--- a/scripts/ci/test-cloudflare-tunnel-errors.sh
+++ b/scripts/ci/test-cloudflare-tunnel-errors.sh
@@ -2,6 +2,8 @@
 set -eu
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+ORIGINAL_PATH=$PATH
+SH_BIN=$(command -v sh)
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
 : > "$TMP_DIR/empty.env"
@@ -14,18 +16,32 @@ chmod +x "$TMP_DIR/cloudflared"
 
 set +e
 CLOUDFLARED_TUNNEL_TOKEN= CLOUDFLARED_PUBLIC_HOSTNAME= PUBLIC_BASE_URL= \
-  PATH="$TMP_DIR:/usr/bin:/bin" DEVBOX_ENV_FILE="$TMP_DIR/empty.env" \
-  sh "$ROOT_DIR/scripts/install-cloudflare-tunnel.sh" foreground >"$TMP_DIR/token.out" 2>&1
+  PATH="$TMP_DIR:$ORIGINAL_PATH" DEVBOX_ENV_FILE="$TMP_DIR/empty.env" \
+  "$SH_BIN" "$ROOT_DIR/scripts/install-cloudflare-tunnel.sh" foreground >"$TMP_DIR/token.out" 2>&1
 code=$?
 set -e
 [ "$code" -eq 2 ]
 grep -F "CLOUDFLARED_TUNNEL_TOKEN is missing" "$TMP_DIR/token.out" >/dev/null
 
-after_path="/usr/bin:/bin"
+# Build a deterministic PATH with enough tools to start the installer but no
+# cloudflared binary. Do not assume desktop /usr/bin:/bin: Termux tools live
+# under $PREFIX/bin.
+NO_CLOUDFLARED_BIN="$TMP_DIR/no-cloudflared-bin"
+mkdir -p "$NO_CLOUDFLARED_BIN"
+for tool in dirname cat; do
+  tool_path=$(command -v "$tool")
+  [ -n "$tool_path" ]
+  cat > "$NO_CLOUDFLARED_BIN/$tool" <<EOF
+#!$SH_BIN
+exec "$tool_path" "\$@"
+EOF
+  chmod +x "$NO_CLOUDFLARED_BIN/$tool"
+done
+
 set +e
 TERMUX_VERSION=ci PREFIX=/data/data/com.termux/files/usr CLOUDFLARED_TUNNEL_TOKEN= \
-  PATH="$after_path" DEVBOX_ENV_FILE="$TMP_DIR/empty.env" \
-  sh "$ROOT_DIR/scripts/install-cloudflare-tunnel.sh" auto >"$TMP_DIR/termux.out" 2>&1
+  PATH="$NO_CLOUDFLARED_BIN" DEVBOX_ENV_FILE="$TMP_DIR/empty.env" \
+  "$SH_BIN" "$ROOT_DIR/scripts/install-cloudflare-tunnel.sh" auto >"$TMP_DIR/termux.out" 2>&1
 code=$?
 set -e
 [ "$code" -eq 2 ]
@@ -39,8 +55,8 @@ PUBLIC_BASE_URL=https://mcp.example.com
 CLOUDFLARED_EDGE_IP_VERSION=bogus
 EOF
 set +e
-PATH="$TMP_DIR:/usr/bin:/bin" DEVBOX_ENV_FILE="$TMP_DIR/edge.env" \
-  sh "$ROOT_DIR/scripts/install-cloudflare-tunnel.sh" foreground >"$TMP_DIR/edge.out" 2>&1
+CLOUDFLARED_EDGE_IP_VERSION= PATH="$TMP_DIR:$ORIGINAL_PATH" DEVBOX_ENV_FILE="$TMP_DIR/edge.env" \
+  "$SH_BIN" "$ROOT_DIR/scripts/install-cloudflare-tunnel.sh" foreground >"$TMP_DIR/edge.out" 2>&1
 code=$?
 set -e
 [ "$code" -eq 2 ]
@@ -53,8 +69,8 @@ exit 0
 EOF
 chmod +x "$TMP_DIR/systemctl"
 : > "$TMP_DIR/systemctl.calls"
-DEVBOX_FAKE_SYSTEMCTL_LOG="$TMP_DIR/systemctl.calls" PATH="$TMP_DIR:/usr/bin:/bin" \
-  sh "$ROOT_DIR/scripts/restart-cloudflare-tunnel.sh" systemd >"$TMP_DIR/restart.out" 2>&1
+DEVBOX_FAKE_SYSTEMCTL_LOG="$TMP_DIR/systemctl.calls" PATH="$TMP_DIR:$ORIGINAL_PATH" \
+  "$SH_BIN" "$ROOT_DIR/scripts/restart-cloudflare-tunnel.sh" systemd >"$TMP_DIR/restart.out" 2>&1
 grep -F -- "--user status devbox-cloudflared.service" "$TMP_DIR/systemctl.calls" >/dev/null
 grep -F -- "--user restart devbox-cloudflared.service" "$TMP_DIR/systemctl.calls" >/dev/null
 grep -F "Restarted Linux Cloudflare user service" "$TMP_DIR/restart.out" >/dev/null

--- a/scripts/ci/test-windows-startup-contract.ps1
+++ b/scripts/ci/test-windows-startup-contract.ps1
@@ -1,0 +1,55 @@
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$startPath = Join-Path $root 'scripts\Start-ChatGptDevboxMcp.ps1'
+$installPath = Join-Path $root 'scripts\Install-ChatGptDevboxGuardian.ps1'
+$vbsPath = Join-Path $root 'scripts\Run-Start-ChatGptDevboxMcp.vbs'
+
+function Assert-Contains {
+    param([string]$Text, [string]$Needle, [string]$Message)
+    if (-not $Text.Contains($Needle)) { throw $Message }
+}
+
+function Assert-Before {
+    param([string]$Text, [string]$First, [string]$Second, [string]$Message)
+    $a = $Text.IndexOf($First, [StringComparison]::Ordinal)
+    $b = $Text.IndexOf($Second, [StringComparison]::Ordinal)
+    if ($a -lt 0 -or $b -lt 0 -or $a -ge $b) { throw $Message }
+}
+
+$start = Get-Content -LiteralPath $startPath -Raw
+$install = Get-Content -LiteralPath $installPath -Raw
+$vbs = Get-Content -LiteralPath $vbsPath -Raw
+
+Assert-Contains $start '$script:lifecycleMutex.WaitOne(0, $false)' 'Lifecycle mutex must reject concurrent starts instead of queueing them.'
+Assert-Contains $start "Join-Path `$RunDir 'startup-state.json'" 'Startup phase journal is missing.'
+Assert-Contains $start "Write-StartupPhase -Phase 'waiting-local-health'" 'Local-health phase journaling is missing.'
+Assert-Contains $start "Write-StartupPhase -Phase 'waiting-public-health'" 'Public-health phase journaling is missing.'
+Assert-Contains $start 'Assert-StartupDeadline' 'Startup deadline enforcement is missing.'
+Assert-Contains $start '$script:startupMcpPid = [int]$process.Id' 'Spawned MCP PID ownership tracking is missing.'
+Assert-Contains $start 'Stop-Process -Id ([int]$script:startupMcpPid) -Force' 'Failed startup must clean up the spawned MCP process.'
+Assert-Before $start 'Set-Content -Path $pidFile -Value $process.Id -Encoding ASCII' '$localUrl = "http://127.0.0.1:$port"' 'MCP PID must be persisted before health validation begins.'
+Assert-Contains $vbs 'shell.Run(command, 0, True)' 'Scheduled-task VBS must wait for the real startup child and propagate its exit code.'
+Assert-Contains $install '-ExecutionTimeLimit (New-TimeSpan -Minutes 10)' 'Elevated startup task must have a bounded execution time.'
+
+foreach ($file in @($startPath, $installPath)) {
+    $tokens = $null
+    $errors = $null
+    [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$tokens, [ref]$errors) | Out-Null
+    if ($errors.Count -gt 0) {
+        throw "PowerShell parser errors in $file`n$($errors | Out-String)"
+    }
+}
+
+$legacy = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+if (Test-Path $legacy) {
+    $escapedStart = $startPath.Replace("'", "''")
+    $escapedInstall = $installPath.Replace("'", "''")
+    $command = @"
+`$ErrorActionPreference='Stop'; foreach(`$f in @('$escapedStart','$escapedInstall')) { `$t=`$null; `$e=`$null; [System.Management.Automation.Language.Parser]::ParseFile(`$f,[ref]`$t,[ref]`$e) | Out-Null; if(`$e.Count -gt 0) { throw (`$e | Out-String) } }
+"@
+    & $legacy -NoLogo -NoProfile -NonInteractive -Command $command
+    if ($LASTEXITCODE -ne 0) { throw "Windows PowerShell 5.1 parse validation failed with exit code $LASTEXITCODE." }
+}
+
+Write-Host 'Windows Devbox startup lifecycle contract checks passed.'

--- a/scripts/devbox-guardian.mjs
+++ b/scripts/devbox-guardian.mjs
@@ -10,6 +10,9 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   classifyReadiness,
+  classifyStartupActivity,
+  classifyTunnelTransport,
+  deriveCloudflaredMetricDeltas,
   isRepairAllowed,
   normalizeRuntimeMode,
   resolveSelectedRuntime,
@@ -690,6 +693,26 @@ export const runRepairCommand = async ({
     });
   }
 
+  if (repairScope === "public-tunnel") {
+    const helper = path.join(environment.DEVBOX_PROJECT_ROOT, "scripts", "restart-cloudflare-tunnel.sh");
+    if (existsSync(helper)) {
+      try {
+        return await runProcessUntilExit(environment.SHELL || "/bin/sh", [helper, "auto"], {
+          cwd: environment.DEVBOX_PROJECT_ROOT,
+          env: environment,
+          encoding: "utf8",
+          timeout: timeoutSeconds * 1000,
+          maxBuffer: 4 * 1024 * 1024,
+        });
+      } catch (error) {
+        // If the tunnel was not installed through Devbox's known service
+        // managers, fall back to the ordinary runtime restart below. Preserve
+        // the helper failure as context in the final stderr when possible.
+        environment.DEVBOX_TUNNEL_RESTART_FALLBACK_REASON = String(error.stderr ?? error.message ?? "");
+      }
+    }
+  }
+
   return runProcessUntilExit(process.execPath, [path.join(environment.DEVBOX_PROJECT_ROOT, "bin", "devbox.js"), "restart"], {
     cwd: environment.DEVBOX_PROJECT_ROOT,
     env: { ...environment, DEVBOX_RUNTIME_MODE: selectedRuntime },
@@ -715,6 +738,7 @@ const createPaths = (projectRoot) => {
     log: path.join(guardianDir, "guardian.log"),
     repairPolicy: path.join(guardianDir, "repair-policy.json"),
     lastRepair: path.join(guardianDir, "last-repair.json"),
+    startupState: path.join(runDir, "startup-state.json"),
   };
 };
 
@@ -760,6 +784,8 @@ const main = async () => {
   let lastRepairAtMs = 0;
   let repairPolicy = await readJson(paths.repairPolicy, {});
   let mcpElevationCache = { pid: null, elevated: null };
+  let lastCloudflaredSample = { key: null, metrics: null };
+  let lastDeferredStartupAttemptId = null;
   let lastHeartbeatState = null;
   let heartbeatExtra = {};
 
@@ -768,15 +794,21 @@ const main = async () => {
   };
 
   const probe = async () => {
-    const [environment, settingsValue, desiredValue] = await Promise.all([
+    const [environment, settingsValue, desiredValue, startupStateValue] = await Promise.all([
       loadGuardianEnv(options.projectRoot),
       readJson(paths.settings, {}),
       readJson(paths.desired, { ShouldRun: true, Source: "devbox-guardian.mjs" }),
+      readJson(paths.startupState, null),
     ]);
     environment.DEVBOX_PROJECT_ROOT = options.projectRoot;
     const settings = settingsValue ?? {};
     const desired = desiredValue ?? { ShouldRun: true };
     const shouldRun = desired.ShouldRun !== false;
+    const startupPid = Number.parseInt(startupStateValue?.ProcessId ?? "", 10);
+    const startupActivity = classifyStartupActivity({
+      startupState: startupStateValue,
+      processAlive: Number.isInteger(startupPid) && startupPid > 0 ? isProcessAlive(startupPid) : false,
+    });
     const port = Number.parseInt(settings.Port ?? environment.PORT ?? "8100", 10) || 8100;
     const publicBaseUrl = normalizePublicUrl(settings.PublicBaseUrl || environment.PUBLIC_BASE_URL || environment.CLOUDFLARED_PUBLIC_HOSTNAME);
     const publicEnabled = settings.Public === true || Boolean(publicBaseUrl);
@@ -851,12 +883,39 @@ const main = async () => {
     const cloudflaredMetrics = publicEnabled && tunnelRunning !== false
       ? await readCloudflaredMetrics(environment)
       : null;
+    const cloudflaredSampleKey = hostTunnelPid
+      ? `pid:${hostTunnelPid}`
+      : selectedRuntime === "docker"
+        ? `docker:${settings.CloudflaredContainerName || environment.CLOUDFLARED_CONTAINER_NAME || "chatgpt-devbox-cloudflared"}`
+        : "externally-managed";
+    const previousCloudflaredMetrics = lastCloudflaredSample.key === cloudflaredSampleKey
+      ? lastCloudflaredSample.metrics
+      : null;
+    const cloudflaredMetricsDelta = deriveCloudflaredMetricDeltas({
+      previous: previousCloudflaredMetrics,
+      current: cloudflaredMetrics,
+    });
+    if (cloudflaredMetrics) {
+      lastCloudflaredSample = { key: cloudflaredSampleKey, metrics: cloudflaredMetrics };
+    } else if (tunnelRunning === false) {
+      lastCloudflaredSample = { key: null, metrics: null };
+    }
+    const tunnelTransport = classifyTunnelTransport({
+      publicEnabled,
+      tunnelRunning,
+      metrics: cloudflaredMetrics,
+    });
     const optionalDegradations = [];
     if (publicEnabled && cloudflaredMetrics && cloudflaredMetrics.Reachable === false) {
       optionalDegradations.push("cloudflared metrics endpoint is unavailable");
     }
     if (publicEnabled && publicHealth && tunnelRunning === null) {
       optionalDegradations.push("public endpoint is healthy but the tunnel is externally managed");
+    }
+    if (cloudflaredMetricsDelta?.QuicClosedConnections > 0) {
+      optionalDegradations.push(
+        `cloudflared observed ${cloudflaredMetricsDelta.QuicClosedConnections} newly closed QUIC connection(s) since the previous probe`,
+      );
     }
     const classified = classifyReadiness({
       shouldRun,
@@ -866,6 +925,7 @@ const main = async () => {
       publicEnabled,
       publicHealth,
       tunnelRunning,
+      tunnelTransportHealthy: tunnelTransport.Healthy,
       dockerReady,
       devboxContainerRunning,
       optionalDegradations,
@@ -890,12 +950,19 @@ const main = async () => {
       },
       RuntimeMode: runtimeMode,
       SelectedRuntime: selectedRuntime,
+      StartupState: startupStateValue,
+      StartupInProgress: startupActivity.Active,
+      StartupActivity: startupActivity,
       DockerProbePerformed: selectedRuntime === "docker" && shouldRun,
       DockerReady: dockerReady,
       DevboxRunning: devboxContainerRunning,
       CloudflaredRunning: tunnelRunning,
       HostCloudflaredProcessId: hostTunnelPid && isProcessAlive(hostTunnelPid) ? hostTunnelPid : null,
       CloudflaredMetrics: cloudflaredMetrics,
+      CloudflaredMetricsDelta: cloudflaredMetricsDelta,
+      TunnelTransportHealthy: tunnelTransport.Healthy,
+      TunnelTransportDegraded: tunnelTransport.Degraded,
+      TunnelTransportReasons: tunnelTransport.Reasons,
       McpProcessId: mcpProcess.pid,
       McpElevated: mcpElevated,
       RequireMcpElevated: requireMcpElevated,
@@ -917,6 +984,8 @@ const main = async () => {
     IsHealthy: state?.IsHealthy ?? false,
     SelectedRuntime: state?.SelectedRuntime ?? null,
     McpProcessId: state?.McpProcessId ?? null,
+    StartupInProgress: state?.StartupInProgress ?? false,
+    StartupPhase: state?.StartupActivity?.Phase ?? null,
     Readiness: state?.Readiness ?? null,
     Reasons: state?.Reasons ?? [],
     ...extra,
@@ -955,7 +1024,7 @@ const main = async () => {
     let commandElapsedMs = 0;
     let stdout = "";
     let stderr = "";
-    const repairScope = process.platform === "win32" ? selectRepairScope(state) : "full";
+    const repairScope = selectRepairScope(state);
     const repairHeartbeat = setInterval(() => {
       void writeJsonAtomic(paths.heartbeat, {
         GuardianVersion: 2,
@@ -1074,7 +1143,19 @@ const main = async () => {
       await publishState(state);
       if (!state.DesiredState.ShouldRun || state.IsHealthy) {
         unhealthyCount = 0;
+        lastDeferredStartupAttemptId = null;
+      } else if (state.StartupInProgress) {
+        unhealthyCount = 0;
+        const attemptId = state.StartupActivity?.AttemptId ?? "unknown";
+        if (lastDeferredStartupAttemptId !== attemptId) {
+          await log(
+            "INFO",
+            `startup in progress; deferring repair attempt=${attemptId} pid=${state.StartupActivity?.ProcessId ?? "unknown"} phase=${state.StartupActivity?.Phase ?? "unknown"}`,
+          );
+          lastDeferredStartupAttemptId = attemptId;
+        }
       } else {
+        lastDeferredStartupAttemptId = null;
         unhealthyCount += 1;
         if (unhealthyCount === 1) {
           await log("WARN", `unhealthy (${state.SelectedRuntime}): ${state.Reasons.join("; ")}`);

--- a/scripts/install-cloudflare-tunnel.sh
+++ b/scripts/install-cloudflare-tunnel.sh
@@ -98,6 +98,12 @@ HOSTNAME=${CLOUDFLARED_PUBLIC_HOSTNAME:-$(read_env_value CLOUDFLARED_PUBLIC_HOST
 PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-$(read_env_value PUBLIC_BASE_URL)}
 PORT=${PORT:-$(read_env_value PORT)}
 PORT=${PORT:-8100}
+EDGE_IP_VERSION=${CLOUDFLARED_EDGE_IP_VERSION:-$(read_env_value CLOUDFLARED_EDGE_IP_VERSION)}
+EDGE_IP_VERSION=${EDGE_IP_VERSION:-auto}
+case "$EDGE_IP_VERSION" in
+  auto|4|6) ;;
+  *) fail "CLOUDFLARED_EDGE_IP_VERSION must be one of: auto, 4, 6" ;;
+esac
 
 if [ -z "$TOKEN" ]; then
   cat >&2 <<EOF
@@ -164,7 +170,7 @@ EOF
     mkdir -p "$SERVICE_DIR/log"
     cat > "$SERVICE_DIR/run" <<EOF
 #!/data/data/com.termux/files/usr/bin/sh
-exec "$CLOUDFLARED" tunnel --no-autoupdate --metrics "$METRICS_ADDRESS" run --token-file "$TOKEN_FILE"
+exec "$CLOUDFLARED" tunnel --no-autoupdate --metrics "$METRICS_ADDRESS" --edge-ip-version "$EDGE_IP_VERSION" run --token-file "$TOKEN_FILE"
 EOF
     chmod 700 "$SERVICE_DIR/run"
     if [ -x "$PREFIX/share/termux-services/svlogger" ]; then
@@ -198,7 +204,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart="$CLOUDFLARED" tunnel --no-autoupdate --metrics "$METRICS_ADDRESS" run --token-file "$TOKEN_FILE"
+ExecStart="$CLOUDFLARED" tunnel --no-autoupdate --metrics "$METRICS_ADDRESS" --edge-ip-version "$EDGE_IP_VERSION" run --token-file "$TOKEN_FILE"
 Restart=on-failure
 RestartSec=5
 
@@ -230,6 +236,7 @@ EOF
     CF_XML=$(xml_escape "$CLOUDFLARED")
     TOKEN_XML=$(xml_escape "$TOKEN_FILE")
     METRICS_XML=$(xml_escape "$METRICS_ADDRESS")
+    EDGE_IP_XML=$(xml_escape "$EDGE_IP_VERSION")
     OUT_XML=$(xml_escape "$RUN_DIR/cloudflared-launchd.stdout.log")
     ERR_XML=$(xml_escape "$RUN_DIR/cloudflared-launchd.stderr.log")
     cat > "$PLIST" <<EOF
@@ -240,6 +247,7 @@ EOF
   <key>ProgramArguments</key><array>
     <string>$CF_XML</string><string>tunnel</string><string>--no-autoupdate</string>
     <string>--metrics</string><string>$METRICS_XML</string>
+    <string>--edge-ip-version</string><string>$EDGE_IP_XML</string>
     <string>run</string><string>--token-file</string><string>$TOKEN_XML</string>
   </array>
   <key>RunAtLoad</key><true/>
@@ -270,7 +278,7 @@ EOF
   foreground)
     log "Starting cloudflared in the foreground. Press Ctrl-C to stop it."
     log "For persistent setup see: $DOC_URL"
-    exec "$CLOUDFLARED" tunnel --no-autoupdate --metrics "$METRICS_ADDRESS" run --token-file "$TOKEN_FILE"
+    exec "$CLOUDFLARED" tunnel --no-autoupdate --metrics "$METRICS_ADDRESS" --edge-ip-version "$EDGE_IP_VERSION" run --token-file "$TOKEN_FILE"
     ;;
 
   *) fail "unknown mode '$MODE'; expected auto, systemd, launchd, termux, or foreground" ;;
@@ -278,6 +286,7 @@ esac
 
 log "Tunnel token is stored with user-only permissions at: $TOKEN_FILE"
 log "Expected origin: http://127.0.0.1:$PORT"
+log "Cloudflare edge IP selection: $EDGE_IP_VERSION"
 [ -n "$PUBLIC_BASE_URL" ] && log "Configured public MCP base URL: $PUBLIC_BASE_URL"
 log "If the hostname does not resolve/reach Devbox, confirm the Cloudflare Tunnel public-hostname route targets http://127.0.0.1:$PORT."
 log "Full troubleshooting guide: $DOC_URL"

--- a/scripts/restart-cloudflare-tunnel.sh
+++ b/scripts/restart-cloudflare-tunnel.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+MODE=${1:-auto}
+SERVICE_NAME=devbox-cloudflared
+LAUNCHD_LABEL=com.adybag14.devbox.cloudflared
+
+log() { printf '%s
+' "$*"; }
+fail() { printf 'ERROR: %s
+' "$*" >&2; exit 3; }
+
+is_termux() {
+  [ -n "${TERMUX_VERSION:-}" ] || case "${PREFIX:-}" in *com.termux/files/usr*) return 0 ;; *) return 1 ;; esac
+}
+
+restart_termux() {
+  command -v sv >/dev/null 2>&1 || return 1
+  sv status "$SERVICE_NAME" >/dev/null 2>&1 || return 1
+  sv restart "$SERVICE_NAME"
+  log "Restarted Termux Cloudflare service: $SERVICE_NAME"
+}
+
+restart_launchd() {
+  command -v launchctl >/dev/null 2>&1 || return 1
+  domain="gui/$(id -u)"
+  launchctl print "$domain/$LAUNCHD_LABEL" >/dev/null 2>&1 || return 1
+  launchctl kickstart -k "$domain/$LAUNCHD_LABEL"
+  log "Restarted macOS Cloudflare LaunchAgent: $LAUNCHD_LABEL"
+}
+
+restart_systemd() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  systemctl --user status "$SERVICE_NAME.service" >/dev/null 2>&1 || return 1
+  systemctl --user restart "$SERVICE_NAME.service"
+  log "Restarted Linux Cloudflare user service: $SERVICE_NAME.service"
+}
+
+case "$MODE" in
+  auto)
+    if is_termux && restart_termux; then exit 0; fi
+    case "$(uname -s 2>/dev/null || true)" in
+      Darwin) if restart_launchd; then exit 0; fi ;;
+      Linux) if restart_systemd; then exit 0; fi ;;
+    esac
+    ;;
+  termux) restart_termux && exit 0 ;;
+  launchd) restart_launchd && exit 0 ;;
+  systemd) restart_systemd && exit 0 ;;
+  *) fail "unknown mode '$MODE'; expected auto, termux, launchd, or systemd" ;;
+esac
+
+fail "no managed Devbox Cloudflare tunnel service was found. Re-run scripts/install-cloudflare-tunnel.sh auto or inspect $ROOT_DIR/docs/CLOUDFLARE_TUNNEL.md"

--- a/setup-tui/CMakeLists.txt
+++ b/setup-tui/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(devbox_tui VERSION 0.4.1 LANGUAGES CXX)
+project(devbox_tui VERSION 0.4.2 LANGUAGES CXX)
 
 add_executable(devbox-tui src/main.cpp)
 target_compile_features(devbox-tui PRIVATE cxx_std_17)

--- a/setup-tui/src/main.cpp
+++ b/setup-tui/src/main.cpp
@@ -26,7 +26,7 @@ namespace fs = std::filesystem;
 
 namespace {
 
-constexpr const char* kVersion = "0.4.1";
+constexpr const char* kVersion = "0.4.2";
 constexpr const char* kRepoUrl = "https://github.com/adybag14-cyber/devbox.git";
 
 struct Theme {

--- a/src/guardian-core.js
+++ b/src/guardian-core.js
@@ -100,12 +100,98 @@ export const selectRepairScope = (state = {}) => {
   return publicOnlyFailure ? "public-tunnel" : "full";
 };
 
+export const classifyStartupActivity = ({
+  startupState = null,
+  processAlive = false,
+  nowMs = Date.now(),
+  maxAgeMs = 300000,
+} = {}) => {
+  const status = String(startupState?.Status ?? "").trim().toLowerCase();
+  const pid = Number.parseInt(startupState?.ProcessId ?? "", 10);
+  const updatedAtMs = Date.parse(startupState?.UpdatedAtUtc ?? "");
+  const ageMs = Number.isFinite(updatedAtMs) ? Math.max(0, nowMs - updatedAtMs) : null;
+  const fresh = ageMs !== null && ageMs <= Math.max(1000, maxAgeMs);
+  const active = status === "running" && Number.isInteger(pid) && pid > 0 && processAlive === true && fresh;
+
+  return {
+    Active: active,
+    Stale: status === "running" && !active,
+    ProcessId: Number.isInteger(pid) && pid > 0 ? pid : null,
+    Phase: startupState?.Phase ?? null,
+    Status: status || null,
+    AttemptId: startupState?.AttemptId ?? null,
+    UpdatedAtUtc: startupState?.UpdatedAtUtc ?? null,
+    AgeMs: ageMs,
+  };
+};
+
+export const classifyTunnelTransport = ({
+  publicEnabled = false,
+  tunnelRunning = null,
+  metrics = null,
+} = {}) => {
+  if (!publicEnabled || tunnelRunning === false || !metrics || metrics.Reachable !== true) {
+    return {
+      Healthy: null,
+      Degraded: false,
+      Reasons: [],
+    };
+  }
+
+  const reasons = [];
+  const rawHaConnections = metrics.HaConnections;
+  if (rawHaConnections === null || rawHaConnections === undefined) {
+    return {
+      Healthy: null,
+      Degraded: false,
+      Reasons: [],
+    };
+  }
+  const haConnections = Number(rawHaConnections);
+  if (Number.isFinite(haConnections) && haConnections <= 0) {
+    reasons.push("cloudflared has no active HA connections");
+  }
+
+  return {
+    Healthy: Number.isFinite(haConnections) ? reasons.length === 0 : null,
+    Degraded: reasons.length > 0,
+    Reasons: reasons,
+  };
+};
+
+export const deriveCloudflaredMetricDeltas = ({ previous = null, current = null } = {}) => {
+  if (!previous || !current || current.Reachable !== true || previous.Reachable !== true) {
+    return null;
+  }
+
+  const delta = (name) => {
+    const rawBefore = previous[name];
+    const rawAfter = current[name];
+    if (rawBefore === null || rawBefore === undefined || rawAfter === null || rawAfter === undefined) return null;
+    const before = Number(rawBefore);
+    const after = Number(rawAfter);
+    if (!Number.isFinite(before) || !Number.isFinite(after) || after < before) return null;
+    return after - before;
+  };
+
+  return {
+    RequestErrors: delta("RequestErrors"),
+    TotalRequests: delta("TotalRequests"),
+    QuicClosedConnections: delta("QuicClosedConnections"),
+  };
+};
+
 export const resolveFailureThreshold = ({ state = {}, configuredThreshold = 3 } = {}) => {
   const configured = Math.max(1, Number.parseInt(configuredThreshold, 10) || 1);
   // A failed localhost health probe means the MCP itself is unavailable or
-  // hung, so recover after two observations. Public-only tunnel failures keep
-  // the configured threshold to tolerate normal edge/QUIC reconnect churn.
-  return state.LocalHealth === false ? Math.min(2, configured) : configured;
+  // hung, so recover after two observations. A confirmed cloudflared transport
+  // collapse (for example HA connections reaching zero) also gets the faster
+  // threshold, but still selects a tunnel-only repair while MCP stays healthy.
+  // Generic public-health failures retain the configured threshold so normal
+  // edge/QUIC reconnect churn does not trigger unnecessary repair.
+  return state.LocalHealth === false || state.TunnelTransportDegraded === true
+    ? Math.min(2, configured)
+    : configured;
 };
 
 export const classifyReadiness = ({
@@ -116,6 +202,7 @@ export const classifyReadiness = ({
   publicEnabled = false,
   publicHealth = null,
   tunnelRunning = null,
+  tunnelTransportHealthy = null,
   dockerReady = null,
   devboxContainerRunning = null,
   optionalDegradations = [],
@@ -137,7 +224,7 @@ export const classifyReadiness = ({
   }
   const mcpHealthy = Boolean(mcpProcessRunning && localHealth && elevationOk);
   const publicTunnelHealthy = publicEnabled
-    ? Boolean(publicHealth && tunnelRunning !== false)
+    ? Boolean(publicHealth && tunnelRunning !== false && tunnelTransportHealthy !== false)
     : null;
   const selectedRuntimeHealthy = runtime === "docker"
     ? Boolean(dockerReady && devboxContainerRunning)
@@ -160,6 +247,9 @@ export const classifyReadiness = ({
     }
     if (publicEnabled && tunnelRunning === false) {
       reasons.push("public tunnel is not running");
+    }
+    if (publicEnabled && tunnelTransportHealthy === false) {
+      reasons.push("cloudflared transport has no active HA connections");
     }
     if (publicEnabled && !publicHealth) {
       reasons.push("public health check failed");

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -14,6 +14,9 @@ export const getLauncherPaths = (root = projectRoot) => {
     runDir,
     pidFile: path.join(runDir, "devbox.pid"),
     logFile: path.join(runDir, "devbox.log"),
+    managedPidFile: path.join(runDir, "mcp.pid"),
+    managedStdoutLogFile: path.join(runDir, "mcp.stdout.log"),
+    managedStderrLogFile: path.join(runDir, "mcp.stderr.log"),
     guardianDesiredStateFile: path.join(runDir, "guardian.desired-state.json"),
   };
 };
@@ -97,6 +100,20 @@ const ensureRunDir = async (runDir) => {
   await mkdir(runDir, { recursive: true });
 };
 
+export const probeServerHealth = async ({ url = buildServerUrl(), timeoutMs = 1000 } = {}) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(100, timeoutMs));
+  timer.unref?.();
+  try {
+    const response = await fetch(`${String(url).replace(/\/$/u, "")}/healthz`, { signal: controller.signal });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
 const writeGuardianDesiredState = async (paths, shouldRun, source) => {
   await writeFile(paths.guardianDesiredStateFile, `${JSON.stringify({
     ShouldRun: shouldRun,
@@ -105,22 +122,60 @@ const writeGuardianDesiredState = async (paths, shouldRun, source) => {
   }, null, 2)}\n`, "utf8");
 };
 
-export const getServerStatus = async (root = projectRoot) => {
+export const getServerStatus = async (root = projectRoot, { url = buildServerUrl(), healthTimeoutMs = 1000 } = {}) => {
   const paths = getLauncherPaths(root);
   await ensureRunDir(paths.runDir);
-  const pid = await readPidFile(paths.pidFile);
-  const running = isProcessAlive(pid);
 
-  if (!running && pid !== null) {
+  const launcherPid = await readPidFile(paths.pidFile);
+  const launcherAlive = isProcessAlive(launcherPid);
+  if (!launcherAlive && launcherPid !== null) {
     await rm(paths.pidFile, { force: true });
+  }
+  if (launcherAlive) {
+    const healthy = await probeServerHealth({ url, timeoutMs: healthTimeoutMs });
+    return {
+      running: true,
+      healthy,
+      pid: launcherPid,
+      pidFile: paths.pidFile,
+      logFile: paths.logFile,
+      stderrLogFile: paths.logFile,
+      manager: "portable-launcher",
+      managedExternally: false,
+      url,
+    };
+  }
+
+  // Windows Guardian/PowerShell startup owns run/mcp.pid instead of devbox.pid.
+  // Recognize that process for status/start de-duplication, but never assume
+  // ownership of it for stop/restart operations.
+  const managedPid = await readPidFile(paths.managedPidFile);
+  const managedAlive = isProcessAlive(managedPid);
+  if (managedAlive) {
+    const healthy = await probeServerHealth({ url, timeoutMs: healthTimeoutMs });
+    return {
+      running: true,
+      healthy,
+      pid: managedPid,
+      pidFile: paths.managedPidFile,
+      logFile: paths.managedStdoutLogFile,
+      stderrLogFile: paths.managedStderrLogFile,
+      manager: "managed-mcp",
+      managedExternally: true,
+      url,
+    };
   }
 
   return {
-    running,
-    pid: running ? pid : null,
+    running: false,
+    healthy: false,
+    pid: null,
     pidFile: paths.pidFile,
     logFile: paths.logFile,
-    url: buildServerUrl(),
+    stderrLogFile: paths.logFile,
+    manager: null,
+    managedExternally: false,
+    url,
   };
 };
 
@@ -130,6 +185,11 @@ export const startServerProcess = async (root = projectRoot) => {
   await writeGuardianDesiredState(paths, true, "devbox start");
   const status = await getServerStatus(root);
   if (status.running) {
+    if (status.healthy === false) {
+      throw new Error(
+        `A Devbox MCP process is already running as PID ${status.pid} (${status.manager}) but its health endpoint is not responding; refusing to start a competing server.`,
+      );
+    }
     return { ...status, started: false };
   }
 
@@ -175,12 +235,20 @@ export const startServerProcess = async (root = projectRoot) => {
   };
 };
 
-export const stopServerProcess = async (root = projectRoot) => {
+export const stopServerProcess = async (root = projectRoot, statusOptions = {}) => {
   const paths = getLauncherPaths(root);
   const pid = await readPidFile(paths.pidFile);
   if (!isProcessAlive(pid)) {
     await rm(paths.pidFile, { force: true });
-    const status = await getServerStatus(root);
+    const status = await getServerStatus(root, statusOptions);
+    if (status.managedExternally) {
+      return {
+        ...status,
+        stopped: false,
+        stopRefused: true,
+        note: `PID ${status.pid} is owned by the managed MCP lifecycle; use Guardian or the platform service/start-stop scripts rather than the portable launcher.`,
+      };
+    }
     await writeGuardianDesiredState(paths, false, "devbox stop");
     return { ...status, stopped: false };
   }
@@ -224,7 +292,10 @@ export const runLauncher = async (argv = process.argv.slice(2), root = projectRo
   }
 
   if (parsed.command === "restart") {
-    await stopServerProcess(root);
+    const stopped = await stopServerProcess(root);
+    if (stopped.stopRefused) {
+      throw new Error(stopped.note);
+    }
     return { command: "restart", ...(await startServerProcess(root)) };
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -69,6 +69,15 @@ const httpUsageLogPath = path.join(runDir, "http-usage.jsonl");
 const logRotationChains = new Map();
 const activeMcpRequestControllers = new Map();
 const guardianStatePath = path.join(runDir, "guardian", "state.json");
+const startupStatePath = path.join(runDir, "startup-state.json");
+
+const readStartupStatusSnapshot = async () => {
+  try {
+    return JSON.parse(await readFile(startupStatePath, "utf8"));
+  } catch {
+    return null;
+  }
+};
 
 const readGuardianStatusSnapshot = async () => {
   try {
@@ -81,6 +90,10 @@ const readGuardianStatusSnapshot = async () => {
       publicTunnelHealthy: state.PublicTunnelHealthy ?? null,
       cloudflaredRunning: state.CloudflaredRunning ?? null,
       cloudflaredMetrics: state.CloudflaredMetrics ?? null,
+      cloudflaredMetricsDelta: state.CloudflaredMetricsDelta ?? null,
+      tunnelTransportHealthy: state.TunnelTransportHealthy ?? null,
+      tunnelTransportDegraded: state.TunnelTransportDegraded ?? false,
+      tunnelTransportReasons: state.TunnelTransportReasons ?? [],
       readiness: state.Readiness ?? null,
       reasons: state.Reasons ?? [],
     };
@@ -101,6 +114,10 @@ const outputSchema = {
 
 const MAX_USAGE_PREVIEW_CHARS = 240;
 export const MAX_TOOL_SUMMARY_CHARS = 4096;
+export const SYNC_MCP_TIMEOUT_SECONDS = 90;
+const syncCommandTimeoutSchema = () => z.number().int().min(1).max(SYNC_MCP_TIMEOUT_SECONDS).default(SYNC_MCP_TIMEOUT_SECONDS).describe(
+  `Synchronous command timeout in seconds (maximum ${SYNC_MCP_TIMEOUT_SECONDS}). Use devbox_exec_start for longer work so upstream MCP request deadlines cannot cancel it.`,
+);
 const COMMAND_OUTPUT_LIMIT_CHARS = config.maxTextOutputChars === null
   ? config.maxCommandOutputChars
   : Math.min(config.maxTextOutputChars, config.maxCommandOutputChars);
@@ -662,6 +679,7 @@ const buildServer = ({ requestSignal } = {}) => {
           devboxWorkspacePath: config.devboxWorkspacePath,
           hostExecEnabled: config.enableHostExec,
           guardian: await readGuardianStatusSnapshot(),
+          startup: await readStartupStatusSnapshot(),
         };
 
         if (info.running) {
@@ -781,12 +799,12 @@ const buildServer = ({ requestSignal } = {}) => {
       {
         title: `Run Read-Only Shell Command In ${runtimeTitle}`,
         description: isDockerRuntime
-          ? "Prefer this for inspection-only shell work such as ls, find, cat, sed -n, rg, git diff, git log, or config inspection. It runs in the long-lived devbox container; read-only behavior is advisory so Docker clients do not strand during disposable-container probes."
-          : `Prefer this for inspection-only shell work such as ls, find, cat, sed -n, rg, git diff, git log, or config inspection. In ${runtimeLabel} mode this runs directly on the host shell, so read-only behavior is advisory rather than sandbox-enforced.`,
+          ? `Prefer this for inspection-only shell work such as ls, find, cat, sed -n, rg, git diff, git log, or config inspection. It runs in the long-lived devbox container; read-only behavior is advisory. Synchronous calls are capped at ${SYNC_MCP_TIMEOUT_SECONDS}s; use devbox_exec_start for longer work.`
+          : `Prefer this for inspection-only shell work such as ls, find, cat, sed -n, rg, git diff, git log, or config inspection. In ${runtimeLabel} mode this runs directly on the host shell, so read-only behavior is advisory rather than sandbox-enforced. Synchronous calls are capped at ${SYNC_MCP_TIMEOUT_SECONDS}s; use devbox_exec_start for longer work.`,
         inputSchema: {
           command: z.string().min(1).describe(`Read-only shell command to run inside the ${runtimeLabel}.`),
           working_dir: z.string().default(config.devboxWorkspacePath).describe(`Working directory inside the ${runtimeLabel}.`),
-          timeout_seconds: z.number().int().min(1).max(7200).default(900).describe("Command timeout in seconds."),
+          timeout_seconds: syncCommandTimeoutSchema(),
           user: z.string().default(config.devboxDefaultUser).describe(isDockerRuntime ? "Linux user inside the disposable read-only container." : `Host user hint for ${runtimeLabel} mode.`),
         },
         outputSchema,
@@ -816,12 +834,12 @@ const buildServer = ({ requestSignal } = {}) => {
       {
         title: `Run Mutating Shell Command In ${runtimeTitle}`,
         description: isDockerRuntime
-          ? "Use this only when the shell command needs side effects such as writing files, building artifacts, installing packages, changing git state, or otherwise mutating the devbox or workspace. Prefer devbox_exec_readonly for inspection, search, and file-reading commands."
-          : `Use this when the shell command needs side effects such as writing files, building artifacts, installing packages, changing git state, or otherwise mutating the ${runtimeLabel}. Prefer devbox_exec_readonly for inspection, search, and file-reading commands.`,
+          ? `Use this only when the shell command needs side effects such as writing files, building artifacts, installing packages, changing git state, or otherwise mutating the devbox or workspace. Prefer devbox_exec_readonly for inspection. Synchronous calls are capped at ${SYNC_MCP_TIMEOUT_SECONDS}s; use devbox_exec_start for builds or other longer work.`
+          : `Use this when the shell command needs side effects such as writing files, building artifacts, installing packages, changing git state, or otherwise mutating the ${runtimeLabel}. Prefer devbox_exec_readonly for inspection. Synchronous calls are capped at ${SYNC_MCP_TIMEOUT_SECONDS}s; use devbox_exec_start for builds or other longer work.`,
         inputSchema: {
           command: z.string().min(1).describe(`Shell command to run inside the ${runtimeLabel}.`),
           working_dir: z.string().default(config.devboxWorkspacePath).describe(`Working directory inside the ${runtimeLabel}.`),
-          timeout_seconds: z.number().int().min(1).max(7200).default(900).describe("Command timeout in seconds."),
+          timeout_seconds: syncCommandTimeoutSchema(),
           user: z.string().default(config.devboxDefaultUser).describe(isDockerRuntime ? "Linux user inside the devbox container." : `Host user hint for ${runtimeLabel} mode.`),
         },
         outputSchema,
@@ -1304,7 +1322,7 @@ const buildServer = ({ requestSignal } = {}) => {
         inputSchema: {
           command: z.string().min(1).describe(`Command to run on the ${hostTitle.toLowerCase()}.`),
           working_dir: z.string().default(config.hostDefaultWorkdir).describe(`Working directory on the ${hostTitle.toLowerCase()}.`),
-          timeout_seconds: z.number().int().min(1).max(7200).default(300).describe("Command timeout in seconds."),
+          timeout_seconds: syncCommandTimeoutSchema(),
         },
         outputSchema,
       },
@@ -1435,7 +1453,7 @@ const buildServer = ({ requestSignal } = {}) => {
         inputSchema: {
           command: z.string().min(1).describe(`Command to run on the ${hostTitle.toLowerCase()}.`),
           working_dir: z.string().default(config.hostDefaultWorkdir).describe(`Working directory on the ${hostTitle.toLowerCase()}.`),
-          timeout_seconds: z.number().int().min(1).max(7200).default(900).describe("Command timeout in seconds."),
+          timeout_seconds: syncCommandTimeoutSchema(),
         },
         outputSchema,
       },
@@ -1455,7 +1473,7 @@ const buildServer = ({ requestSignal } = {}) => {
           program: z.string().min(1).describe("Program name or path. It must be allowed by HOST_PROGRAM_ALLOWLIST."),
           args: z.array(z.string()).default([]).describe("Argument list for the program."),
           working_dir: z.string().default(config.hostDefaultWorkdir).describe(`Working directory on the ${hostTitle.toLowerCase()}.`),
-          timeout_seconds: z.number().int().min(1).max(7200).default(300).describe("Command timeout in seconds."),
+          timeout_seconds: syncCommandTimeoutSchema(),
         },
         outputSchema,
       },
@@ -1475,7 +1493,7 @@ const buildServer = ({ requestSignal } = {}) => {
           program: z.string().min(1).describe("Program name or path. It must be allowed by HOST_PROGRAM_ALLOWLIST."),
           args: z.array(z.string()).default([]).describe("Argument list for the program."),
           working_dir: z.string().default(config.hostDefaultWorkdir).describe(`Working directory on the ${hostTitle.toLowerCase()}.`),
-          timeout_seconds: z.number().int().min(1).max(7200).default(900).describe("Command timeout in seconds."),
+          timeout_seconds: syncCommandTimeoutSchema(),
         },
         outputSchema,
       },

--- a/test/guardian-core.test.js
+++ b/test/guardian-core.test.js
@@ -4,6 +4,9 @@ import assert from "node:assert/strict";
 import {
   calculateRepairBackoffSeconds,
   classifyReadiness,
+  classifyStartupActivity,
+  classifyTunnelTransport,
+  deriveCloudflaredMetricDeltas,
   isRepairAllowed,
   resolveSelectedRuntime,
   resolveFailureThreshold,
@@ -162,4 +165,93 @@ test("local MCP health failures use a faster repair threshold than tunnel-only f
   assert.equal(resolveFailureThreshold({ state: { LocalHealth: false }, configuredThreshold: 1 }), 1);
   assert.equal(resolveFailureThreshold({ state: { LocalHealth: true }, configuredThreshold: 3 }), 3);
   assert.equal(resolveFailureThreshold({ state: { LocalHealth: null }, configuredThreshold: 4 }), 4);
+});
+
+
+test("cloudflared HA collapse is a required tunnel transport failure", () => {
+  const transport = classifyTunnelTransport({
+    publicEnabled: true,
+    tunnelRunning: true,
+    metrics: { Reachable: true, HaConnections: 0 },
+  });
+  assert.equal(transport.Healthy, false);
+  assert.equal(transport.Degraded, true);
+  assert.match(transport.Reasons.join("; "), /no active HA connections/i);
+
+  const state = classifyReadiness({
+    selectedRuntime: "host",
+    mcpProcessRunning: true,
+    localHealth: true,
+    publicEnabled: true,
+    publicHealth: true,
+    tunnelRunning: true,
+    tunnelTransportHealthy: transport.Healthy,
+  });
+  assert.equal(state.McpHealthy, true);
+  assert.equal(state.PublicTunnelHealthy, false);
+  assert.equal(state.NeedsRepair, true);
+  assert.match(state.Reasons.join("; "), /transport has no active HA/i);
+  assert.equal(selectRepairScope({ Settings: { Public: true }, ...state }), "public-tunnel");
+});
+
+test("cloudflared metrics deltas ignore counter resets and expose transport churn", () => {
+  assert.deepEqual(deriveCloudflaredMetricDeltas({
+    previous: { Reachable: true, RequestErrors: 10, TotalRequests: 100, QuicClosedConnections: 2 },
+    current: { Reachable: true, RequestErrors: 12, TotalRequests: 109, QuicClosedConnections: 5 },
+  }), { RequestErrors: 2, TotalRequests: 9, QuicClosedConnections: 3 });
+
+  assert.deepEqual(deriveCloudflaredMetricDeltas({
+    previous: { Reachable: true, RequestErrors: 12, TotalRequests: 109, QuicClosedConnections: 5 },
+    current: { Reachable: true, RequestErrors: 0, TotalRequests: 1, QuicClosedConnections: 0 },
+  }), { RequestErrors: null, TotalRequests: null, QuicClosedConnections: null });
+});
+
+test("confirmed tunnel transport collapse uses the faster repair threshold", () => {
+  assert.equal(resolveFailureThreshold({
+    state: { LocalHealth: true, TunnelTransportDegraded: true },
+    configuredThreshold: 4,
+  }), 2);
+  assert.equal(resolveFailureThreshold({
+    state: { LocalHealth: true, TunnelTransportDegraded: false },
+    configuredThreshold: 4,
+  }), 4);
+});
+
+
+test("startup activity requires a fresh live owner and expires safely", () => {
+  const now = Date.parse("2026-08-06T23:00:00.000Z");
+  const active = classifyStartupActivity({
+    startupState: {
+      Status: "running",
+      ProcessId: 4242,
+      Phase: "waiting-local-health",
+      AttemptId: "attempt-1",
+      UpdatedAtUtc: "2026-08-06T22:59:30.000Z",
+    },
+    processAlive: true,
+    nowMs: now,
+    maxAgeMs: 60000,
+  });
+  assert.equal(active.Active, true);
+  assert.equal(active.Stale, false);
+  assert.equal(active.ProcessId, 4242);
+  assert.equal(active.Phase, "waiting-local-health");
+
+  const dead = classifyStartupActivity({
+    startupState: { Status: "running", ProcessId: 4242, UpdatedAtUtc: "2026-08-06T22:59:30.000Z" },
+    processAlive: false,
+    nowMs: now,
+    maxAgeMs: 60000,
+  });
+  assert.equal(dead.Active, false);
+  assert.equal(dead.Stale, true);
+
+  const old = classifyStartupActivity({
+    startupState: { Status: "running", ProcessId: 4242, UpdatedAtUtc: "2026-08-06T22:50:00.000Z" },
+    processAlive: true,
+    nowMs: now,
+    maxAgeMs: 60000,
+  });
+  assert.equal(old.Active, false);
+  assert.equal(old.Stale, true);
 });

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 
 import { buildServerUrl, getLauncherPaths, getServerStatus, parseLauncherArgs, stopServerProcess, waitForServerReady } from "../src/launcher.js";
@@ -20,6 +20,8 @@ test("getLauncherPaths stores pid and log files under run/", () => {
   assert.equal(paths.runDir, path.join("/tmp/devbox-project", "run"));
   assert.equal(paths.pidFile, path.join("/tmp/devbox-project", "run", "devbox.pid"));
   assert.equal(paths.logFile, path.join("/tmp/devbox-project", "run", "devbox.log"));
+  assert.equal(paths.managedPidFile, path.join("/tmp/devbox-project", "run", "mcp.pid"));
+  assert.equal(paths.managedStdoutLogFile, path.join("/tmp/devbox-project", "run", "mcp.stdout.log"));
   assert.equal(paths.guardianDesiredStateFile, path.join("/tmp/devbox-project", "run", "guardian.desired-state.json"));
 });
 
@@ -65,6 +67,42 @@ test("status is read-only while stop records intentional-stop state", async () =
     assert.equal(desired.ShouldRun, false);
     assert.equal(desired.Source, "devbox stop");
   } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+
+test("status recognizes a healthy externally managed MCP without claiming stop ownership", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "devbox-managed-status-"));
+  const server = createServer((_request, response) => {
+    response.statusCode = 200;
+    response.end("ok");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.equal(typeof address, "object");
+  const url = `http://127.0.0.1:${address.port}`;
+
+  try {
+    const paths = getLauncherPaths(root);
+    await mkdir(paths.runDir, { recursive: true });
+    await writeFile(paths.managedPidFile, `${process.pid}\n`, "utf8");
+
+    const status = await getServerStatus(root, { url, healthTimeoutMs: 1000 });
+    assert.equal(status.running, true);
+    assert.equal(status.healthy, true);
+    assert.equal(status.pid, process.pid);
+    assert.equal(status.manager, "managed-mcp");
+    assert.equal(status.managedExternally, true);
+    assert.equal(status.pidFile, paths.managedPidFile);
+
+    const stop = await stopServerProcess(root, { url, healthTimeoutMs: 1000 });
+    assert.equal(stop.stopRefused, true);
+    assert.equal(stop.running, true);
+    assert.match(stop.note, /managed MCP lifecycle/i);
+    await assert.rejects(readFile(paths.guardianDesiredStateFile, "utf8"), { code: "ENOENT" });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/test/mcp-http.test.js
+++ b/test/mcp-http.test.js
@@ -563,6 +563,13 @@ test("async MCP jobs survive the request boundary and support status, logs, and 
   for (const name of ["devbox_exec_start", "devbox_job_status", "devbox_job_logs", "devbox_job_cancel"]) {
     assert.ok(names.has(name), `Expected async MCP tool ${name} to be registered.`);
   }
+  for (const name of ["devbox_exec", "devbox_exec_readonly", "host_exec", "windows_host_exec"]) {
+    const tool = (tools.tools || []).find((entry) => entry.name === name);
+    assert.equal(tool?.inputSchema?.properties?.timeout_seconds?.maximum, 90, `${name} should advertise the safe synchronous timeout ceiling.`);
+    assert.match(tool?.inputSchema?.properties?.timeout_seconds?.description ?? "", /devbox_exec_start/i);
+  }
+  const asyncTool = (tools.tools || []).find((entry) => entry.name === "devbox_exec_start");
+  assert.equal(asyncTool?.inputSchema?.properties?.timeout_seconds?.maximum, 86400);
 
   const started = await client.callTool({
     name: "devbox_exec_start",


### PR DESCRIPTION
Hardens Hermes/Devbox against the failure modes observed on the live Windows host: fail-fast single-owner startup, accurate scheduled-task lifetime/results, immediate MCP PID ownership and cleanup-on-failure, startup phase/deadline journaling, Guardian startup awareness, HA=0 tunnel-only recovery across platforms, Cloudflare edge IP selection, 90-second synchronous MCP ceiling with async jobs for longer work, and managed-MCP-aware portable status. Bumps setup/TUI to 0.4.2 and adds Windows lifecycle CI coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable startup deadlines and Cloudflare Edge IP selection (`auto`, IPv4, or IPv6).
  * Added tunnel restart support across Termux, macOS, and Linux.
  * Added richer status reporting for health, ownership, startup progress, tunnel transport, and diagnostics.
  * Synchronous command tools now enforce a 90-second limit, with longer tasks supported through background execution.

* **Bug Fixes**
  * Improved startup cleanup, lifecycle locking, process ownership, and recovery handling.
  * Prevented stopping externally managed processes and unhealthy duplicate launches.
  * Added faster recovery for confirmed tunnel transport failures.

* **Documentation**
  * Expanded Windows startup, Guardian, Cloudflare tunnel, and timeout guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->