### PR TITLE
fix: make Guardian recovery persist on Windows

### DIFF
--- a/scripts/Ensure-ChatGptDevboxGuardian.ps1
+++ b/scripts/Ensure-ChatGptDevboxGuardian.ps1
@@ -16,6 +16,7 @@ $powerShellResolver = Join-Path $PSScriptRoot 'Resolve-DevboxPowerShell.ps1'
 . $powerShellResolver
 $powerShellExe = Resolve-DevboxPowerShellExecutable
 $guardianScript = Join-Path $ProjectRoot 'scripts\Watch-ChatGptDevboxGuardian.ps1'
+$supervisorScript = Join-Path $ProjectRoot 'scripts\devbox-guardian.mjs'
 $guardianDir = Join-Path $ProjectRoot 'run\guardian'
 $guardianPidPath = Join-Path $guardianDir 'guardian.pid'
 $heartbeatPath = Join-Path $guardianDir 'heartbeat.json'
@@ -60,23 +61,29 @@ function Get-LiveGuardianProcess {
         }
     }
 
-    if (Test-Path $heartbeatPath) {
-        try {
-            $heartbeat = Get-Content -Path $heartbeatPath -Raw | ConvertFrom-Json
-            if ($heartbeat.PSObject.Properties['SupervisorPid'] -and ([string]$heartbeat.SupervisorPid) -match '^\d+$') {
-                $supervisor = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f [int]$heartbeat.SupervisorPid) -ErrorAction SilentlyContinue
-                if ($supervisor -and ([string]$supervisor.CommandLine) -match 'devbox-guardian\.mjs') {
-                    return $supervisor
-                }
-            }
-        } catch {
-        }
-    }
-
     $escapedScriptPath = [regex]::Escape($guardianScript)
     return Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
         Where-Object { ([string]$_.CommandLine) -match $escapedScriptPath } |
         Select-Object -First 1
+}
+
+function Get-LiveGuardianSupervisorProcess {
+    if (-not (Test-Path $heartbeatPath)) {
+        return $null
+    }
+    try {
+        $heartbeat = Get-Content -Path $heartbeatPath -Raw | ConvertFrom-Json
+        if (-not $heartbeat.PSObject.Properties['SupervisorPid'] -or ([string]$heartbeat.SupervisorPid) -notmatch '^\d+$') {
+            return $null
+        }
+        $supervisor = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f [int]$heartbeat.SupervisorPid) -ErrorAction SilentlyContinue
+        $escapedSupervisorPath = [regex]::Escape($supervisorScript)
+        if ($supervisor -and ([string]$supervisor.CommandLine) -match $escapedSupervisorPath -and ([string]$supervisor.CommandLine) -notmatch 'codex\.js|@openai/codex') {
+            return $supervisor
+        }
+    } catch {
+    }
+    return $null
 }
 
 function Test-GuardianSourceFresh {
@@ -216,6 +223,12 @@ if ($existing) {
 
 if (-not $existing) {
     Clear-StaleHeartbeatObservation
+    $orphanSupervisor = Get-LiveGuardianSupervisorProcess
+    if ($orphanSupervisor) {
+        Write-EnsureLog -Level 'WARN' -Message ("guardian watcher is missing; stopping orphan supervisor pid={0}" -f $orphanSupervisor.ProcessId)
+        Stop-Process -Id ([int]$orphanSupervisor.ProcessId) -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 1
+    }
 }
 
 if (-not (Test-Path $guardianScript)) {
@@ -229,7 +242,7 @@ $arguments = @(
     '-NonInteractive',
     '-ExecutionPolicy', 'Bypass',
     '-WindowStyle', 'Hidden',
-    '-File', $guardianScript
+    '-File', ('"{0}"' -f $guardianScript)
 )
 
 Write-EnsureLog -Message 'guardian not running; starting detached guardian process directly'
@@ -237,10 +250,11 @@ Start-Process -FilePath $powerShellExe -ArgumentList $arguments -WorkingDirector
 Start-Sleep -Seconds 4
 
 $started = Get-LiveGuardianProcess
-if (-not $started) {
-    Write-EnsureLog -Level 'ERROR' -Message 'guardian failed to start'
+$escapedWatcherPath = [regex]::Escape($guardianScript)
+if (-not $started -or ([string]$started.CommandLine) -notmatch $escapedWatcherPath) {
+    Write-EnsureLog -Level 'ERROR' -Message 'guardian watcher failed to start persistently'
     exit 1
 }
 
-Write-EnsureLog -Message ("guardian running pid={0}" -f $started.ProcessId)
+Write-EnsureLog -Message ("guardian watcher running pid={0}" -f $started.ProcessId)
 exit 0

--- a/scripts/Ensure-ChatGptDevboxGuardian.ps1
+++ b/scripts/Ensure-ChatGptDevboxGuardian.ps1
@@ -21,7 +21,6 @@ $guardianPidPath = Join-Path $guardianDir 'guardian.pid'
 $heartbeatPath = Join-Path $guardianDir 'heartbeat.json'
 $ensureLogPath = Join-Path $guardianDir 'ensure.log'
 $staleObservationPath = Join-Path $guardianDir 'ensure-stale-observation.json'
-$hiddenLauncher = Join-Path $PSScriptRoot 'Run-ChatGptDevboxGuardian.vbs'
 $guardianSourcePaths = @(
     $guardianScript,
     $powerShellResolver,
@@ -224,16 +223,17 @@ if (-not (Test-Path $guardianScript)) {
     exit 1
 }
 
-if (-not (Test-Path $hiddenLauncher)) {
-    Write-EnsureLog -Level 'ERROR' -Message ("hidden launcher missing: {0}" -f $hiddenLauncher)
-    exit 1
-}
+$arguments = @(
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy', 'Bypass',
+    '-WindowStyle', 'Hidden',
+    '-File', $guardianScript
+)
 
-$wscriptExe = Join-Path $env:WINDIR 'System32\wscript.exe'
-$arguments = @('//B', '//NoLogo', $hiddenLauncher)
-
-Write-EnsureLog -Message 'guardian not running; starting detached guardian process'
-Start-Process -FilePath $wscriptExe -ArgumentList $arguments -WindowStyle Hidden | Out-Null
+Write-EnsureLog -Message 'guardian not running; starting detached guardian process directly'
+Start-Process -FilePath $powerShellExe -ArgumentList $arguments -WorkingDirectory $ProjectRoot -WindowStyle Hidden | Out-Null
 Start-Sleep -Seconds 4
 
 $started = Get-LiveGuardianProcess

--- a/scripts/Install-ChatGptDevboxGuardian.ps1
+++ b/scripts/Install-ChatGptDevboxGuardian.ps1
@@ -307,6 +307,9 @@ $elevatedSettings = New-ScheduledTaskSettingsSet `
 Register-ScheduledTask -TaskName $elevatedStartTaskName -Action $elevatedAction -Settings $elevatedSettings -Principal $interactivePrincipal -Force | Out-Null
 
 & $powerShellExe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ensureScript | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "Guardian ensure process failed with exit code $LASTEXITCODE."
+}
 Start-Sleep -Seconds 5
 
 $taskInfo = @(

--- a/scripts/ci/run-windows-runtime-e2e.ps1
+++ b/scripts/ci/run-windows-runtime-e2e.ps1
@@ -60,6 +60,20 @@ try {
         if ($guardianTask.Settings.RestartCount -lt 3) { throw 'Guardian CI task restart policy is missing.' }
     }
 
+    $guardianPidPath = Join-Path $root 'run\guardian\guardian.pid'
+    $heartbeatPath = Join-Path $root 'run\guardian\heartbeat.json'
+    $guardianPid = [int](Get-Content $guardianPidPath -ErrorAction Stop | Select-Object -First 1)
+    $guardianProcess = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f $guardianPid) -ErrorAction SilentlyContinue
+    if (-not $guardianProcess -or ([string]$guardianProcess.CommandLine) -notmatch 'Watch-ChatGptDevboxGuardian\.ps1') {
+        throw 'Guardian installer did not leave a persistent Watch-ChatGptDevboxGuardian process running.'
+    }
+    $firstHeartbeat = Get-Content $heartbeatPath -Raw -ErrorAction Stop | ConvertFrom-Json
+    Start-Sleep -Seconds 12
+    $secondHeartbeat = Get-Content $heartbeatPath -Raw -ErrorAction Stop | ConvertFrom-Json
+    if ([DateTime]$secondHeartbeat.ObservedAtUtc -le [DateTime]$firstHeartbeat.ObservedAtUtc) {
+        throw 'Guardian heartbeat did not advance after installation.'
+    }
+
     & node (Join-Path $root 'scripts\devbox-guardian.mjs') --project-root $root --once --no-repair | Out-Host
     $state = Get-Content (Join-Path $root 'run\guardian\state.json') -Raw | ConvertFrom-Json
     if (-not $state.IsHealthy) { throw "Guardian did not classify native Rust runtime healthy: $($state.Reasons -join '; ')" }
@@ -69,6 +83,21 @@ try {
     Write-Host "Windows native lifecycle E2E passed: PID=$($state.McpProcessId) git=$($metadata.build.gitSha)"
 } finally {
     Remove-CiTasks
+    try {
+        $guardianPidPath = Join-Path $root 'run\guardian\guardian.pid'
+        if (Test-Path $guardianPidPath) {
+            $guardianPid = [int](Get-Content $guardianPidPath -ErrorAction SilentlyContinue | Select-Object -First 1)
+            if ($guardianPid -gt 0) { Stop-Process -Id $guardianPid -Force -ErrorAction SilentlyContinue }
+        }
+        $heartbeatPath = Join-Path $root 'run\guardian\heartbeat.json'
+        if (Test-Path $heartbeatPath) {
+            $heartbeat = Get-Content $heartbeatPath -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json
+            $supervisorPid = [int]$heartbeat.SupervisorPid
+            if ($supervisorPid -gt 0) { Stop-Process -Id $supervisorPid -Force -ErrorAction SilentlyContinue }
+        }
+        Remove-Item (Join-Path $root 'run\guardian\guardian.lock') -Force -ErrorAction SilentlyContinue
+        Remove-Item $guardianPidPath -Force -ErrorAction SilentlyContinue
+    } catch {}
     try { & (Join-Path $root 'scripts\Stop-ChatGptDevboxMcp.ps1') -ErrorAction SilentlyContinue | Out-Null } catch {}
     if ($hadEnv) {
         [IO.File]::WriteAllText($envPath, $envBackup, [Text.UTF8Encoding]::new($false))

--- a/scripts/ci/run-windows-runtime-e2e.ps1
+++ b/scripts/ci/run-windows-runtime-e2e.ps1
@@ -70,6 +70,13 @@ try {
     $firstHeartbeat = Get-Content $heartbeatPath -Raw -ErrorAction Stop | ConvertFrom-Json
     Start-Sleep -Seconds 12
     $secondHeartbeat = Get-Content $heartbeatPath -Raw -ErrorAction Stop | ConvertFrom-Json
+    $guardianProcess = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f $guardianPid) -ErrorAction SilentlyContinue
+    if (-not $guardianProcess -or ([string]$guardianProcess.CommandLine) -notmatch 'Watch-ChatGptDevboxGuardian\.ps1') {
+        throw 'Guardian wrapper did not remain running.'
+    }
+    if (-not $secondHeartbeat.PSObject.Properties['GuardianPid'] -or [int]$secondHeartbeat.GuardianPid -ne $guardianPid) {
+        throw 'Heartbeat is not associated with the persistent Guardian wrapper.'
+    }
     if ([DateTime]$secondHeartbeat.ObservedAtUtc -le [DateTime]$firstHeartbeat.ObservedAtUtc) {
         throw 'Guardian heartbeat did not advance after installation.'
     }
@@ -83,22 +90,51 @@ try {
     Write-Host "Windows native lifecycle E2E passed: PID=$($state.McpProcessId) git=$($metadata.build.gitSha)"
 } finally {
     Remove-CiTasks
+    $guardianPidPath = Join-Path $root 'run\guardian\guardian.pid'
     try {
-        $guardianPidPath = Join-Path $root 'run\guardian\guardian.pid'
         if (Test-Path $guardianPidPath) {
-            $guardianPid = [int](Get-Content $guardianPidPath -ErrorAction SilentlyContinue | Select-Object -First 1)
-            if ($guardianPid -gt 0) { Stop-Process -Id $guardianPid -Force -ErrorAction SilentlyContinue }
+            $guardianPid = [int](Get-Content $guardianPidPath -ErrorAction Stop | Select-Object -First 1)
+            if ($guardianPid -gt 0) {
+                $guardianProcess = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f $guardianPid) -ErrorAction SilentlyContinue
+                if ($guardianProcess -and ([string]$guardianProcess.CommandLine) -match 'Watch-ChatGptDevboxGuardian\.ps1') {
+                    Stop-Process -Id $guardianPid -Force -ErrorAction Stop
+                }
+            }
         }
-        $heartbeatPath = Join-Path $root 'run\guardian\heartbeat.json'
+    } catch {
+        Write-Warning ("Guardian wrapper cleanup failed: {0}" -f $_.Exception.Message)
+    }
+
+    $heartbeatPath = Join-Path $root 'run\guardian\heartbeat.json'
+    try {
         if (Test-Path $heartbeatPath) {
-            $heartbeat = Get-Content $heartbeatPath -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json
+            $heartbeat = Get-Content $heartbeatPath -Raw -ErrorAction Stop | ConvertFrom-Json
             $supervisorPid = [int]$heartbeat.SupervisorPid
-            if ($supervisorPid -gt 0) { Stop-Process -Id $supervisorPid -Force -ErrorAction SilentlyContinue }
+            if ($supervisorPid -gt 0) {
+                $supervisorProcess = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f $supervisorPid) -ErrorAction SilentlyContinue
+                if ($supervisorProcess -and ([string]$supervisorProcess.CommandLine) -match 'devbox-guardian\.mjs') {
+                    Stop-Process -Id $supervisorPid -Force -ErrorAction Stop
+                }
+            }
         }
-        Remove-Item (Join-Path $root 'run\guardian\guardian.lock') -Force -ErrorAction SilentlyContinue
-        Remove-Item $guardianPidPath -Force -ErrorAction SilentlyContinue
-    } catch {}
-    try { & (Join-Path $root 'scripts\Stop-ChatGptDevboxMcp.ps1') -ErrorAction SilentlyContinue | Out-Null } catch {}
+    } catch {
+        Write-Warning ("Guardian supervisor cleanup failed: {0}" -f $_.Exception.Message)
+    }
+
+    foreach ($stalePath in @((Join-Path $root 'run\guardian\guardian.lock'), $guardianPidPath)) {
+        try {
+            Remove-Item $stalePath -Force -ErrorAction Stop
+        } catch [System.Management.Automation.ItemNotFoundException] {
+        } catch {
+            Write-Warning ("Guardian state cleanup failed for {0}: {1}" -f $stalePath, $_.Exception.Message)
+        }
+    }
+
+    try {
+        & (Join-Path $root 'scripts\Stop-ChatGptDevboxMcp.ps1') -ErrorAction Stop | Out-Null
+    } catch {
+        Write-Warning ("MCP cleanup failed: {0}" -f $_.Exception.Message)
+    }
     if ($hadEnv) {
         [IO.File]::WriteAllText($envPath, $envBackup, [Text.UTF8Encoding]::new($false))
     } else {

--- a/scripts/ci/test-windows-startup-contract.ps1
+++ b/scripts/ci/test-windows-startup-contract.ps1
@@ -5,6 +5,7 @@ $startPath = Join-Path $root 'scripts\Start-ChatGptDevboxMcp.ps1'
 $stopPath = Join-Path $root 'scripts\Stop-ChatGptDevboxMcp.ps1'
 $ownershipPath = Join-Path $root 'scripts\DevboxMcpOwnership.ps1'
 $installPath = Join-Path $root 'scripts\Install-ChatGptDevboxGuardian.ps1'
+$ensureGuardianPath = Join-Path $root 'scripts\Ensure-ChatGptDevboxGuardian.ps1'
 $vbsPath = Join-Path $root 'scripts\Run-Start-ChatGptDevboxMcp.vbs'
 
 function Assert-Contains {
@@ -23,6 +24,7 @@ $start = Get-Content -LiteralPath $startPath -Raw
 $stop = Get-Content -LiteralPath $stopPath -Raw
 $ownership = Get-Content -LiteralPath $ownershipPath -Raw
 $install = Get-Content -LiteralPath $installPath -Raw
+$ensureGuardian = Get-Content -LiteralPath $ensureGuardianPath -Raw
 $vbs = Get-Content -LiteralPath $vbsPath -Raw
 
 Assert-Contains $start '$script:lifecycleMutex.WaitOne(0, $false)' 'Lifecycle mutex must reject concurrent starts instead of queueing them.'
@@ -74,8 +76,13 @@ Assert-Contains $start 'Stop-Process -Id ([int]$script:startupMcpPid) -Force' 'F
 Assert-Before $start 'Set-Content -Path $pidFile -Value $process.Id -Encoding ASCII' '$localUrl = "http://127.0.0.1:$port"' 'MCP PID must be persisted before health validation begins.'
 Assert-Contains $vbs 'shell.Run(command, 0, True)' 'Scheduled-task VBS must wait for the real startup child and propagate its exit code.'
 Assert-Contains $install '-ExecutionTimeLimit (New-TimeSpan -Minutes 10)' 'Elevated startup task must have a bounded execution time.'
+Assert-Contains $install 'if ($LASTEXITCODE -ne 0)' 'Guardian installation must fail when the Ensure process fails.'
+Assert-Contains $ensureGuardian "'-File', ('`"{0}`"' -f `$guardianScript)" 'Guardian direct launch must quote a watcher path containing spaces.'
+Assert-Contains $ensureGuardian 'Start-Process -FilePath $powerShellExe -ArgumentList $arguments -WorkingDirectory $ProjectRoot -WindowStyle Hidden' 'Guardian Ensure must launch the watcher directly through the resolved PowerShell executable.'
+Assert-Contains $ensureGuardian 'function Get-LiveGuardianSupervisorProcess' 'Guardian Ensure must identify a verified orphan supervisor separately from the watcher.'
+Assert-Contains $ensureGuardian 'guardian watcher failed to start persistently' 'Guardian Ensure must require a persistent watcher before reporting success.'
 
-foreach ($file in @($startPath, $stopPath, $ownershipPath, $installPath)) {
+foreach ($file in @($startPath, $stopPath, $ownershipPath, $installPath, $ensureGuardianPath)) {
     $tokens = $null
     $errors = $null
     [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$tokens, [ref]$errors) | Out-Null
@@ -90,8 +97,9 @@ if (Test-Path $legacy) {
     $escapedStop = $stopPath.Replace("'", "''")
     $escapedOwnership = $ownershipPath.Replace("'", "''")
     $escapedInstall = $installPath.Replace("'", "''")
+    $escapedEnsureGuardian = $ensureGuardianPath.Replace("'", "''")
     $command = @"
-`$ErrorActionPreference='Stop'; foreach(`$f in @('$escapedStart','$escapedStop','$escapedOwnership','$escapedInstall')) { `$t=`$null; `$e=`$null; [System.Management.Automation.Language.Parser]::ParseFile(`$f,[ref]`$t,[ref]`$e) | Out-Null; if(`$e.Count -gt 0) { throw (`$e | Out-String) } }
+`$ErrorActionPreference='Stop'; foreach(`$f in @('$escapedStart','$escapedStop','$escapedOwnership','$escapedInstall','$escapedEnsureGuardian')) { `$t=`$null; `$e=`$null; [System.Management.Automation.Language.Parser]::ParseFile(`$f,[ref]`$t,[ref]`$e) | Out-Null; if(`$e.Count -gt 0) { throw (`$e | Out-String) } }
 "@
     & $legacy -NoLogo -NoProfile -NonInteractive -Command $command
     if ($LASTEXITCODE -ne 0) { throw "Windows PowerShell 5.1 parse validation failed with exit code $LASTEXITCODE." }


### PR DESCRIPTION
Fix the production Guardian restart failure found after PR #26 deployment.

- launch Watch-ChatGptDevboxGuardian.ps1 directly with resolved PowerShell instead of a second VBS detachment hop
- fail installation when Ensure-ChatGptDevboxGuardian.ps1 fails
- extend native Windows lifecycle E2E to require a persistent Guardian wrapper and advancing heartbeat
- clean Guardian processes in CI teardown

Production MCP/tunnel remain healthy; this PR only hardens Guardian supervision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guardian startup reliability by launching it directly with the configured PowerShell executable.
  * Installations now report clear errors when guardian setup fails.

* **Tests**
  * Added Windows runtime checks confirming the guardian remains active and its heartbeat updates.
  * Improved test cleanup to stop background processes and remove temporary guardian state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->