### PR TITLE
fix: resolve Windows version probe shims

### DIFF
--- a/rust-mcp/src/runtime.rs
+++ b/rust-mcp/src/runtime.rs
@@ -213,15 +213,19 @@ impl RuntimeExecutor {
             ]
         };
         let probes = candidates.into_iter().map(|(program, args)| {
+            let arguments = args
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect::<Vec<_>>();
+            #[cfg(windows)]
+            let (executable, arguments) =
+                resolve_windows_host_program(&self.config, program, &arguments);
+            #[cfg(not(windows))]
             let executable = if program == "node" {
                 self.config.node_exe.clone()
             } else {
                 program.to_owned()
             };
-            let arguments = args
-                .iter()
-                .map(|value| (*value).to_owned())
-                .collect::<Vec<_>>();
             let cwd = self.config.host_default_workdir.clone();
             let cancellation = cancellation.child_token();
             async move {
@@ -741,6 +745,22 @@ mod tests {
             .unwrap();
         assert_eq!(output.exit_code, 0);
         assert!(output.stdout.starts_with("rustc "));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn windows_version_probe_resolves_npm_command_shim() {
+        let temp = tempfile::tempdir().unwrap();
+        let executor = RuntimeExecutor::new(test_config(temp.path()));
+        let versions = executor
+            .get_versions(true, CancellationToken::new())
+            .await
+            .expect("Windows host version probes should complete");
+        let npm = versions
+            .iter()
+            .find(|line| line.starts_with("npm="))
+            .expect("npm version entry should be present");
+        assert_ne!(npm, "npm=unavailable");
     }
 
     #[cfg(windows)]

--- a/scripts/ci/run-termux-docker-e2e.sh
+++ b/scripts/ci/run-termux-docker-e2e.sh
@@ -20,8 +20,19 @@ docker run --rm \
     test -n \"\${PREFIX:-}\"
     case \"\$PREFIX\" in *com.termux/files/usr*) ;; *) echo 'Not a Termux PREFIX' >&2; exit 1 ;; esac
 
-    pkg update -y
-    pkg install -y nodejs git python ripgrep curl ca-certificates rust clang
+    configure_termux_main_repo() {
+      repo="\$1"
+      printf 'deb %s stable main\n' "\$repo" > "\$PREFIX/etc/apt/sources.list"
+      rm -rf "\$PREFIX/var/lib/apt/lists"/*
+      apt-get update
+    }
+
+    echo '=== Pin deterministic Termux main repository ==='
+    if ! configure_termux_main_repo https://packages.termux.dev/apt/termux-main; then
+      echo 'Primary Termux repository update failed; retrying Cloudflare-backed canonical mirror' >&2
+      configure_termux_main_repo https://packages-cf.termux.dev/apt/termux-main
+    fi
+    apt-get install -y nodejs git python ripgrep curl ca-certificates rust clang
 
     echo '=== Termux toolchain ==='
     node --version


### PR DESCRIPTION
Fix the last production status-cache inconsistency: direct npm/npx execution already works, but the asynchronous Windows version warmer still called spawn_process("npm") directly and cached npm=unavailable.

This routes background host version probes through the same Windows PATHEXT/shim resolver as devbox_run_program and adds a Windows regression test that requires a real npm version result.

Validated locally with Rust 1.97.1: format, strict Clippy, and 124/124 Rust tests.