### PR TITLE
Harden MCP supervision, jobs, readiness, and dependencies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,9 @@ MCP_JOB_LOG_ROTATIONS=2
 MCP_JOB_HEARTBEAT_MS=5000
 MCP_JOB_ORPHAN_STALE_MS=15000
 MCP_JOB_RETENTION_HOURS=168
+# Global retained-job pressure limits; oldest terminal jobs are evicted toward a 90% low-water mark.
+MCP_JOB_STORE_MAX_BYTES=2147483648
+MCP_JOB_STORE_MAX_TERMINAL_JOBS=5000
 # No-process wait ceiling and capture fail-fast policy.
 MCP_WAIT_MAX_SECONDS=300
 SCREEN_CAPTURE_ATTEMPT_TIMEOUT_MS=8000
@@ -67,7 +70,12 @@ POWERSHELL_EXE=
 POWERSHELL_FALLBACK_EXE=
 # HOST_SHELL still overrides the general host shell. On Windows, blank means the resolved PowerShell executable above.
 HOST_SHELL=
+# Added to the canonical safe host defaults.
 HOST_PROGRAM_ALLOWLIST=
+# Additional additive entries, useful for local tooling.
+HOST_PROGRAM_ALLOWLIST_EXTRA=
+# Set true only when intentionally replacing the canonical defaults with HOST_PROGRAM_ALLOWLIST.
+HOST_PROGRAM_ALLOWLIST_REPLACE=false
 
 # Leave blank to use the current Node executable
 NODE_EXE=

--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,8 @@ POWERSHELL_EXE=
 POWERSHELL_FALLBACK_EXE=
 # HOST_SHELL still overrides the general host shell. On Windows, blank means the resolved PowerShell executable above.
 HOST_SHELL=
-# Added to the canonical safe host defaults.
+# Added to the canonical safe host defaults. Existing deployments that intentionally narrowed this list
+# must set HOST_PROGRAM_ALLOWLIST_REPLACE=true to preserve the old replacement behavior.
 HOST_PROGRAM_ALLOWLIST=
 # Additional additive entries, useful for local tooling.
 HOST_PROGRAM_ALLOWLIST_EXTRA=

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,25 @@ updates:
     directory: /rust-mcp
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
+    groups:
+      rust-mcp-routine:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
+    groups:
+      node-runtime-routine:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    groups:
+      github-actions-routine:
+        patterns: ["*"]

--- a/.github/workflows/platform-runtime-e2e.yml
+++ b/.github/workflows/platform-runtime-e2e.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "src/**"
       - "rust-mcp/**"
+      - "rust-toolchain.toml"
       - "bin/**"
       - "scripts/**"
       - "bootstrap/**"
@@ -36,11 +37,11 @@ jobs:
           cache: npm
       - name: Install JavaScript dependencies
         run: npm ci --ignore-scripts --no-audit --no-fund
-      - name: Select Rust 1.97.1
+      - name: Select Rust 1.91.1
         shell: pwsh
         run: |
-          rustup toolchain install 1.97.1 --profile minimal
-          rustup default 1.97.1
+          rustup toolchain install 1.91.1 --profile minimal
+          rustup default 1.91.1
           rustc --version
           cargo --version
       - name: Validate native Windows launcher, Guardian tasks and Rust MCP lifecycle
@@ -67,10 +68,10 @@ jobs:
         with:
           node-version: 24
           cache: npm
-      - name: Select Rust 1.97.1
+      - name: Select Rust 1.91.1
         run: |
-          rustup toolchain install 1.97.1 --profile minimal
-          rustup default 1.97.1
+          rustup toolchain install 1.91.1 --profile minimal
+          rustup default 1.91.1
           rustc --version
           cargo --version
       - name: Validate native macOS runtime and MCP bridge

--- a/.github/workflows/rust-mcp.yml
+++ b/.github/workflows/rust-mcp.yml
@@ -65,7 +65,16 @@ jobs:
       - name: Run strict Clippy
         run: cargo clippy --manifest-path rust-mcp/Cargo.toml --all-targets -- -D warnings
       - name: Run Rust tests
-        run: cargo test --manifest-path rust-mcp/Cargo.toml --locked
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            # Windows hosted runners can stall many simultaneous native child launches.
+            # Keep unit subprocess tests deterministic; the dedicated contention smoke below
+            # remains the explicit concurrent scheduler/watcher regression gate.
+            cargo test --manifest-path rust-mcp/Cargo.toml --locked -- --test-threads=2
+          else
+            cargo test --manifest-path rust-mcp/Cargo.toml --locked
+          fi
       - name: Validate Windows managed cutover contracts
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/rust-mcp.yml
+++ b/.github/workflows/rust-mcp.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "rust-mcp/**"
+      - "rust-toolchain.toml"
       - "src/server.js"
       - "src/launcher.js"
       - "src/mcp-implementation.js"
@@ -16,6 +17,7 @@ on:
   pull_request:
     paths:
       - "rust-mcp/**"
+      - "rust-toolchain.toml"
       - "src/server.js"
       - "src/launcher.js"
       - "src/mcp-implementation.js"
@@ -51,11 +53,11 @@ jobs:
           cache: npm
       - name: Install JavaScript SDK dependencies
         run: npm ci --ignore-scripts --no-audit --no-fund
-      - name: Install Rust 1.97.1 with quality components
+      - name: Install Rust 1.91.1 with quality components
         shell: bash
         run: |
-          rustup toolchain install 1.97.1 --profile minimal --component rustfmt,clippy
-          rustup default 1.97.1
+          rustup toolchain install 1.91.1 --profile minimal --component rustfmt,clippy
+          rustup default 1.91.1
       - name: Check JavaScript-to-Rust tool contract drift
         run: node rust-mcp/scripts/check-contract-parity.mjs
       - name: Check formatting
@@ -105,6 +107,20 @@ jobs:
         run: node rust-mcp/scripts/result-parity-audit.mjs
       - name: Run JavaScript MCP SDK interoperability smoke
         run: node rust-mcp/scripts/smoke-runner.mjs
+
+
+  msrv:
+    name: Rust MCP MSRV (1.88.0)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Install declared MSRV
+        run: rustup toolchain install 1.88.0 --profile minimal
+      - name: Verify declared MSRV still compiles
+        run: cargo +1.88.0 check --manifest-path rust-mcp/Cargo.toml --locked
 
   dependency-audit:
     name: Rust dependency security audit

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Important `.env` values:
 - `POWERSHELL_FALLBACK_EXE` (optional Windows fallback override; defaults to Windows PowerShell 5.1)
 - `HOST_SHELL`
 - `HOST_PROGRAM_ALLOWLIST` adds entries to the canonical host defaults; use `HOST_PROGRAM_ALLOWLIST_EXTRA` for explicit local additions, and set `HOST_PROGRAM_ALLOWLIST_REPLACE=true` only when intentionally replacing the canonical defaults
+  - Migration note: older deployments treated `HOST_PROGRAM_ALLOWLIST` as a full replacement. If you intentionally narrowed the defaults, set `HOST_PROGRAM_ALLOWLIST_REPLACE=true`; otherwise the configured entries are now merged with the canonical safe defaults.
 - `DEVBOX_PROGRAM_ALLOWLIST` controls the structured `devbox_run_program` fast path; in host mode the executable must also be allowed by `HOST_PROGRAM_ALLOWLIST`
 - `HOST_SEARCH_BACKEND=auto|rg|js` selects host search acceleration; `auto` prefers ripgrep
 - `MCP_EXEC_MAX_CONCURRENT`, `MCP_EXEC_RESERVED_INTERACTIVE`, `MCP_EXEC_QUEUE_TIMEOUT_MS`, and `MCP_BACKGROUND_QUEUE_TIMEOUT_MS` tune the light/heavy execution pool

--- a/README.md
+++ b/README.md
@@ -234,16 +234,16 @@ Important `.env` values:
 - `POWERSHELL_EXE` (optional Windows primary override; defaults to installed PowerShell 7)
 - `POWERSHELL_FALLBACK_EXE` (optional Windows fallback override; defaults to Windows PowerShell 5.1)
 - `HOST_SHELL`
-- `HOST_PROGRAM_ALLOWLIST`
+- `HOST_PROGRAM_ALLOWLIST` adds entries to the canonical host defaults; use `HOST_PROGRAM_ALLOWLIST_EXTRA` for explicit local additions, and set `HOST_PROGRAM_ALLOWLIST_REPLACE=true` only when intentionally replacing the canonical defaults
 - `DEVBOX_PROGRAM_ALLOWLIST` controls the structured `devbox_run_program` fast path; in host mode the executable must also be allowed by `HOST_PROGRAM_ALLOWLIST`
 - `HOST_SEARCH_BACKEND=auto|rg|js` selects host search acceleration; `auto` prefers ripgrep
 - `MCP_EXEC_MAX_CONCURRENT`, `MCP_EXEC_RESERVED_INTERACTIVE`, `MCP_EXEC_QUEUE_TIMEOUT_MS`, and `MCP_BACKGROUND_QUEUE_TIMEOUT_MS` tune the light/heavy execution pool
 - `MCP_WATCH_MAX_CONCURRENT` gives passive watchers such as `gh run watch` a separate pool; `MCP_EXEC_HEAVY_WEIGHT` controls how much execution capacity heavy build/browser jobs consume
-- `MCP_JOB_LOG_MAX_BYTES` and `MCP_JOB_LOG_ROTATIONS` bound detached-job stdout/stderr on disk; `MCP_JOB_HEARTBEAT_MS` and `MCP_JOB_ORPHAN_STALE_MS` control orphan detection; `MCP_JOB_RETENTION_HOURS` bounds persisted terminal-job history
+- `MCP_JOB_LOG_MAX_BYTES` and `MCP_JOB_LOG_ROTATIONS` bound detached-job stdout/stderr on disk; `MCP_JOB_HEARTBEAT_MS` and `MCP_JOB_ORPHAN_STALE_MS` control orphan detection; `MCP_JOB_RETENTION_HOURS` bounds persisted terminal-job history; `MCP_JOB_STORE_MAX_BYTES` and `MCP_JOB_STORE_MAX_TERMINAL_JOBS` apply global pressure limits that evict the oldest terminal jobs toward a low-water mark without deleting active jobs
 - `MCP_WAIT_MAX_SECONDS` bounds no-process waits; prefer `devbox_wait`, `devbox_wait_for_file`, or `devbox_job_status(wait_seconds=...)` over shell `sleep`/`Start-Sleep`
 - `SCREEN_CAPTURE_ATTEMPT_TIMEOUT_MS`, `SCREEN_CAPTURE_RETRIES`, and `SCREEN_CAPTURE_QUEUE_TIMEOUT_MS` control serialized fail-fast screenshot capture
 - `GUARDIAN_HOST_PRESSURE_SAMPLE_MS` controls diagnostic Windows CPU/memory/commit/pagefile sampling; it does not trigger repair by itself
-- `DEVBOX_VERSION_CACHE_MS` controls the short-lived `devbox_status` toolchain-version cache
+- `DEVBOX_VERSION_CACHE_MS` controls the toolchain-version cache; Rust refreshes it in a supervised background loop so `devbox_status` remains subprocess-free while normally returning fresh versions
 - `PUBLIC_BASE_URL` for public OAuth deployments
 - `ENABLE_GATEWAY_BRIDGE=true|false`
 - `GATEWAY_BRIDGE_ORIGINS=https://chatgpt.com,https://chat.openai.com`

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "docker-chatgpt-devbox",
       "version": "0.1.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.28.0",
-        "express": "5.1.0",
-        "jose": "^6.1.0",
-        "zod": "4.1.11"
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "express": "5.2.1",
+        "jose": "^6.2.8",
+        "zod": "4.4.3"
       },
       "bin": {
         "devbox": "bin/devbox.js"
@@ -21,24 +21,24 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -70,58 +70,6 @@
         "zod": {
           "optional": false
         }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/accepts": {
@@ -171,21 +119,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -425,19 +386,20 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -493,9 +455,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -630,9 +592,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -682,9 +644,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -712,9 +674,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
-      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1128,17 +1090,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/unpipe": {
@@ -1181,9 +1160,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "usage:summary": "node scripts/summarize-mcp-telemetry.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.28.0",
-    "express": "5.1.0",
-    "jose": "^6.1.0",
-    "zod": "4.1.11"
+    "@modelcontextprotocol/sdk": "1.30.0",
+    "express": "5.2.1",
+    "jose": "^6.2.8",
+    "zod": "4.4.3"
   },
   "engines": {
     "node": ">=18"

--- a/rust-mcp/Cargo.lock
+++ b/rust-mcp/Cargo.lock
@@ -127,11 +127,11 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -187,7 +187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core",
 ]
 
@@ -204,19 +204,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -238,12 +235,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -285,9 +281,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "devbox-mcp"
@@ -295,7 +288,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "dotenvy",
  "futures",
@@ -313,7 +306,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -323,11 +316,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -412,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -427,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -437,15 +431,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -454,38 +448,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -496,16 +490,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -585,6 +569,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -938,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -975,9 +968,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -1243,7 +1236,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1355,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1482,12 +1475,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -1524,9 +1517,9 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1673,12 +1666,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1688,15 +1680,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1820,8 +1812,24 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1956,12 +1964,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/rust-mcp/Cargo.toml
+++ b/rust-mcp/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 axum = "0.8"
-base64 = "0.22"
+base64 = "0.23"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 futures = "0.3"
 dotenvy = "0.15"
@@ -22,12 +22,12 @@ rmcp = { version = "3.1.2", features = ["transport-streamable-http-server"] }
 schemars = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-sha2 = "0.10"
+sha2 = "0.11"
 tokio = { version = "1.48", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "time"] }
 tokio-util = "0.7"
-time = { version = "0.3.47", features = ["formatting", "parsing"] }
+time = { version = "0.3.55", features = ["formatting", "parsing"] }
 tempfile = "3.23"
-tower-http = { version = "0.6", features = ["trace"] }
+tower-http = { version = "0.7", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 url = "2.5"
@@ -39,6 +39,7 @@ windows-sys = { version = "0.61", features = [
   "Win32_Graphics_Dwm",
   "Win32_Graphics_Gdi",
   "Win32_System_Diagnostics_ToolHelp",
+  "Win32_System_JobObjects",
   "Win32_System_ProcessStatus",
   "Win32_System_Threading",
   "Win32_Storage_Xps",
@@ -47,7 +48,7 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.30", features = ["process", "signal"] }
+nix = { version = "0.31", features = ["process", "signal"] }
 
 [lints.rust]
 unsafe_code = "deny"

--- a/rust-mcp/Cargo.toml
+++ b/rust-mcp/Cargo.toml
@@ -48,7 +48,7 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", features = ["process", "signal"] }
+nix = { version = "0.31", features = ["process", "signal", "resource"] }
 
 [lints.rust]
 unsafe_code = "deny"

--- a/rust-mcp/scripts/result-parity-audit.mjs
+++ b/rust-mcp/scripts/result-parity-audit.mjs
@@ -210,7 +210,7 @@ const stable = (value, pathParts = []) => {
   const out = {};
   for (const key of Object.keys(value).sort()) {
     const item = value[key];
-    if (["pid", "runnerPid", "childPid"].includes(key)) continue;
+    if (["pid", "runnerPid", "childPid", "runnerProcessInstance", "childProcessInstance", "processInstance"].includes(key)) continue;
     if (volatileTimingKeys.has(key) && item !== null) {
       out[key] = "<timing>";
       continue;
@@ -228,7 +228,7 @@ const normalizeTextValue = (value, pathParts = []) => {
   const out = {};
   for (const key of Object.keys(value).sort()) {
     const item = value[key];
-    if (["pid", "runnerPid", "childPid"].includes(key)) continue;
+    if (["pid", "runnerPid", "childPid", "runnerProcessInstance", "childProcessInstance", "processInstance"].includes(key)) continue;
     if (volatileTimingKeys.has(key) && item !== null) {
       out[key] = "<timing>";
       continue;
@@ -276,11 +276,22 @@ const calls = [
 ];
 
 const normalizeImplementationDiagnostics = (name, value) => {
-  if (name !== "devbox_status" || !value || typeof value !== "object") return value;
+  if (!value || typeof value !== "object") return value;
   const cloned = structuredClone(value);
   const data = cloned?.data;
   if (!data || typeof data !== "object") return cloned;
-  for (const key of ["activeRequests", "jobMaintenance", "processProbe", "versions", "versionsCached"]) delete data[key];
+  for (const key of ["runnerProcessInstance", "childProcessInstance", "processInstance"]) delete data[key];
+  if (name !== "devbox_status") return cloned;
+  for (const key of [
+    "activeRequests",
+    "activeRequestsIncludingCurrent",
+    "backgroundTasks",
+    "usageTelemetry",
+    "jobMaintenance",
+    "processProbe",
+    "versions",
+    "versionsCached",
+  ]) delete data[key];
   if (data.execution && typeof data.execution === "object") {
     delete data.execution.global_queued;
     delete data.execution.global_queued_by_class;
@@ -361,6 +372,9 @@ const differences = [];
 let comparedCalls = 0;
 const compareResults = (name, jsResult, rustResult) => {
   comparedCalls += 1;
+  if (name === "devbox_sync_github_auth_from_host" && jsResult.isError === true && rustResult.isError === true) {
+    return;
+  }
   const a = normalizedResult(name, jsResult);
   const b = normalizedResult(name, rustResult);
   if (JSON.stringify(a) !== JSON.stringify(b)) differences.push({ name, js: a, rust: b });

--- a/rust-mcp/scripts/result-parity-audit.mjs
+++ b/rust-mcp/scripts/result-parity-audit.mjs
@@ -296,6 +296,10 @@ const normalizeImplementationDiagnostics = (name, value) => {
     delete data.execution.global_queued;
     delete data.execution.global_queued_by_class;
   }
+  if (data.performance && typeof data.performance === "object") {
+    delete data.performance.cachedAgeMs;
+    delete data.performance.stale;
+  }
   if (data.performance?.eventLoop) {
     delete data.performance.eventLoop.sampleCount;
     delete data.performance.eventLoop.oneMinute;
@@ -305,7 +309,10 @@ const normalizeImplementationDiagnostics = (name, value) => {
     delete data.performance.process.memory.private;
     delete data.performance.process.memory.allocator;
   }
-  if (data.performance?.process) delete data.performance.process.platform;
+  if (data.performance?.process) {
+    delete data.performance.process.platform;
+    delete data.performance.process.cpuTotalMs;
+  }
   return cloned;
 };
 

--- a/rust-mcp/scripts/smoke-client.mjs
+++ b/rust-mcp/scripts/smoke-client.mjs
@@ -41,6 +41,15 @@ const assertShellResult = (result, { readOnly } = {}) => {
 const healthResponse = await fetch(new URL("healthz", baseUrl));
 assert.equal(healthResponse.status, 200);
 assert.equal(await healthResponse.text(), "ok");
+const liveResponse = await fetch(new URL("livez", baseUrl));
+assert.equal(liveResponse.status, 200);
+assert.equal(await liveResponse.text(), "ok");
+const readyResponse = await fetch(new URL("readyz", baseUrl));
+assert.equal(readyResponse.status, 200);
+const ready = await readyResponse.json();
+assert.equal(ready.ok, true);
+assert.equal(ready.toolContractComplete, true);
+assert.equal(ready.toolCount, 37);
 
 const metadataResponse = await fetch(baseUrl);
 assert.equal(metadataResponse.status, 200);
@@ -181,6 +190,9 @@ try {
   );
   assert.ok(Date.now() - processCancelStarted < 4_000, "cancelled child process should terminate promptly");
 
+  // The smoke server uses a 2s version TTL. Waiting beyond the TTL proves the
+  // supervised refresher keeps status populated without status launching probes.
+  await new Promise((resolve) => setTimeout(resolve, 2_500));
   const status = await client.callTool({ name: "devbox_status", arguments: {} });
   assert.equal(status.isError, false);
   assert.equal(status.structuredContent?.ok, true);
@@ -201,16 +213,18 @@ try {
   assert.equal(Number.isFinite(allocator?.currentRequestedBytes), true);
   assert.equal(allocator?.peakRequestedBytes > 0, true);
   assert.equal(allocator?.allocationCalls > 0, true);
-  assert.equal(typeof statusData.versionsCached, "boolean");
-  assert.ok(statusData.versions === null || Array.isArray(statusData.versions));
-  if (statusData.versionsCached) {
-    assert.ok(Array.isArray(statusData.versions));
-    for (const program of process.platform === "win32" ? ["node", "npm", "git", "gh", "python"] : ["node", "npm", "git", "gh", "python3", "rg"]) {
-      assert.ok(statusData.versions.some((line) => line.startsWith(`${program}=`)), `missing version status for ${program}`);
-    }
-  } else {
-    assert.equal(statusData.versions, null);
+  assert.equal(statusData.versionsCached, true);
+  assert.ok(Array.isArray(statusData.versions));
+  for (const program of process.platform === "win32"
+    ? ["node", "npm", "git", "gh", "python", "pwsh", "rg", "curl"]
+    : ["node", "npm", "git", "gh", "python3", "rg"]) {
+    assert.ok(statusData.versions.some((line) => line.startsWith(`${program}=`)), `missing refreshed version status for ${program}`);
   }
+  assert.equal(statusData.activeRequests, 0);
+  assert.equal(statusData.activeRequestsIncludingCurrent >= 1, true);
+  assert.equal(statusData.backgroundTasks?.["version-refresh"]?.running, true);
+  assert.equal(statusData.backgroundTasks?.["job-maintenance"]?.running, true);
+  assert.equal(statusData.usageTelemetry?.tool?.dropped >= 0, true);
 
   for (const toolName of ["host_status", "windows_host_status"]) {
     const hostStatus = await client.callTool({ name: toolName, arguments: {} });

--- a/rust-mcp/scripts/smoke-client.mjs
+++ b/rust-mcp/scripts/smoke-client.mjs
@@ -47,9 +47,7 @@ assert.equal(await liveResponse.text(), "ok");
 const readyResponse = await fetch(new URL("readyz", baseUrl));
 assert.equal(readyResponse.status, 200);
 const ready = await readyResponse.json();
-assert.equal(ready.ok, true);
-assert.equal(ready.toolContractComplete, true);
-assert.equal(ready.toolCount, 37);
+assert.deepEqual(ready, { ok: true });
 
 const metadataResponse = await fetch(baseUrl);
 assert.equal(metadataResponse.status, 200);

--- a/rust-mcp/scripts/smoke-client.mjs
+++ b/rust-mcp/scripts/smoke-client.mjs
@@ -192,7 +192,7 @@ try {
 
   // The smoke server uses a 2s version TTL. Waiting beyond the TTL proves the
   // supervised refresher keeps status populated without status launching probes.
-  await new Promise((resolve) => setTimeout(resolve, 2_500));
+  await new Promise((resolve) => setTimeout(resolve, 32_000));
   const status = await client.callTool({ name: "devbox_status", arguments: {} });
   assert.equal(status.isError, false);
   assert.equal(status.structuredContent?.ok, true);

--- a/rust-mcp/scripts/smoke-runner.mjs
+++ b/rust-mcp/scripts/smoke-runner.mjs
@@ -113,6 +113,7 @@ const serverEnv = {
   HOST_DEFAULT_WORKDIR: projectRoot,
   MCP_JOBS_ROOT: path.join(runtimeDir, "jobs"),
   MCP_EXEC_SLOT_ROOT: path.join(runtimeDir, "execution-slots"),
+  DEVBOX_VERSION_CACHE_MS: "2000",
 };
 
 let stdout = "";

--- a/rust-mcp/scripts/smoke-runner.mjs
+++ b/rust-mcp/scripts/smoke-runner.mjs
@@ -113,7 +113,7 @@ const serverEnv = {
   HOST_DEFAULT_WORKDIR: projectRoot,
   MCP_JOBS_ROOT: path.join(runtimeDir, "jobs"),
   MCP_EXEC_SLOT_ROOT: path.join(runtimeDir, "execution-slots"),
-  DEVBOX_VERSION_CACHE_MS: "2000",
+  DEVBOX_VERSION_CACHE_MS: "31000",
 };
 
 let stdout = "";

--- a/rust-mcp/scripts/windows-contention-smoke-runner.mjs
+++ b/rust-mcp/scripts/windows-contention-smoke-runner.mjs
@@ -33,8 +33,8 @@ const waitForHealth = async (url) => {
   const deadline = Date.now() + 20_000;
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(new URL("healthz", url), { signal: AbortSignal.timeout(1_000) });
-      if (response.ok && await response.text() === "ok") return;
+      const response = await fetch(new URL("readyz", url), { signal: AbortSignal.timeout(1_000) });
+      if (response.ok && (await response.json()).ok === true) return;
     } catch {}
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
@@ -106,9 +106,9 @@ try {
     while (!stopProbes) {
       const started = performance.now();
       try {
-        const response = await fetch(new URL("healthz", baseUrl), { signal: AbortSignal.timeout(1_500) });
+        const response = await fetch(new URL("readyz", baseUrl), { signal: AbortSignal.timeout(1_500) });
         assert.equal(response.status, 200);
-        assert.equal(await response.text(), "ok");
+        assert.equal((await response.json()).ok, true);
         probeSamples.push(performance.now() - started);
       } catch (error) {
         probeSamples.push(Number.POSITIVE_INFINITY);

--- a/rust-mcp/src/background.rs
+++ b/rust-mcp/src/background.rs
@@ -1,0 +1,188 @@
+use std::{
+    collections::BTreeMap,
+    future::Future,
+    sync::{Arc, Mutex, PoisonError},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use serde::Serialize;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BackgroundTaskState {
+    pub running: bool,
+    pub starts: u64,
+    pub restarts: u64,
+    pub last_tick_unix_ms: Option<u64>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BackgroundTaskRegistry {
+    inner: Arc<Mutex<BTreeMap<String, BackgroundTaskState>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskHeartbeat {
+    registry: BackgroundTaskRegistry,
+    name: Arc<str>,
+}
+
+impl TaskHeartbeat {
+    pub fn tick(&self) {
+        self.registry.tick(&self.name);
+    }
+}
+
+impl BackgroundTaskRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn spawn_supervised<F, Fut>(
+        &self,
+        name: &'static str,
+        cancellation: CancellationToken,
+        factory: F,
+    ) where
+        F: Fn(CancellationToken, TaskHeartbeat) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<(), String>> + Send + 'static,
+    {
+        let registry = self.clone();
+        let factory = Arc::new(factory);
+        tokio::spawn(async move {
+            loop {
+                if cancellation.is_cancelled() {
+                    registry.mark_stopped(name, None);
+                    return;
+                }
+                registry.mark_started(name);
+                let heartbeat = TaskHeartbeat {
+                    registry: registry.clone(),
+                    name: Arc::from(name),
+                };
+                heartbeat.tick();
+                let child_cancel = cancellation.child_token();
+                let mut task = tokio::spawn(factory(child_cancel.clone(), heartbeat));
+                let failure = tokio::select! {
+                    () = cancellation.cancelled() => {
+                        child_cancel.cancel();
+                        task.abort();
+                        let _ = task.await;
+                        registry.mark_stopped(name, None);
+                        return;
+                    }
+                    result = &mut task => match result {
+                        Ok(Ok(())) => Some("background task exited unexpectedly".to_owned()),
+                        Ok(Err(error)) => Some(error),
+                        Err(error) => Some(format!("background task panicked or was cancelled: {error}")),
+                    },
+                };
+                registry.mark_stopped(name, failure);
+                tokio::select! {
+                    () = cancellation.cancelled() => return,
+                    () = tokio::time::sleep(Duration::from_millis(500)) => {},
+                }
+            }
+        });
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> serde_json::Value {
+        let now = unix_ms();
+        let states = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let mapped = states
+            .iter()
+            .map(|(name, state)| {
+                let age = state.last_tick_unix_ms.map(|tick| now.saturating_sub(tick));
+                (
+                    name.clone(),
+                    serde_json::json!({
+                        "running": state.running,
+                        "starts": state.starts,
+                        "restarts": state.restarts,
+                        "lastTickUnixMs": state.last_tick_unix_ms,
+                        "lastTickAgeMs": age,
+                        "lastError": state.last_error,
+                    }),
+                )
+            })
+            .collect::<serde_json::Map<_, _>>();
+        serde_json::Value::Object(mapped)
+    }
+
+    fn mark_started(&self, name: &str) {
+        let mut states = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let state = states.entry(name.to_owned()).or_default();
+        if state.starts > 0 {
+            state.restarts = state.restarts.saturating_add(1);
+        }
+        state.starts = state.starts.saturating_add(1);
+        state.running = true;
+        state.last_error = None;
+        state.last_tick_unix_ms = Some(unix_ms());
+    }
+
+    fn mark_stopped(&self, name: &str, error: Option<String>) {
+        let mut states = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let state = states.entry(name.to_owned()).or_default();
+        state.running = false;
+        if let Some(error) = error {
+            state.last_error = Some(error);
+        }
+    }
+
+    fn tick(&self, name: &str) {
+        let mut states = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let state = states.entry(name.to_owned()).or_default();
+        state.running = true;
+        state.last_tick_unix_ms = Some(unix_ms());
+    }
+}
+
+fn unix_ms() -> u64 {
+    u64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis(),
+    )
+    .unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn supervisor_restarts_failed_background_task() {
+        let registry = BackgroundTaskRegistry::new();
+        let cancellation = CancellationToken::new();
+        let starts = Arc::new(AtomicUsize::new(0));
+        let starts_factory = starts.clone();
+        registry.spawn_supervised("fixture", cancellation.clone(), move |cancel, heartbeat| {
+            let starts = starts_factory.clone();
+            async move {
+                let attempt = starts.fetch_add(1, Ordering::SeqCst);
+                heartbeat.tick();
+                if attempt == 0 {
+                    return Err("synthetic failure".to_owned());
+                }
+                cancel.cancelled().await;
+                Ok(())
+            }
+        });
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        while starts.load(Ordering::SeqCst) < 2 && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        let snapshot = registry.snapshot();
+        assert!(starts.load(Ordering::SeqCst) >= 2);
+        assert!(snapshot["fixture"]["restarts"].as_u64().unwrap_or(0) >= 1);
+        assert_eq!(snapshot["fixture"]["running"], true);
+        cancellation.cancel();
+    }
+}

--- a/rust-mcp/src/background.rs
+++ b/rust-mcp/src/background.rs
@@ -2,11 +2,15 @@ use std::{
     collections::BTreeMap,
     future::Future,
     sync::{Arc, Mutex, PoisonError},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
+
+const RESTART_BACKOFF_INITIAL: Duration = Duration::from_millis(500);
+const RESTART_BACKOFF_MAX: Duration = Duration::from_secs(30);
+const RESTART_BACKOFF_RESET_AFTER: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -53,6 +57,7 @@ impl BackgroundTaskRegistry {
         let registry = self.clone();
         let factory = Arc::new(factory);
         tokio::spawn(async move {
+            let mut restart_delay = RESTART_BACKOFF_INITIAL;
             loop {
                 if cancellation.is_cancelled() {
                     registry.mark_stopped(name, None);
@@ -65,6 +70,7 @@ impl BackgroundTaskRegistry {
                 };
                 heartbeat.tick();
                 let child_cancel = cancellation.child_token();
+                let started = Instant::now();
                 let mut task = tokio::spawn(factory(child_cancel.clone(), heartbeat));
                 let failure = tokio::select! {
                     () = cancellation.cancelled() => {
@@ -81,9 +87,15 @@ impl BackgroundTaskRegistry {
                     },
                 };
                 registry.mark_stopped(name, failure);
+                let delay = restart_delay;
+                restart_delay = if started.elapsed() >= RESTART_BACKOFF_RESET_AFTER {
+                    RESTART_BACKOFF_INITIAL
+                } else {
+                    restart_delay.saturating_mul(2).min(RESTART_BACKOFF_MAX)
+                };
                 tokio::select! {
                     () = cancellation.cancelled() => return,
-                    () = tokio::time::sleep(Duration::from_millis(500)) => {},
+                    () = tokio::time::sleep(delay) => {},
                 }
             }
         });

--- a/rust-mcp/src/capture.rs
+++ b/rust-mcp/src/capture.rs
@@ -401,7 +401,7 @@ fn temporary_capture_dir() -> Result<TempDir> {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    crate::hex::lower_hex(Sha256::digest(bytes))
 }
 
 fn duration_ms(duration: Duration) -> u64 {

--- a/rust-mcp/src/config.rs
+++ b/rust-mcp/src/config.rs
@@ -198,6 +198,8 @@ pub struct Config {
     pub job_heartbeat_ms: u64,
     pub job_orphan_stale_ms: u64,
     pub job_retention_hours: u64,
+    pub job_store_max_bytes: u64,
+    pub job_store_max_terminal_jobs: usize,
     pub screen_capture_attempt_timeout_ms: u64,
     pub screen_capture_retries: usize,
     pub screen_capture_queue_timeout_ms: u64,
@@ -211,6 +213,12 @@ struct OauthConfiguration {
     cloudflare_team_domain: Option<String>,
     cloudflare_aud: String,
     cloudflare_jwks_url: Option<String>,
+}
+
+struct ScreenCaptureConfiguration {
+    attempt_timeout_ms: u64,
+    retries: usize,
+    queue_timeout_ms: u64,
 }
 
 struct ProgramConfiguration {
@@ -268,6 +276,7 @@ impl Config {
             .unwrap_or_else(|| project_root.join("run").join("execution-slots"));
         let jobs_root =
             env_path("MCP_JOBS_ROOT").unwrap_or_else(|| project_root.join("run").join("jobs"));
+        let screen_capture = load_screen_capture_configuration();
         Ok(Self {
             project_root: project_root.clone(),
             host: env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_owned()),
@@ -317,15 +326,11 @@ impl Config {
             job_heartbeat_ms: parse_env("MCP_JOB_HEARTBEAT_MS", 5_000_u64),
             job_orphan_stale_ms: parse_env("MCP_JOB_ORPHAN_STALE_MS", 15_000_u64),
             job_retention_hours: parse_env("MCP_JOB_RETENTION_HOURS", 168_u64),
-            screen_capture_attempt_timeout_ms: parse_env(
-                "SCREEN_CAPTURE_ATTEMPT_TIMEOUT_MS",
-                8_000_u64,
-            ),
-            screen_capture_retries: parse_env("SCREEN_CAPTURE_RETRIES", 1_usize),
-            screen_capture_queue_timeout_ms: parse_env(
-                "SCREEN_CAPTURE_QUEUE_TIMEOUT_MS",
-                5_000_u64,
-            ),
+            job_store_max_bytes: parse_env("MCP_JOB_STORE_MAX_BYTES", 2_u64 * 1024 * 1024 * 1024),
+            job_store_max_terminal_jobs: parse_env("MCP_JOB_STORE_MAX_TERMINAL_JOBS", 5_000_usize),
+            screen_capture_attempt_timeout_ms: screen_capture.attempt_timeout_ms,
+            screen_capture_retries: screen_capture.retries,
+            screen_capture_queue_timeout_ms: screen_capture.queue_timeout_ms,
             max_wait_seconds: f64::from(parse_env("MCP_WAIT_MAX_SECONDS", 300_u16).max(1)),
             command_output_limit_chars: parse_command_output_limit(),
             max_mcp_transfer_chars: parse_transfer_limit(),
@@ -411,6 +416,14 @@ fn load_devbox_default_user(runtime_mode: RuntimeMode) -> String {
         })
 }
 
+fn load_screen_capture_configuration() -> ScreenCaptureConfiguration {
+    ScreenCaptureConfiguration {
+        attempt_timeout_ms: parse_env("SCREEN_CAPTURE_ATTEMPT_TIMEOUT_MS", 8_000_u64),
+        retries: parse_env("SCREEN_CAPTURE_RETRIES", 1_usize),
+        queue_timeout_ms: parse_env("SCREEN_CAPTURE_QUEUE_TIMEOUT_MS", 5_000_u64),
+    }
+}
+
 fn load_program_configuration(
     platform: &Platform,
     runtime_mode: RuntimeMode,
@@ -431,10 +444,18 @@ fn load_program_configuration(
                 default_host_shell(platform)
             }
         });
-    let host_program_allowlist = parse_csv_env(
-        "HOST_PROGRAM_ALLOWLIST",
-        default_host_program_allowlist(platform),
-    );
+    let host_defaults = default_host_program_allowlist(platform);
+    let host_configured = parse_csv_env("HOST_PROGRAM_ALLOWLIST", Vec::new());
+    let host_extra = parse_csv_env("HOST_PROGRAM_ALLOWLIST_EXTRA", Vec::new());
+    let host_program_allowlist = if parse_bool_env("HOST_PROGRAM_ALLOWLIST_REPLACE", false) {
+        if host_configured.is_empty() {
+            host_defaults
+        } else {
+            host_configured
+        }
+    } else {
+        merge_program_allowlists(host_defaults, host_configured.into_iter().chain(host_extra))
+    };
     let devbox_program_allowlist = parse_csv_env(
         "DEVBOX_PROGRAM_ALLOWLIST",
         if runtime_mode == RuntimeMode::Host {
@@ -510,6 +531,19 @@ fn default_power_shell_fallback(platform: &Platform) -> String {
 fn usable_executable_candidate(candidate: &str) -> bool {
     let candidate = candidate.trim();
     !candidate.is_empty() && (!Path::new(candidate).is_absolute() || Path::new(candidate).is_file())
+}
+
+fn merge_program_allowlists<I>(mut base: Vec<String>, extra: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    for value in extra {
+        let value = value.trim().to_ascii_lowercase();
+        if !value.is_empty() && !base.iter().any(|existing| existing == &value) {
+            base.push(value);
+        }
+    }
+    base
 }
 
 fn default_host_program_allowlist(platform: &Platform) -> Vec<String> {
@@ -831,6 +865,15 @@ fn parse_bool_env(name: &str, fallback: bool) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn host_allowlist_merge_preserves_defaults_and_deduplicates_additions() {
+        let merged = merge_program_allowlists(
+            vec!["git".to_owned(), "rg".to_owned(), "curl".to_owned()],
+            vec!["git".to_owned(), "custom".to_owned(), "CUSTOM".to_owned()],
+        );
+        assert_eq!(merged, vec!["git", "rg", "curl", "custom"]);
+    }
 
     #[test]
     fn host_search_backend_rejects_unknown_values() {

--- a/rust-mcp/src/config.rs
+++ b/rust-mcp/src/config.rs
@@ -451,7 +451,7 @@ fn load_program_configuration(
         if host_configured.is_empty() {
             host_defaults
         } else {
-            host_configured
+            merge_program_allowlists(Vec::new(), host_configured)
         }
     } else {
         merge_program_allowlists(host_defaults, host_configured.into_iter().chain(host_extra))
@@ -863,6 +863,77 @@ fn parse_bool_env(name: &str, fallback: bool) -> bool {
 }
 
 #[cfg(test)]
+pub(crate) fn test_config(root: &Path) -> Config {
+    Config {
+        project_root: root.to_path_buf(),
+        host: "127.0.0.1".to_owned(),
+        port: 0,
+        auth_mode: AuthMode::None,
+        runtime_mode: RuntimeMode::Host,
+        platform: Platform::detect(),
+        public_base_url: None,
+        gateway_bridge: GatewayBridgeConfig {
+            enabled: false,
+            origins: vec![
+                "https://chatgpt.com".to_owned(),
+                "https://chat.openai.com".to_owned(),
+            ],
+        },
+        oauth_state_file_path: root.join("oauth-state.json"),
+        cloudflare_access_team_domain: None,
+        cloudflare_access_aud: String::new(),
+        cloudflare_access_jwks_url: None,
+        host_workspace_path: root.to_path_buf(),
+        devbox_workspace_path: root.to_path_buf(),
+        devbox_container_name: "chatgpt-devbox-runtime".to_owned(),
+        devbox_image_name: "chatgpt-devbox-runtime:local".to_owned(),
+        devbox_tmp_volume_name: "chatgpt-devbox-runtime-tmp".to_owned(),
+        devbox_retired_container_grace_ms: 300_000,
+        devbox_auto_start: true,
+        devbox_version_cache_ms: 120_000,
+        docker_command_timeout_ms: 120_000,
+        devbox_default_user: String::new(),
+        host_default_workdir: root.to_path_buf(),
+        host_shell: if cfg!(windows) { "cmd.exe" } else { "/bin/sh" }.to_owned(),
+        power_shell_exe: if cfg!(windows) { "pwsh.exe" } else { "" }.to_owned(),
+        power_shell_fallback_exe: if cfg!(windows) { "powershell.exe" } else { "" }.to_owned(),
+        node_exe: "node".to_owned(),
+        host_program_allowlist: Vec::new(),
+        devbox_program_allowlist: Vec::new(),
+        host_search_backend: HostSearchBackend::Auto,
+        host_exec_enabled: true,
+        allow_windows_host_exec_uac: false,
+        execution_slot_root: root.join("execution-slots"),
+        jobs_root: root.join("jobs"),
+        mcp_performance_state_path: root.join("mcp-performance.json"),
+        usage_log: UsageLogConfig {
+            max_bytes: 16 * 1024 * 1024,
+            rotations: 3,
+        },
+        mcp_json_body_limit_bytes: 16 * 1024 * 1024,
+        exec_max_concurrent: 6,
+        exec_reserved_interactive: 1,
+        exec_queue_timeout_ms: 15_000,
+        background_queue_timeout_ms: 300_000,
+        watch_max_concurrent: 4,
+        exec_heavy_weight: 2,
+        job_log_max_bytes: 32 * 1024 * 1024,
+        job_log_rotations: 2,
+        job_heartbeat_ms: 5_000,
+        job_orphan_stale_ms: 15_000,
+        job_retention_hours: 168,
+        job_store_max_bytes: 2 * 1024 * 1024 * 1024,
+        job_store_max_terminal_jobs: 5_000,
+        screen_capture_attempt_timeout_ms: 8_000,
+        screen_capture_retries: 1,
+        screen_capture_queue_timeout_ms: 5_000,
+        max_wait_seconds: 300.0,
+        command_output_limit_chars: 65_536,
+        max_mcp_transfer_chars: 4_000_000,
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -873,6 +944,15 @@ mod tests {
             vec!["git".to_owned(), "custom".to_owned(), "CUSTOM".to_owned()],
         );
         assert_eq!(merged, vec!["git", "rg", "curl", "custom"]);
+    }
+
+    #[test]
+    fn host_allowlist_replacement_normalizes_case_and_whitespace() {
+        let replaced = merge_program_allowlists(
+            Vec::new(),
+            vec![" Git ".to_owned(), "CURL".to_owned(), "git".to_owned()],
+        );
+        assert_eq!(replaced, vec!["git", "curl"]);
     }
 
     #[test]

--- a/rust-mcp/src/execution.rs
+++ b/rust-mcp/src/execution.rs
@@ -1576,7 +1576,14 @@ mod tests {
     #[tokio::test]
     async fn fifo_ticket_prevents_later_light_job_from_overtaking_heavy_waiter() {
         let temp = tempfile::tempdir().unwrap();
-        let scheduler = scheduler(temp.path(), 2, 0, 1);
+        let scheduler = ExecutionScheduler::new(SchedulerConfig {
+            root: temp.path().to_path_buf(),
+            max_concurrent: 2,
+            reserved_interactive: 0,
+            watch_max_concurrent: 1,
+            queue_timeout: Duration::from_secs(2),
+            heavy_weight: 2,
+        });
         let mut blocker = scheduler
             .acquire(
                 AcquireRequest::background("blocker", ResourceClass::Light, 1),

--- a/rust-mcp/src/execution.rs
+++ b/rust-mcp/src/execution.rs
@@ -903,10 +903,6 @@ fn owner_process_alive(owner: &Value) -> bool {
 
 #[cfg(not(windows))]
 fn process_alive_now(pid: u32) -> bool {
-    #[cfg(windows)]
-    {
-        crate::windows_process::process_alive(pid)
-    }
     #[cfg(unix)]
     {
         use nix::{sys::signal::kill, unistd::Pid};

--- a/rust-mcp/src/execution.rs
+++ b/rust-mcp/src/execution.rs
@@ -17,6 +17,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const MAX_QUEUE_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const CLAIM_RETRY_INTERVAL: Duration = Duration::from_millis(20);
 const CORRUPT_SLOT_STALE: Duration = Duration::from_secs(5 * 60);
 const CORRUPT_QUEUE_TICKET_STALE: Duration = Duration::from_secs(5);
@@ -227,6 +228,7 @@ struct Metrics {
 struct SlotOwner {
     token: String,
     pid: u32,
+    process_instance: Option<u64>,
     kind: String,
     pool: String,
     resource_class: String,
@@ -499,7 +501,7 @@ impl ExecutionScheduler {
             }
             if !queue_ticket_is_head(&self.config.root, ticket).await? {
                 cancellable_sleep(
-                    CLAIM_RETRY_INTERVAL.min(timeout.saturating_sub(elapsed)),
+                    queue_poll_interval(elapsed).min(timeout.saturating_sub(elapsed)),
                     cancellation,
                 )
                 .await?;
@@ -521,7 +523,7 @@ impl ExecutionScheduler {
                 return Err(timeout_error(request, plan, elapsed, false).into());
             }
             cancellable_sleep(
-                POLL_INTERVAL.min(timeout.saturating_sub(elapsed)),
+                queue_poll_interval(elapsed).min(timeout.saturating_sub(elapsed)),
                 cancellation,
             )
             .await?;
@@ -558,6 +560,7 @@ impl ExecutionScheduler {
             let slot_owner = SlotOwner {
                 token: token.clone(),
                 pid: std::process::id(),
+                process_instance: current_process_instance(),
                 kind: request.kind.as_str().to_owned(),
                 pool: plan.pool.clone(),
                 resource_class: plan.resource_class.as_str().to_owned(),
@@ -619,6 +622,7 @@ impl ExecutionScheduler {
             let owner = json!({
                 "token": token,
                 "pid": std::process::id(),
+                "processInstance": current_process_instance(),
                 "pool": pool,
                 "acquiredAtUtc": utc_now(),
             });
@@ -770,6 +774,7 @@ async fn create_queue_ticket(
     let value = json!({
         "token": token,
         "pid": std::process::id(),
+        "processInstance": current_process_instance(),
         "class": class,
         "kind": request.kind.as_str(),
         "resourceClass": request.resource_class.as_str(),
@@ -846,13 +851,7 @@ async fn queue_ticket_is_head(root: &Path, ticket: &QueueTicket) -> Result<bool>
             remove_slot_file(&path).await.ok();
             continue;
         }
-        let alive = owner
-            .as_ref()
-            .and_then(|value| value.get("pid"))
-            .and_then(Value::as_u64)
-            .and_then(|value| u32::try_from(value).ok())
-            .is_some_and(process_alive_now);
-        if alive {
+        if owner.as_ref().is_some_and(owner_process_alive) {
             return Ok(false);
         }
         // Dead queue owners must never permanently block later tickets.
@@ -860,6 +859,49 @@ async fn queue_ticket_is_head(root: &Path, ticket: &QueueTicket) -> Result<bool>
     }
 }
 
+fn queue_poll_interval(elapsed: Duration) -> Duration {
+    if elapsed < Duration::from_secs(1) {
+        POLL_INTERVAL
+    } else if elapsed < Duration::from_secs(5) {
+        Duration::from_millis(100)
+    } else if elapsed < Duration::from_secs(30) {
+        Duration::from_millis(250)
+    } else {
+        MAX_QUEUE_POLL_INTERVAL
+    }
+}
+
+fn current_process_instance() -> Option<u64> {
+    #[cfg(windows)]
+    {
+        crate::windows_process::current_process_instance()
+    }
+    #[cfg(not(windows))]
+    {
+        None
+    }
+}
+
+fn owner_process_alive(owner: &Value) -> bool {
+    let Some(pid) = owner
+        .get("pid")
+        .and_then(Value::as_u64)
+        .and_then(|v| u32::try_from(v).ok())
+    else {
+        return false;
+    };
+    #[cfg(windows)]
+    {
+        let instance = owner.get("processInstance").and_then(Value::as_u64);
+        crate::windows_process::process_matches_instance(pid, instance)
+    }
+    #[cfg(not(windows))]
+    {
+        process_alive_now(pid)
+    }
+}
+
+#[cfg(not(windows))]
 fn process_alive_now(pid: u32) -> bool {
     #[cfg(windows)]
     {
@@ -1042,13 +1084,7 @@ async fn remove_stale_slot(path: &Path) -> Result<bool> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
         Err(error) => return Err(error.into()),
     };
-    if let Some(pid) = owner
-        .as_ref()
-        .and_then(|value| value.get("pid"))
-        .and_then(Value::as_u64)
-        .and_then(|value| u32::try_from(value).ok())
-        && process_alive(pid).await
-    {
+    if owner.as_ref().is_some_and(owner_process_alive) {
         return Ok(false);
     }
     if owner.is_none() {
@@ -1188,14 +1224,7 @@ async fn read_pool_entries(root: &Path, pool: &str) -> Result<Vec<Value>> {
         else {
             continue;
         };
-        let alive = match value
-            .get("pid")
-            .and_then(Value::as_u64)
-            .and_then(|pid| u32::try_from(pid).ok())
-        {
-            Some(pid) => process_alive(pid).await,
-            None => false,
-        };
+        let alive = owner_process_alive(&value);
         if !alive {
             fs::remove_file(path).await.ok();
             continue;

--- a/rust-mcp/src/files.rs
+++ b/rust-mcp/src/files.rs
@@ -517,7 +517,7 @@ fn normalize_expected_sha256(value: Option<&str>) -> Result<Option<String>> {
 }
 
 fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    crate::hex::lower_hex(Sha256::digest(bytes))
 }
 
 async fn sha256_file(path: &Path) -> Result<String> {
@@ -534,7 +534,7 @@ async fn sha256_file(path: &Path) -> Result<String> {
         }
         hasher.update(&buffer[..count]);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(crate::hex::lower_hex(hasher.finalize()))
 }
 
 async fn verify_suffix(path: &Path, previous_file_size: u64, payload: &[u8]) -> Result<bool> {

--- a/rust-mcp/src/hex.rs
+++ b/rust-mcp/src/hex.rs
@@ -1,0 +1,11 @@
+use std::fmt::Write as _;
+
+#[must_use]
+pub fn lower_hex(value: impl AsRef<[u8]>) -> String {
+    let bytes = value.as_ref();
+    let mut encoded = String::with_capacity(bytes.len().saturating_mul(2));
+    for byte in bytes {
+        let _ = write!(&mut encoded, "{byte:02x}");
+    }
+    encoded
+}

--- a/rust-mcp/src/host_inspect.rs
+++ b/rust-mcp/src/host_inspect.rs
@@ -373,7 +373,7 @@ async fn hash_file_sha256(path: &Path) -> Result<String> {
         }
         hash.update(&buffer[..count]);
     }
-    Ok(format!("{:x}", hash.finalize()))
+    Ok(crate::hex::lower_hex(hash.finalize()))
 }
 
 fn resolve_host_path(requested: &str, working_dir: &Path) -> PathBuf {

--- a/rust-mcp/src/job_logs.rs
+++ b/rust-mcp/src/job_logs.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use tokio::{
     fs::{self, OpenOptions},
     io::AsyncWriteExt,
-    sync::mpsc::{self, UnboundedSender},
+    sync::mpsc::{self, Sender},
     task::JoinHandle,
 };
 
@@ -32,7 +32,7 @@ pub struct JobLogSnapshots {
 }
 
 pub struct JobLogPump {
-    tx: Option<UnboundedSender<OutputChunk>>,
+    tx: Option<Sender<OutputChunk>>,
     task: JoinHandle<Result<JobLogSnapshots>>,
 }
 
@@ -49,7 +49,7 @@ impl JobLogPump {
     ) -> Result<Self> {
         let stdout = RotatingSink::open(stdout_path, max_bytes, rotations).await?;
         let stderr = RotatingSink::open(stderr_path, max_bytes, rotations).await?;
-        let (tx, mut rx) = mpsc::unbounded_channel::<OutputChunk>();
+        let (tx, mut rx) = mpsc::channel::<OutputChunk>(256);
         let task = tokio::spawn(async move {
             let mut stdout = stdout;
             let mut stderr = stderr;
@@ -75,7 +75,7 @@ impl JobLogPump {
     }
 
     #[must_use]
-    pub fn sender(&self) -> Option<UnboundedSender<OutputChunk>> {
+    pub fn sender(&self) -> Option<Sender<OutputChunk>> {
         self.tx.clone()
     }
 
@@ -250,12 +250,14 @@ mod tests {
                 stream: OutputStream::Stdout,
                 bytes: Arc::from(vec![b'a'; 9000]),
             })
+            .await
             .unwrap();
         sender
             .send(OutputChunk {
                 stream: OutputStream::Stderr,
                 bytes: Arc::from(b"warning".as_slice()),
             })
+            .await
             .unwrap();
         drop(sender);
         let snapshot = pump.finish().await.unwrap();
@@ -289,6 +291,7 @@ mod tests {
                 stream: OutputStream::Stdout,
                 bytes: Arc::from(vec![b'b'; 5000]),
             })
+            .await
             .unwrap();
         drop(sender);
         let snapshot = pump.finish().await.unwrap();

--- a/rust-mcp/src/job_manager.rs
+++ b/rust-mcp/src/job_manager.rs
@@ -229,6 +229,8 @@ pub fn job_store_config(config: &Config) -> JobStoreConfig {
         orphan_stale: Duration::from_millis(config.job_orphan_stale_ms),
         retention: Duration::from_secs(config.job_retention_hours.saturating_mul(3600)),
         max_wait: Duration::from_secs_f64(config.max_wait_seconds.max(0.1)),
+        max_store_bytes: config.job_store_max_bytes,
+        max_terminal_jobs: config.job_store_max_terminal_jobs,
     }
 }
 

--- a/rust-mcp/src/job_runner.rs
+++ b/rust-mcp/src/job_runner.rs
@@ -2,7 +2,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         Arc,
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicU32, AtomicU64, Ordering},
     },
     time::Duration,
 };
@@ -31,16 +31,19 @@ struct HeartbeatState {
     runtime_mode: String,
     status: Arc<RwLock<String>>,
     child_pid: Arc<AtomicU32>,
+    child_process_instance: Arc<AtomicU64>,
 }
 
 impl HeartbeatState {
     async fn write(&self) {
         let status = self.status.read().await.clone();
         let child_pid = self.child_pid.load(Ordering::Relaxed);
+        let child_process_instance = self.child_process_instance.load(Ordering::Relaxed);
         let heartbeat = json!({
             "pid": std::process::id(),
             "status": status,
             "childPid": (child_pid > 0).then_some(child_pid),
+            "childProcessInstance": (child_process_instance > 0).then_some(child_process_instance),
             "runtimeMode": self.runtime_mode,
             "updatedAtUtc": utc_now(),
         });
@@ -60,6 +63,12 @@ impl HeartbeatState {
 
     async fn set_child_pid(&self, pid: u32) {
         self.child_pid.store(pid, Ordering::Relaxed);
+        #[cfg(windows)]
+        let instance = crate::windows_process::process_instance(pid).unwrap_or(0);
+        #[cfg(not(windows))]
+        let instance = 0;
+        self.child_process_instance
+            .store(instance, Ordering::Relaxed);
         self.write().await;
     }
 
@@ -84,6 +93,7 @@ impl RunnerMonitor {
             runtime_mode: request.runtime_mode.clone(),
             status: Arc::new(RwLock::new("queued".to_owned())),
             child_pid: Arc::new(AtomicU32::new(0)),
+            child_process_instance: Arc::new(AtomicU64::new(0)),
         };
         heartbeat.write().await;
         let cancellation = CancellationToken::new();
@@ -454,6 +464,17 @@ async fn execute_runtime(
     result
 }
 
+fn runner_process_instance() -> Option<u64> {
+    #[cfg(windows)]
+    {
+        crate::windows_process::current_process_instance()
+    }
+    #[cfg(not(windows))]
+    {
+        None
+    }
+}
+
 fn resolve_working_dir(config: &Config, request: &JobRequest) -> PathBuf {
     if !request.working_dir.trim().is_empty() {
         return PathBuf::from(request.working_dir.trim());
@@ -483,6 +504,7 @@ fn queued_status(request: &JobRequest, queued_at_utc: &str) -> Value {
         "startedAtUtc": null,
         "completedAtUtc": null,
         "runnerPid": std::process::id(),
+        "runnerProcessInstance": runner_process_instance(),
         "exitCode": null,
         "readOnly": request.read_only,
         "resourceClass": request.resource_class.as_str(),
@@ -506,6 +528,7 @@ fn running_status(
         "startedAtUtc": started_at_utc,
         "completedAtUtc": null,
         "runnerPid": std::process::id(),
+        "runnerProcessInstance": runner_process_instance(),
         "exitCode": null,
         "readOnly": request.read_only,
         "resourceClass": request.resource_class.as_str(),
@@ -536,6 +559,7 @@ fn failed_before_execution_status(
         "startedAtUtc": null,
         "completedAtUtc": utc_now(),
         "runnerPid": std::process::id(),
+        "runnerProcessInstance": runner_process_instance(),
         "exitCode": null,
         "readOnly": request.read_only,
         "resourceClass": request.resource_class.as_str(),
@@ -567,6 +591,7 @@ fn cancelled_status(
         "startedAtUtc": null,
         "completedAtUtc": utc_now(),
         "runnerPid": std::process::id(),
+        "runnerProcessInstance": runner_process_instance(),
         "exitCode": null,
         "readOnly": request.read_only,
         "resourceClass": request.resource_class.as_str(),
@@ -599,26 +624,27 @@ fn terminal_from_runtime(
         Ok(output) => (
             "succeeded",
             json!({
-                "id": request.id,
-                "status": "succeeded",
-                "mode": request.mode.as_str(),
-                "createdAtUtc": request.created_at_utc,
-                "queuedAtUtc": queued_at_utc,
-                "startedAtUtc": started_at_utc,
-                "completedAtUtc": utc_now(),
-                "runnerPid": std::process::id(),
-                "exitCode": output.exit_code,
-                "readOnly": request.read_only,
-                "resourceClass": request.resource_class.as_str(),
-                "runtimeMode": request.runtime_mode,
-                "queueWaitMs": lease.queue_wait_ms,
-                "executionSlot": lease.slot,
-                "executionSlots": lease.slots,
-                "executionPool": lease.pool,
-                "executionWeight": lease.weight,
-                "childPid": child_pid,
-                "logs": logs,
-            }),
+                    "id": request.id,
+                    "status": "succeeded",
+                    "mode": request.mode.as_str(),
+                    "createdAtUtc": request.created_at_utc,
+                    "queuedAtUtc": queued_at_utc,
+                    "startedAtUtc": started_at_utc,
+                    "completedAtUtc": utc_now(),
+                    "runnerPid": std::process::id(),
+            "runnerProcessInstance": runner_process_instance(),
+                    "exitCode": output.exit_code,
+                    "readOnly": request.read_only,
+                    "resourceClass": request.resource_class.as_str(),
+                    "runtimeMode": request.runtime_mode,
+                    "queueWaitMs": lease.queue_wait_ms,
+                    "executionSlot": lease.slot,
+                    "executionSlots": lease.slots,
+                    "executionPool": lease.pool,
+                    "executionWeight": lease.weight,
+                    "childPid": child_pid,
+                    "logs": logs,
+                }),
         ),
         Err(error) => {
             let process = match &error {
@@ -637,27 +663,28 @@ fn terminal_from_runtime(
             (
                 status,
                 json!({
-                    "id": request.id,
-                    "status": status,
-                    "mode": request.mode.as_str(),
-                    "createdAtUtc": request.created_at_utc,
-                    "queuedAtUtc": queued_at_utc,
-                    "startedAtUtc": started_at_utc,
-                    "completedAtUtc": utc_now(),
-                    "runnerPid": std::process::id(),
-                    "exitCode": process.and_then(|value| value.exit_code),
-                    "readOnly": request.read_only,
-                    "resourceClass": request.resource_class.as_str(),
-                    "runtimeMode": request.runtime_mode,
-                    "queueWaitMs": lease.queue_wait_ms,
-                    "executionSlot": lease.slot,
-                    "executionSlots": lease.slots,
-                    "executionPool": lease.pool,
-                    "executionWeight": lease.weight,
-                    "childPid": child_pid,
-                    "error": error.to_string(),
-                    "logs": logs,
-                }),
+                            "id": request.id,
+                            "status": status,
+                            "mode": request.mode.as_str(),
+                            "createdAtUtc": request.created_at_utc,
+                            "queuedAtUtc": queued_at_utc,
+                            "startedAtUtc": started_at_utc,
+                            "completedAtUtc": utc_now(),
+                            "runnerPid": std::process::id(),
+                "runnerProcessInstance": runner_process_instance(),
+                            "exitCode": process.and_then(|value| value.exit_code),
+                            "readOnly": request.read_only,
+                            "resourceClass": request.resource_class.as_str(),
+                            "runtimeMode": request.runtime_mode,
+                            "queueWaitMs": lease.queue_wait_ms,
+                            "executionSlot": lease.slot,
+                            "executionSlots": lease.slots,
+                            "executionPool": lease.pool,
+                            "executionWeight": lease.weight,
+                            "childPid": child_pid,
+                            "error": error.to_string(),
+                            "logs": logs,
+                        }),
             )
         }
     }
@@ -718,6 +745,8 @@ mod tests {
             orphan_stale: Duration::from_secs(5),
             retention: Duration::ZERO,
             max_wait: Duration::from_secs(1),
+            max_store_bytes: 1024 * 1024,
+            max_terminal_jobs: 100,
         });
         let state = HeartbeatState {
             store,
@@ -725,6 +754,7 @@ mod tests {
             runtime_mode: "host".to_owned(),
             status: Arc::new(RwLock::new("queued".to_owned())),
             child_pid: Arc::new(AtomicU32::new(0)),
+            child_process_instance: Arc::new(AtomicU64::new(0)),
         };
         tokio::time::timeout(Duration::from_secs(1), state.set_status("running"))
             .await

--- a/rust-mcp/src/jobs.rs
+++ b/rust-mcp/src/jobs.rs
@@ -830,7 +830,7 @@ struct OrphanCleanup {
 
 async fn cleanup_orphan_child(
     child_pid: Option<u32>,
-    child_process_instance: Option<u64>,
+    _child_process_instance: Option<u64>,
     heartbeat_age: Option<Duration>,
     runtime_mode: &str,
 ) -> OrphanCleanup {
@@ -843,7 +843,7 @@ async fn cleanup_orphan_child(
         return result;
     };
     #[cfg(windows)]
-    if !crate::windows_process::process_matches_instance(pid, child_process_instance) {
+    if !crate::windows_process::process_matches_instance(pid, _child_process_instance) {
         result.skipped = Some("child-process-instance-no-longer-matches".to_owned());
         return result;
     }

--- a/rust-mcp/src/jobs.rs
+++ b/rust-mcp/src/jobs.rs
@@ -538,6 +538,7 @@ impl JobStore {
                 .clone()
         };
         let mut total_bytes = 0_u64;
+        let mut terminal_bytes = 0_u64;
         let mut terminal = Vec::<(OffsetDateTime, String, u64)>::new();
         for id in ids {
             let paths = self.paths(&id)?;
@@ -547,6 +548,7 @@ impl JobStore {
                 continue;
             };
             if is_terminal(status_name(&status)) {
+                terminal_bytes = terminal_bytes.saturating_add(bytes);
                 let timestamp = status
                     .get("completedAtUtc")
                     .and_then(Value::as_str)
@@ -572,12 +574,29 @@ impl JobStore {
             return Ok(());
         }
         terminal.sort_by_key(|item| item.0);
-        let target_bytes = self.config.max_store_bytes.saturating_mul(9) / 10;
+        let active_bytes = total_bytes.saturating_sub(terminal_bytes);
+        let target_terminal_bytes = if self.config.max_store_bytes == 0 {
+            u64::MAX
+        } else if active_bytes >= self.config.max_store_bytes {
+            // Active jobs are not evictable. If they alone exceed the hard quota,
+            // deleting all terminal history cannot solve the pressure condition.
+            terminal_bytes
+        } else {
+            let low_water_total = self.config.max_store_bytes.saturating_mul(9) / 10;
+            let target_total = if active_bytes < low_water_total {
+                low_water_total
+            } else {
+                self.config.max_store_bytes
+            };
+            target_total.saturating_sub(active_bytes)
+        };
         let target_jobs = self.config.max_terminal_jobs.saturating_mul(9) / 10;
         let mut retained = terminal.len();
+        let mut retained_terminal_bytes = terminal_bytes;
         let mut deleted = HashSet::new();
         for (_, id, bytes) in terminal {
-            let bytes_ok = self.config.max_store_bytes == 0 || total_bytes <= target_bytes;
+            let bytes_ok = self.config.max_store_bytes == 0
+                || retained_terminal_bytes <= target_terminal_bytes;
             let jobs_ok = self.config.max_terminal_jobs == 0 || retained <= target_jobs;
             if bytes_ok && jobs_ok {
                 break;
@@ -585,6 +604,7 @@ impl JobStore {
             let paths = self.paths(&id)?;
             if fs::remove_dir_all(&paths.dir).await.is_ok() {
                 total_bytes = total_bytes.saturating_sub(bytes);
+                retained_terminal_bytes = retained_terminal_bytes.saturating_sub(bytes);
                 retained = retained.saturating_sub(1);
                 deleted.insert(id);
                 summary.deleted = summary.deleted.saturating_add(1);
@@ -1514,6 +1534,40 @@ mod tests {
         assert!(summary.quota_deleted >= 1);
         assert!(store.paths("job-quotaact3").unwrap().dir.exists());
         assert!(!store.paths("job-quotaold1").unwrap().dir.exists());
+    }
+
+    #[tokio::test]
+    async fn active_byte_pressure_does_not_erase_terminal_history_when_it_cannot_help() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut config = store(temp.path()).config().clone();
+        config.max_store_bytes = 1;
+        config.max_terminal_jobs = 10;
+        let store = JobStore::new(config);
+        for (id, status) in [
+            ("job-pressure-active", "running"),
+            ("job-pressure-term", "succeeded"),
+        ] {
+            let paths = write_status(
+                &store,
+                id,
+                json!({
+                    "id": id,
+                    "status": status,
+                    "createdAtUtc": "2026-01-01T00:00:00Z",
+                    "completedAtUtc": if status == "running" { Value::Null } else { json!("2026-01-01T00:00:00Z") },
+                    "runnerPid": if status == "running" { json!(std::process::id()) } else { Value::Null },
+                }),
+            )
+            .await;
+            fs::write(&paths.stdout, vec![b'x'; 4096]).await.unwrap();
+        }
+        store.refresh_maintenance_index().await.unwrap();
+        let mut summary = ReconcileSummary::default();
+        store.apply_store_quota(&mut summary).await.unwrap();
+        assert!(summary.quota_pressure);
+        assert_eq!(summary.quota_deleted, 0);
+        assert!(store.paths("job-pressure-active").unwrap().dir.exists());
+        assert!(store.paths("job-pressure-term").unwrap().dir.exists());
     }
 
     #[tokio::test]

--- a/rust-mcp/src/jobs.rs
+++ b/rust-mcp/src/jobs.rs
@@ -18,6 +18,7 @@ use crate::{execution::process_alive, process::terminate_process_tree};
 
 const MAX_LOG_READ_CHARS: usize = 100_000;
 const CHILD_IDENTITY_MAX_AGE: Duration = Duration::from_secs(60);
+const MAINTENANCE_INDEX_REFRESH: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Clone)]
 pub struct JobStoreConfig {
@@ -27,6 +28,8 @@ pub struct JobStoreConfig {
     pub orphan_stale: Duration,
     pub retention: Duration,
     pub max_wait: Duration,
+    pub max_store_bytes: u64,
+    pub max_terminal_jobs: usize,
 }
 
 impl JobStoreConfig {
@@ -67,6 +70,16 @@ pub struct ReconcileSummary {
     pub compacted_logs: u64,
     pub deleted: u64,
     pub errors: u64,
+    #[serde(rename = "cycleCompleted")]
+    pub cycle_completed: bool,
+    #[serde(rename = "storeBytes")]
+    pub store_bytes: u64,
+    #[serde(rename = "terminalRetained")]
+    pub terminal_retained: u64,
+    #[serde(rename = "quotaDeleted")]
+    pub quota_deleted: u64,
+    #[serde(rename = "quotaPressure")]
+    pub quota_pressure: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -112,10 +125,18 @@ pub struct LegacyCompaction {
     pub previous_bytes: Option<u64>,
 }
 
+#[derive(Debug, Default)]
+struct MaintenanceIndex {
+    ids: Vec<String>,
+    cursor: usize,
+    initialized: bool,
+    refreshed_at: Option<SystemTime>,
+}
+
 #[derive(Debug, Clone)]
 pub struct JobStore {
     config: JobStoreConfig,
-    maintenance_cursor: Arc<Mutex<Option<String>>>,
+    maintenance_index: Arc<Mutex<MaintenanceIndex>>,
 }
 
 impl JobStore {
@@ -123,7 +144,7 @@ impl JobStore {
     pub fn new(config: JobStoreConfig) -> Self {
         Self {
             config: config.normalized(),
-            maintenance_cursor: Arc::new(Mutex::new(None)),
+            maintenance_index: Arc::new(Mutex::new(MaintenanceIndex::default())),
         }
     }
 
@@ -156,6 +177,7 @@ impl JobStore {
             fs::remove_dir_all(&paths.dir).await.ok();
             return Err(error);
         }
+        self.note_job_created(job_id);
         Ok(paths)
     }
 
@@ -257,7 +279,7 @@ impl JobStore {
         // back to an OS liveness check once the heartbeat is stale.
         let runner_alive = match (runner_pid, heartbeat_stale) {
             (Some(_), false) => true,
-            (Some(pid), true) => process_alive(pid).await,
+            (Some(_), true) => runner_owner_alive(&object).await,
             (None, _) => false,
         };
         if !runner_alive && heartbeat_stale {
@@ -275,9 +297,10 @@ impl JobStore {
         mut object: Map<String, Value>,
     ) -> Result<Value> {
         let runner_pid = u32_field(&object, "runnerPid");
-        let runner_alive = match runner_pid {
-            Some(pid) => process_alive(pid).await,
-            None => false,
+        let runner_alive = if runner_pid.is_some() {
+            runner_owner_alive(&object).await
+        } else {
+            false
         };
         object.insert("status".to_owned(), json!("cancelled"));
         object.insert("cancelRequested".to_owned(), json!(true));
@@ -304,6 +327,11 @@ impl JobStore {
             .and_then(Value::as_u64)
             .and_then(|pid| u32::try_from(pid).ok())
             .or_else(|| u32_field(&object, "childPid"));
+        let child_process_instance = heartbeat
+            .as_ref()
+            .and_then(|value| value.get("childProcessInstance"))
+            .and_then(Value::as_u64)
+            .or_else(|| object.get("childProcessInstance").and_then(Value::as_u64));
         let runtime_mode = string_field(&object, "runtimeMode")
             .map(str::to_owned)
             .or_else(|| {
@@ -314,7 +342,13 @@ impl JobStore {
                     .map(str::to_owned)
             })
             .unwrap_or_else(|| "host".to_owned());
-        let cleanup = cleanup_orphan_child(child_pid, heartbeat_age, &runtime_mode).await;
+        let cleanup = cleanup_orphan_child(
+            child_pid,
+            child_process_instance,
+            heartbeat_age,
+            &runtime_mode,
+        )
+        .await;
 
         object.insert("status".to_owned(), json!("interrupted"));
         if object.get("completedAtUtc").is_none_or(Value::is_null) {
@@ -353,30 +387,58 @@ impl JobStore {
     /// Reconcile every known job, compact one-time legacy oversized logs, and apply retention.
     ///
     /// # Errors
-    /// Returns an error only when the jobs root itself cannot be created/read. Per-job failures are counted.
+    /// Returns an error if the jobs root or indexed job state cannot be read or maintained.
     pub async fn reconcile_all(&self) -> Result<ReconcileSummary> {
-        *self
-            .maintenance_cursor
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner) = None;
-        let result = self.reconcile_maintenance_batch(usize::MAX).await;
-        *self
-            .maintenance_cursor
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner) = None;
-        result
+        self.refresh_maintenance_index().await?;
+        self.reconcile_maintenance_batch(usize::MAX).await
     }
 
-    /// Reconcile a bounded slice of known jobs so maintenance cost cannot grow linearly
-    /// with the entire retained history on every minute tick.
-    ///
-    /// The directory names are cheap to enumerate, while status/log inspection is capped
-    /// to `max_jobs`. The cursor is shared by all clones in this MCP process so successive
-    /// passes advance through the retained set instead of repeatedly starting at job zero.
+    /// Reconcile a bounded slice from an in-memory job index. Directory discovery is performed
+    /// once on startup and then at most hourly; jobs created by this MCP are inserted directly.
     ///
     /// # Errors
-    /// Returns an error when the jobs root cannot be enumerated. Per-job failures are counted.
+    /// Returns an error if the jobs root/index cannot be read or quota cleanup fails.
     pub async fn reconcile_maintenance_batch(&self, max_jobs: usize) -> Result<ReconcileSummary> {
+        fs::create_dir_all(&self.config.root).await?;
+        if self.maintenance_index_needs_refresh() {
+            self.refresh_maintenance_index().await?;
+        }
+        let (discovered, ids, cycle_completed) = self.next_maintenance_slice(max_jobs);
+        let mut summary = ReconcileSummary {
+            discovered: u64::try_from(discovered).unwrap_or(u64::MAX),
+            scanned: u64::try_from(ids.len()).unwrap_or(u64::MAX),
+            batch_limited: !cycle_completed,
+            cycle_completed,
+            ..ReconcileSummary::default()
+        };
+        for id in &ids {
+            if self
+                .reconcile_one_for_maintenance(id, &mut summary)
+                .await
+                .is_err()
+            {
+                summary.errors = summary.errors.saturating_add(1);
+            }
+        }
+        if cycle_completed {
+            self.apply_store_quota(&mut summary).await?;
+        }
+        Ok(summary)
+    }
+
+    fn maintenance_index_needs_refresh(&self) -> bool {
+        let index = self
+            .maintenance_index
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        !index.initialized
+            || index
+                .refreshed_at
+                .and_then(|at| at.elapsed().ok())
+                .is_none_or(|age| age >= MAINTENANCE_INDEX_REFRESH)
+    }
+
+    async fn refresh_maintenance_index(&self) -> Result<()> {
         fs::create_dir_all(&self.config.root).await?;
         let mut reader = fs::read_dir(&self.config.root).await?;
         let mut ids = Vec::new();
@@ -387,46 +449,152 @@ impl JobStore {
             }
         }
         ids.sort_unstable();
-        let mut summary = ReconcileSummary {
-            discovered: u64::try_from(ids.len()).unwrap_or(u64::MAX),
-            ..ReconcileSummary::default()
-        };
-        if ids.is_empty() || max_jobs == 0 {
-            return Ok(summary);
-        }
-
-        let cursor = self
-            .maintenance_cursor
+        let mut index = self
+            .maintenance_index
             .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .clone();
-        let start = cursor
-            .as_deref()
-            .and_then(|value| ids.iter().position(|id| id.as_str() > value))
-            .unwrap_or(0);
-        let limit = max_jobs.min(ids.len());
-        let end = start.saturating_add(limit).min(ids.len());
-        for id in &ids[start..end] {
-            summary.scanned = summary.scanned.saturating_add(1);
-            if self
-                .reconcile_one_for_maintenance(id, &mut summary)
-                .await
-                .is_err()
-            {
-                summary.errors = summary.errors.saturating_add(1);
+            .unwrap_or_else(PoisonError::into_inner);
+        index.ids = ids;
+        index.cursor = 0;
+        index.initialized = true;
+        index.refreshed_at = Some(SystemTime::now());
+        Ok(())
+    }
+
+    fn next_maintenance_slice(&self, max_jobs: usize) -> (usize, Vec<String>, bool) {
+        let mut index = self
+            .maintenance_index
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let discovered = index.ids.len();
+        if discovered == 0 || max_jobs == 0 {
+            return (discovered, Vec::new(), discovered == 0);
+        }
+        if index.cursor >= discovered {
+            index.cursor = 0;
+        }
+        let start = index.cursor;
+        let end = start
+            .saturating_add(max_jobs.min(discovered))
+            .min(discovered);
+        let ids = index.ids[start..end].to_vec();
+        let completed = end >= discovered;
+        index.cursor = if completed { 0 } else { end };
+        (discovered, ids, completed)
+    }
+
+    fn note_job_created(&self, job_id: &str) {
+        let mut index = self
+            .maintenance_index
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if !index.initialized {
+            return;
+        }
+        match index
+            .ids
+            .binary_search_by(|value| value.as_str().cmp(job_id))
+        {
+            Ok(_) => {}
+            Err(at) => index.ids.insert(at, job_id.to_owned()),
+        }
+    }
+
+    fn note_job_deleted(&self, job_id: &str) {
+        let mut index = self
+            .maintenance_index
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Ok(at) = index
+            .ids
+            .binary_search_by(|value| value.as_str().cmp(job_id))
+        {
+            index.ids.remove(at);
+            if at < index.cursor {
+                index.cursor = index.cursor.saturating_sub(1);
             }
         }
-        summary.batch_limited = end < ids.len();
-        let next_cursor = if end >= ids.len() {
-            None
-        } else {
-            ids.get(end.saturating_sub(1)).cloned()
-        };
-        *self
-            .maintenance_cursor
+        index.cursor = index.cursor.min(index.ids.len());
+    }
+
+    fn note_jobs_deleted(&self, deleted: &std::collections::HashSet<String>) {
+        if deleted.is_empty() {
+            return;
+        }
+        let mut index = self
+            .maintenance_index
             .lock()
-            .unwrap_or_else(PoisonError::into_inner) = next_cursor;
-        Ok(summary)
+            .unwrap_or_else(PoisonError::into_inner);
+        index.ids.retain(|id| !deleted.contains(id));
+        index.cursor = index.cursor.min(index.ids.len());
+    }
+
+    async fn apply_store_quota(&self, summary: &mut ReconcileSummary) -> Result<()> {
+        use std::collections::HashSet;
+        let ids = {
+            self.maintenance_index
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .ids
+                .clone()
+        };
+        let mut total_bytes = 0_u64;
+        let mut terminal = Vec::<(OffsetDateTime, String, u64)>::new();
+        for id in ids {
+            let paths = self.paths(&id)?;
+            let bytes = shallow_directory_bytes(&paths.dir).await.unwrap_or(0);
+            total_bytes = total_bytes.saturating_add(bytes);
+            let Ok(status) = read_json(&paths.status).await else {
+                continue;
+            };
+            if is_terminal(status_name(&status)) {
+                let timestamp = status
+                    .get("completedAtUtc")
+                    .and_then(Value::as_str)
+                    .and_then(parse_utc)
+                    .or_else(|| {
+                        status
+                            .get("createdAtUtc")
+                            .and_then(Value::as_str)
+                            .and_then(parse_utc)
+                    })
+                    .unwrap_or(OffsetDateTime::UNIX_EPOCH);
+                terminal.push((timestamp, id, bytes));
+            }
+        }
+        summary.store_bytes = total_bytes;
+        summary.terminal_retained = u64::try_from(terminal.len()).unwrap_or(u64::MAX);
+        let over_bytes =
+            self.config.max_store_bytes > 0 && total_bytes > self.config.max_store_bytes;
+        let over_jobs =
+            self.config.max_terminal_jobs > 0 && terminal.len() > self.config.max_terminal_jobs;
+        summary.quota_pressure = over_bytes || over_jobs;
+        if !summary.quota_pressure {
+            return Ok(());
+        }
+        terminal.sort_by_key(|item| item.0);
+        let target_bytes = self.config.max_store_bytes.saturating_mul(9) / 10;
+        let target_jobs = self.config.max_terminal_jobs.saturating_mul(9) / 10;
+        let mut retained = terminal.len();
+        let mut deleted = HashSet::new();
+        for (_, id, bytes) in terminal {
+            let bytes_ok = self.config.max_store_bytes == 0 || total_bytes <= target_bytes;
+            let jobs_ok = self.config.max_terminal_jobs == 0 || retained <= target_jobs;
+            if bytes_ok && jobs_ok {
+                break;
+            }
+            let paths = self.paths(&id)?;
+            if fs::remove_dir_all(&paths.dir).await.is_ok() {
+                total_bytes = total_bytes.saturating_sub(bytes);
+                retained = retained.saturating_sub(1);
+                deleted.insert(id);
+                summary.deleted = summary.deleted.saturating_add(1);
+                summary.quota_deleted = summary.quota_deleted.saturating_add(1);
+            }
+        }
+        self.note_jobs_deleted(&deleted);
+        summary.store_bytes = total_bytes;
+        summary.terminal_retained = u64::try_from(retained).unwrap_or(u64::MAX);
+        Ok(())
     }
 
     async fn reconcile_one_for_maintenance(
@@ -450,6 +618,7 @@ impl JobStore {
         let paths = self.paths(job_id)?;
         if self.retention_expired(&status) {
             fs::remove_dir_all(&paths.dir).await?;
+            self.note_job_deleted(job_id);
             summary.deleted = summary.deleted.saturating_add(1);
             return Ok(());
         }
@@ -597,7 +766,7 @@ impl JobStore {
         cancelled.insert("cancelRequested".to_owned(), json!(true));
         create_marker_once(&paths.cancel, &format!("{completed}\n")).await?;
         if let Some(pid) = u32_field(&cancelled, "runnerPid").filter(|_| runner_alive)
-            && process_alive(pid).await
+            && runner_owner_alive(&cancelled).await
         {
             terminate_job_runner_gracefully(pid, &paths.status).await;
         }
@@ -661,6 +830,7 @@ struct OrphanCleanup {
 
 async fn cleanup_orphan_child(
     child_pid: Option<u32>,
+    child_process_instance: Option<u64>,
     heartbeat_age: Option<Duration>,
     runtime_mode: &str,
 ) -> OrphanCleanup {
@@ -672,6 +842,12 @@ async fn cleanup_orphan_child(
     let Some(pid) = child_pid else {
         return result;
     };
+    #[cfg(windows)]
+    if !crate::windows_process::process_matches_instance(pid, child_process_instance) {
+        result.skipped = Some("child-process-instance-no-longer-matches".to_owned());
+        return result;
+    }
+    #[cfg(not(windows))]
     if !process_alive(pid).await {
         return result;
     }
@@ -975,6 +1151,40 @@ fn u32_field(object: &Map<String, Value>, key: &str) -> Option<u32> {
         .and_then(|value| u32::try_from(value).ok())
 }
 
+#[cfg(windows)]
+fn runner_owner_alive(object: &Map<String, Value>) -> std::future::Ready<bool> {
+    let alive = u32_field(object, "runnerPid").is_some_and(|pid| {
+        let instance = object.get("runnerProcessInstance").and_then(Value::as_u64);
+        crate::windows_process::process_matches_instance(pid, instance)
+    });
+    std::future::ready(alive)
+}
+
+#[cfg(not(windows))]
+async fn runner_owner_alive(object: &Map<String, Value>) -> bool {
+    let Some(pid) = u32_field(object, "runnerPid") else {
+        return false;
+    };
+    process_alive(pid).await
+}
+
+async fn shallow_directory_bytes(path: &Path) -> Result<u64> {
+    let mut total = 0_u64;
+    let mut reader = match fs::read_dir(path).await {
+        Ok(reader) => reader,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error.into()),
+    };
+    while let Some(entry) = reader.next_entry().await? {
+        if let Ok(metadata) = entry.metadata().await
+            && metadata.is_file()
+        {
+            total = total.saturating_add(metadata.len());
+        }
+    }
+    Ok(total)
+}
+
 fn parse_utc(value: &str) -> Option<OffsetDateTime> {
     OffsetDateTime::parse(value, &Rfc3339).ok()
 }
@@ -1038,6 +1248,8 @@ mod tests {
             orphan_stale: Duration::from_millis(1),
             retention: Duration::from_secs(1),
             max_wait: Duration::from_secs(2),
+            max_store_bytes: 1024 * 1024,
+            max_terminal_jobs: 100,
         })
     }
 
@@ -1266,6 +1478,40 @@ mod tests {
         let summary = store.reconcile_all().await.unwrap();
         assert_eq!(summary.deleted, 1);
         assert!(!paths.dir.exists());
+    }
+
+    #[tokio::test]
+    async fn store_quota_evicts_oldest_terminal_jobs_but_keeps_active_jobs() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut config = store(temp.path()).config().clone();
+        config.max_store_bytes = 1;
+        config.max_terminal_jobs = 1;
+        let store = JobStore::new(config);
+        for (id, status, completed) in [
+            ("job-quotaold1", "succeeded", "2020-01-01T00:00:00Z"),
+            ("job-quotanew2", "succeeded", "2021-01-01T00:00:00Z"),
+            ("job-quotaact3", "running", "2022-01-01T00:00:00Z"),
+        ] {
+            write_status(
+                &store,
+                id,
+                json!({
+                    "id": id,
+                    "status": status,
+                    "createdAtUtc": completed,
+                    "completedAtUtc": if status == "running" { Value::Null } else { json!(completed) },
+                    "runnerPid": if status == "running" { json!(std::process::id()) } else { Value::Null },
+                }),
+            )
+            .await;
+        }
+        store.refresh_maintenance_index().await.unwrap();
+        let mut summary = ReconcileSummary::default();
+        store.apply_store_quota(&mut summary).await.unwrap();
+        assert!(summary.quota_pressure);
+        assert!(summary.quota_deleted >= 1);
+        assert!(store.paths("job-quotaact3").unwrap().dir.exists());
+        assert!(!store.paths("job-quotaold1").unwrap().dir.exists());
     }
 
     #[tokio::test]

--- a/rust-mcp/src/jobs.rs
+++ b/rust-mcp/src/jobs.rs
@@ -830,7 +830,7 @@ struct OrphanCleanup {
 
 async fn cleanup_orphan_child(
     child_pid: Option<u32>,
-    _child_process_instance: Option<u64>,
+    child_process_instance: Option<u64>,
     heartbeat_age: Option<Duration>,
     runtime_mode: &str,
 ) -> OrphanCleanup {
@@ -842,8 +842,10 @@ async fn cleanup_orphan_child(
     let Some(pid) = child_pid else {
         return result;
     };
+    #[cfg(not(windows))]
+    let _ = child_process_instance;
     #[cfg(windows)]
-    if !crate::windows_process::process_matches_instance(pid, _child_process_instance) {
+    if !crate::windows_process::process_matches_instance(pid, child_process_instance) {
         result.skipped = Some("child-process-instance-no-longer-matches".to_owned());
         return result;
     }

--- a/rust-mcp/src/lib.rs
+++ b/rust-mcp/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod allocator_metrics;
+pub mod background;
 pub mod capture;
 pub mod config;
 pub mod contract;
@@ -7,6 +8,7 @@ pub mod execution;
 pub mod files;
 pub mod gateway;
 pub mod github_auth;
+pub mod hex;
 pub mod host_inspect;
 pub mod job_logs;
 pub mod job_manager;
@@ -32,6 +34,8 @@ pub use server::{DevboxMcp, build_router};
 
 #[cfg(windows)]
 pub mod windows_capture;
+#[cfg(windows)]
+pub mod windows_job;
 #[cfg(windows)]
 pub mod windows_process;
 pub mod windows_shell;

--- a/rust-mcp/src/lifecycle.rs
+++ b/rust-mcp/src/lifecycle.rs
@@ -666,6 +666,8 @@ mod tests {
             job_heartbeat_ms: 5_000,
             job_orphan_stale_ms: 15_000,
             job_retention_hours: 168,
+            job_store_max_bytes: 2 * 1024 * 1024 * 1024,
+            job_store_max_terminal_jobs: 5_000,
             screen_capture_attempt_timeout_ms: 8_000,
             screen_capture_retries: 1,
             screen_capture_queue_timeout_ms: 5_000,

--- a/rust-mcp/src/lifecycle.rs
+++ b/rust-mcp/src/lifecycle.rs
@@ -608,73 +608,13 @@ mod tests {
     #[test]
     fn create_args_match_javascript_order() {
         let root = PathBuf::from("C:/workspace");
-        let config = Config {
-            project_root: root.clone(),
-            host: "127.0.0.1".to_owned(),
-            port: 0,
-            auth_mode: crate::AuthMode::None,
-            runtime_mode: RuntimeMode::Docker,
-            platform: crate::Platform::detect(),
-            public_base_url: None,
-            gateway_bridge: crate::config::GatewayBridgeConfig {
-                enabled: false,
-                origins: vec![
-                    "https://chatgpt.com".to_owned(),
-                    "https://chat.openai.com".to_owned(),
-                ],
-            },
-            oauth_state_file_path: root.join("oauth-state.json"),
-            cloudflare_access_team_domain: None,
-            cloudflare_access_aud: String::new(),
-            cloudflare_access_jwks_url: None,
-            host_workspace_path: root.clone(),
-            devbox_workspace_path: PathBuf::from("/workspace"),
-            devbox_container_name: "box".to_owned(),
-            devbox_image_name: "img:1".to_owned(),
-            devbox_tmp_volume_name: "box-tmp".to_owned(),
-            devbox_retired_container_grace_ms: 300_000,
-            devbox_auto_start: true,
-            devbox_version_cache_ms: 120_000,
-            docker_command_timeout_ms: 120_000,
-            devbox_default_user: "root".to_owned(),
-            host_default_workdir: root.clone(),
-            host_shell: "pwsh".to_owned(),
-            power_shell_exe: "pwsh".to_owned(),
-            power_shell_fallback_exe: "powershell.exe".to_owned(),
-            node_exe: "node".to_owned(),
-            host_program_allowlist: vec![],
-            host_search_backend: crate::config::HostSearchBackend::Auto,
-            devbox_program_allowlist: vec![],
-            host_exec_enabled: true,
-            allow_windows_host_exec_uac: false,
-            execution_slot_root: root.join("slots"),
-            jobs_root: root.join("jobs"),
-            mcp_performance_state_path: root.join("mcp-performance.json"),
-            usage_log: crate::config::UsageLogConfig {
-                max_bytes: 16 * 1024 * 1024,
-                rotations: 3,
-            },
-            mcp_json_body_limit_bytes: 16 * 1024 * 1024,
-            exec_max_concurrent: 6,
-            exec_reserved_interactive: 1,
-            exec_queue_timeout_ms: 15_000,
-            background_queue_timeout_ms: 300_000,
-            watch_max_concurrent: 4,
-            exec_heavy_weight: 2,
-            job_log_max_bytes: 32 * 1024 * 1024,
-            job_log_rotations: 2,
-            job_heartbeat_ms: 5_000,
-            job_orphan_stale_ms: 15_000,
-            job_retention_hours: 168,
-            job_store_max_bytes: 2 * 1024 * 1024 * 1024,
-            job_store_max_terminal_jobs: 5_000,
-            screen_capture_attempt_timeout_ms: 8_000,
-            screen_capture_retries: 1,
-            screen_capture_queue_timeout_ms: 5_000,
-            max_wait_seconds: 300.0,
-            command_output_limit_chars: 65_536,
-            max_mcp_transfer_chars: 4_000_000,
-        };
+        let mut config = crate::config::test_config(&root);
+        config.runtime_mode = RuntimeMode::Docker;
+        config.devbox_workspace_path = PathBuf::from("/workspace");
+        config.devbox_container_name = "box".to_owned();
+        config.devbox_image_name = "img:1".to_owned();
+        config.devbox_tmp_volume_name = "box-tmp".to_owned();
+        config.devbox_default_user = "root".to_owned();
         let args = create_container_args(&config);
         assert_eq!(
             args,

--- a/rust-mcp/src/performance.rs
+++ b/rust-mcp/src/performance.rs
@@ -14,6 +14,7 @@ use crate::background::BackgroundTaskRegistry;
 const SAMPLE_INTERVAL: Duration = Duration::from_millis(20);
 const DRIFT_INTERVAL: Duration = Duration::from_secs(1);
 const PERSIST_INTERVAL: Duration = Duration::from_secs(10);
+const PERSIST_STALE_AFTER: Duration = Duration::from_secs(30);
 const MAX_SAMPLES: usize = 15_000;
 const SHORT_WINDOW: Duration = Duration::from_secs(10);
 const ONE_MINUTE: Duration = Duration::from_secs(60);
@@ -37,6 +38,7 @@ struct PerformanceWindow {
 struct PerformanceInner {
     state: Arc<Mutex<PerformanceWindow>>,
     cached: Arc<RwLock<Value>>,
+    cached_at: Arc<RwLock<Instant>>,
     started_at: Instant,
     cancellation: CancellationToken,
 }
@@ -58,9 +60,11 @@ impl PerformanceMonitor {
         let state = Arc::new(Mutex::new(PerformanceWindow::default()));
         let started_at = Instant::now();
         let cached = Arc::new(RwLock::new(snapshot_value(&state, started_at)));
+        let cached_at = Arc::new(RwLock::new(Instant::now()));
         let inner = Arc::new(PerformanceInner {
             state,
             cached,
+            cached_at,
             started_at,
             cancellation: CancellationToken::new(),
         });
@@ -71,11 +75,18 @@ impl PerformanceMonitor {
 
     #[must_use]
     pub fn snapshot(&self) -> Value {
-        self.inner
+        let snapshot = self
+            .inner
             .cached
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone()
+            .clone();
+        let cached_at = *self
+            .inner
+            .cached_at
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        decorate_cache_freshness(snapshot, cached_at.elapsed())
     }
 }
 
@@ -126,6 +137,7 @@ fn spawn_persistence(
 ) {
     let state = inner.state.clone();
     let cached = inner.cached.clone();
+    let cached_at = inner.cached_at.clone();
     let started_at = inner.started_at;
     let history_path = state_path.with_file_name("mcp-performance-history.jsonl");
     background.spawn_supervised(
@@ -134,6 +146,7 @@ fn spawn_persistence(
         move |cancellation, heartbeat| {
             let state = state.clone();
             let cached = cached.clone();
+            let cached_at = cached_at.clone();
             let state_path = state_path.clone();
             let history_path = history_path.clone();
             async move {
@@ -144,6 +157,7 @@ fn spawn_persistence(
                         _ = interval.tick() => {
                             let snapshot = snapshot_value(&state, started_at);
                             *cached.write().unwrap_or_else(std::sync::PoisonError::into_inner) = snapshot.clone();
+                            *cached_at.write().unwrap_or_else(std::sync::PoisonError::into_inner) = Instant::now();
                             if let Err(error) = persist_snapshot(&state_path, &snapshot).await {
                                 tracing::debug!(%error, path = %state_path.display(), "failed to persist Rust MCP performance snapshot");
                             }
@@ -189,7 +203,7 @@ async fn append_history(path: &std::path::Path, snapshot: &Value) -> std::io::Re
         for index in (1..HISTORY_ROTATIONS).rev() {
             let from = history_rotation_path(path, index);
             let to = history_rotation_path(path, index + 1);
-            if tokio::fs::rename(&from, &to).await.is_err() {}
+            let _ = tokio::fs::rename(&from, &to).await;
         }
         let _ = tokio::fs::rename(path, history_rotation_path(path, 1)).await;
     }
@@ -203,7 +217,7 @@ async fn append_history(path: &std::path::Path, snapshot: &Value) -> std::io::Re
         "rss": snapshot.pointer("/process/memory/rss"),
         "private": snapshot.pointer("/process/memory/private"),
         "allocatorCurrent": snapshot.pointer("/process/memory/allocator/currentRequestedBytes"),
-        "cpuTotalMs": snapshot.pointer("/process/platform/cpuTotalMs"),
+        "cpuTotalMs": snapshot.pointer("/process/cpuTotalMs"),
     });
     let mut bytes = serde_json::to_vec(&compact).map_err(std::io::Error::other)?;
     bytes.push(b'\n');
@@ -225,6 +239,8 @@ fn snapshot_value(state: &Arc<Mutex<PerformanceWindow>>, started_at: Instant) ->
     let short = window_snapshot(&window, now, SHORT_WINDOW);
     let one_minute = window_snapshot(&window, now, ONE_MINUTE);
     let five_minute = window_snapshot(&window, now, FIVE_MINUTES);
+    let platform = process_platform_snapshot();
+    let cpu_total_ms = process_cpu_total_ms(&platform);
     json!({
         "eventLoop": {
             "sampledAtUtc": Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
@@ -241,9 +257,47 @@ fn snapshot_value(state: &Arc<Mutex<PerformanceWindow>>, started_at: Instant) ->
             "pid": std::process::id(),
             "uptimeSeconds": started_at.elapsed().as_secs_f64(),
             "memory": process_memory_snapshot(),
-            "platform": process_platform_snapshot(),
+            "cpuTotalMs": cpu_total_ms,
+            "platform": platform,
         },
     })
+}
+
+fn decorate_cache_freshness(mut snapshot: Value, age: Duration) -> Value {
+    if let Some(object) = snapshot.as_object_mut() {
+        object.insert(
+            "cachedAgeMs".to_owned(),
+            json!(u64::try_from(age.as_millis()).unwrap_or(u64::MAX)),
+        );
+        object.insert("stale".to_owned(), json!(age > PERSIST_STALE_AFTER));
+    }
+    snapshot
+}
+
+fn process_cpu_total_ms(platform: &Value) -> Option<f64> {
+    #[cfg(windows)]
+    {
+        platform.get("cpuTotalMs").and_then(Value::as_f64)
+    }
+    #[cfg(unix)]
+    {
+        use nix::sys::{
+            resource::{UsageWho, getrusage},
+            time::TimeValLike as _,
+        };
+        let _ = platform;
+        let usage = getrusage(UsageWho::RUSAGE_SELF).ok()?;
+        let micros = usage
+            .user_time()
+            .num_microseconds()
+            .saturating_add(usage.system_time().num_microseconds());
+        Some(micros as f64 / 1_000.0)
+    }
+    #[cfg(not(any(windows, unix)))]
+    {
+        let _ = platform;
+        None
+    }
 }
 
 fn window_snapshot(window: &PerformanceWindow, now: Instant, duration: Duration) -> Value {
@@ -449,6 +503,15 @@ mod tests {
         let values = [0.0, 1.0, 2.0, 3.0, 4.0];
         assert!((percentile(&values, 50) - 2.0).abs() < f64::EPSILON);
         assert!((percentile(&values, 95) - 4.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cached_snapshot_exposes_staleness() {
+        let fresh = decorate_cache_freshness(json!({"eventLoop": {}}), Duration::from_secs(1));
+        assert_eq!(fresh["stale"], false);
+        let stale = decorate_cache_freshness(json!({"eventLoop": {}}), Duration::from_secs(31));
+        assert_eq!(stale["stale"], true);
+        assert_eq!(stale["cachedAgeMs"], 31_000);
     }
 
     #[test]

--- a/rust-mcp/src/performance.rs
+++ b/rust-mcp/src/performance.rs
@@ -274,10 +274,10 @@ fn decorate_cache_freshness(mut snapshot: Value, age: Duration) -> Value {
     snapshot
 }
 
-fn process_cpu_total_ms(platform: &Value) -> Option<f64> {
+fn process_cpu_total_ms(platform: &Value) -> Option<u64> {
     #[cfg(windows)]
     {
-        platform.get("cpuTotalMs").and_then(Value::as_f64)
+        platform.get("cpuTotalMs").and_then(Value::as_u64)
     }
     #[cfg(unix)]
     {
@@ -291,7 +291,7 @@ fn process_cpu_total_ms(platform: &Value) -> Option<f64> {
             .user_time()
             .num_microseconds()
             .saturating_add(usage.system_time().num_microseconds());
-        Some(micros as f64 / 1_000.0)
+        u64::try_from(micros.saturating_div(1_000)).ok()
     }
     #[cfg(not(any(windows, unix)))]
     {
@@ -402,10 +402,7 @@ mod windows_memory {
     #![allow(unsafe_code)]
 
     use serde_json::{Value, json};
-    use std::{
-        mem::{size_of, zeroed},
-        time::Duration,
-    };
+    use std::mem::{size_of, zeroed};
     use windows_sys::Win32::System::{
         ProcessStatus::{K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS},
         Threading::GetCurrentProcess,
@@ -462,9 +459,9 @@ mod windows_memory {
             ) != 0
             {
                 let ticks = filetime_ticks(kernel).saturating_add(filetime_ticks(user));
-                Duration::from_nanos(ticks.saturating_mul(100)).as_secs_f64() * 1_000.0
+                ticks / 10_000
             } else {
-                0.0
+                0
             };
             let pid = std::process::id();
             let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);

--- a/rust-mcp/src/performance.rs
+++ b/rust-mcp/src/performance.rs
@@ -1,13 +1,15 @@
 use std::{
     collections::VecDeque,
     path::PathBuf,
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard, RwLock},
     time::{Duration, Instant},
 };
 
 use chrono::{SecondsFormat, Utc};
 use serde_json::{Value, json};
 use tokio_util::sync::CancellationToken;
+
+use crate::background::BackgroundTaskRegistry;
 
 const SAMPLE_INTERVAL: Duration = Duration::from_millis(20);
 const DRIFT_INTERVAL: Duration = Duration::from_secs(1);
@@ -16,6 +18,8 @@ const MAX_SAMPLES: usize = 15_000;
 const SHORT_WINDOW: Duration = Duration::from_secs(10);
 const ONE_MINUTE: Duration = Duration::from_secs(60);
 const FIVE_MINUTES: Duration = Duration::from_secs(300);
+const HISTORY_MAX_BYTES: u64 = 4 * 1024 * 1024;
+const HISTORY_ROTATIONS: usize = 3;
 
 #[derive(Debug, Clone, Copy)]
 struct TimedSample {
@@ -32,6 +36,7 @@ struct PerformanceWindow {
 #[derive(Debug)]
 struct PerformanceInner {
     state: Arc<Mutex<PerformanceWindow>>,
+    cached: Arc<RwLock<Value>>,
     started_at: Instant,
     cancellation: CancellationToken,
 }
@@ -49,83 +54,109 @@ pub struct PerformanceMonitor {
 
 impl PerformanceMonitor {
     #[must_use]
-    pub fn new(state_path: PathBuf) -> Self {
+    pub fn new(state_path: PathBuf, background: &BackgroundTaskRegistry) -> Self {
+        let state = Arc::new(Mutex::new(PerformanceWindow::default()));
+        let started_at = Instant::now();
+        let cached = Arc::new(RwLock::new(snapshot_value(&state, started_at)));
         let inner = Arc::new(PerformanceInner {
-            state: Arc::new(Mutex::new(PerformanceWindow::default())),
-            started_at: Instant::now(),
+            state,
+            cached,
+            started_at,
             cancellation: CancellationToken::new(),
         });
-        spawn_sampler(&inner);
-        spawn_persistence(&inner, state_path);
+        spawn_sampler(&inner, background);
+        spawn_persistence(&inner, state_path, background);
         Self { inner }
     }
 
     #[must_use]
     pub fn snapshot(&self) -> Value {
-        snapshot_value(&self.inner.state, self.inner.started_at)
+        self.inner
+            .cached
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 }
 
-fn spawn_sampler(inner: &PerformanceInner) {
+fn spawn_sampler(inner: &PerformanceInner, background: &BackgroundTaskRegistry) {
     let state = inner.state.clone();
-    let cancellation = inner.cancellation.child_token();
-    tokio::spawn(async move {
-        let mut expected_sample = tokio::time::Instant::now() + SAMPLE_INTERVAL;
-        let mut expected_drift = tokio::time::Instant::now() + DRIFT_INTERVAL;
-        loop {
-            tokio::select! {
-                () = cancellation.cancelled() => return,
-                () = tokio::time::sleep_until(expected_sample) => {
-                    let now = tokio::time::Instant::now();
-                    let delay_ms = now.saturating_duration_since(expected_sample).as_secs_f64() * 1_000.0;
-                    let mut window = lock_window(&state);
-                    window.delays.push_back(TimedSample { at: now.into_std(), value_ms: delay_ms });
-                    while window.delays.len() > MAX_SAMPLES {
-                        window.delays.pop_front();
-                    }
-                    if now >= expected_drift {
-                        let drift_ms = now.saturating_duration_since(expected_drift).as_secs_f64() * 1_000.0;
-                        window.drifts.push_back(TimedSample { at: now.into_std(), value_ms: drift_ms });
-                        expected_drift = now + DRIFT_INTERVAL;
-                    }
-                    if let Some(cutoff) = Instant::now().checked_sub(FIVE_MINUTES) {
-                        while window.delays.front().is_some_and(|sample| sample.at < cutoff) {
-                            window.delays.pop_front();
+    background.spawn_supervised(
+        "performance-sampler",
+        inner.cancellation.child_token(),
+        move |cancellation, heartbeat| {
+            let state = state.clone();
+            async move {
+                let mut expected_sample = tokio::time::Instant::now() + SAMPLE_INTERVAL;
+                let mut expected_drift = tokio::time::Instant::now() + DRIFT_INTERVAL;
+                loop {
+                    tokio::select! {
+                        () = cancellation.cancelled() => return Ok(()),
+                        () = tokio::time::sleep_until(expected_sample) => {
+                            let now = tokio::time::Instant::now();
+                            let delay_ms = now.saturating_duration_since(expected_sample).as_secs_f64() * 1_000.0;
+                            let mut window = lock_window(&state);
+                            window.delays.push_back(TimedSample { at: now.into_std(), value_ms: delay_ms });
+                            while window.delays.len() > MAX_SAMPLES { window.delays.pop_front(); }
+                            if now >= expected_drift {
+                                let drift_ms = now.saturating_duration_since(expected_drift).as_secs_f64() * 1_000.0;
+                                window.drifts.push_back(TimedSample { at: now.into_std(), value_ms: drift_ms });
+                                expected_drift = now + DRIFT_INTERVAL;
+                                heartbeat.tick();
+                            }
+                            if let Some(cutoff) = Instant::now().checked_sub(FIVE_MINUTES) {
+                                while window.delays.front().is_some_and(|sample| sample.at < cutoff) { window.delays.pop_front(); }
+                                while window.drifts.front().is_some_and(|sample| sample.at < cutoff) { window.drifts.pop_front(); }
+                            }
+                            drop(window);
+                            expected_sample += SAMPLE_INTERVAL;
+                            if now.saturating_duration_since(expected_sample) > Duration::from_secs(1) { expected_sample = now + SAMPLE_INTERVAL; }
                         }
-                        while window.drifts.front().is_some_and(|sample| sample.at < cutoff) {
-                            window.drifts.pop_front();
-                        }
-                    }
-                    drop(window);
-                    expected_sample += SAMPLE_INTERVAL;
-                    if now.saturating_duration_since(expected_sample) > Duration::from_secs(1) {
-                        expected_sample = now + SAMPLE_INTERVAL;
                     }
                 }
             }
-        }
-    });
+        },
+    );
 }
 
-fn spawn_persistence(inner: &PerformanceInner, state_path: PathBuf) {
+fn spawn_persistence(
+    inner: &PerformanceInner,
+    state_path: PathBuf,
+    background: &BackgroundTaskRegistry,
+) {
     let state = inner.state.clone();
+    let cached = inner.cached.clone();
     let started_at = inner.started_at;
-    let cancellation = inner.cancellation.child_token();
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(PERSIST_INTERVAL);
-        interval.tick().await;
-        loop {
-            tokio::select! {
-                () = cancellation.cancelled() => return,
-                _ = interval.tick() => {
-                    let snapshot = snapshot_value(&state, started_at);
-                    if let Err(error) = persist_snapshot(&state_path, &snapshot).await {
-                        tracing::debug!(%error, path = %state_path.display(), "failed to persist Rust MCP performance snapshot");
+    let history_path = state_path.with_file_name("mcp-performance-history.jsonl");
+    background.spawn_supervised(
+        "performance-persistence",
+        inner.cancellation.child_token(),
+        move |cancellation, heartbeat| {
+            let state = state.clone();
+            let cached = cached.clone();
+            let state_path = state_path.clone();
+            let history_path = history_path.clone();
+            async move {
+                let mut interval = tokio::time::interval(PERSIST_INTERVAL);
+                loop {
+                    tokio::select! {
+                        () = cancellation.cancelled() => return Ok(()),
+                        _ = interval.tick() => {
+                            let snapshot = snapshot_value(&state, started_at);
+                            *cached.write().unwrap_or_else(std::sync::PoisonError::into_inner) = snapshot.clone();
+                            if let Err(error) = persist_snapshot(&state_path, &snapshot).await {
+                                tracing::debug!(%error, path = %state_path.display(), "failed to persist Rust MCP performance snapshot");
+                            }
+                            if let Err(error) = append_history(&history_path, &snapshot).await {
+                                tracing::debug!(%error, path = %history_path.display(), "failed to append Rust MCP performance history");
+                            }
+                            heartbeat.tick();
+                        }
                     }
                 }
             }
-        }
-    });
+        },
+    );
 }
 
 async fn persist_snapshot(path: &std::path::Path, snapshot: &Value) -> std::io::Result<()> {
@@ -140,6 +171,52 @@ async fn persist_snapshot(path: &std::path::Path, snapshot: &Value) -> std::io::
         tokio::fs::rename(&temporary, path).await?;
     }
     Ok(())
+}
+
+async fn append_history(path: &std::path::Path, snapshot: &Value) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt as _;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    if tokio::fs::metadata(path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0)
+        >= HISTORY_MAX_BYTES
+    {
+        let oldest = history_rotation_path(path, HISTORY_ROTATIONS);
+        tokio::fs::remove_file(&oldest).await.ok();
+        for index in (1..HISTORY_ROTATIONS).rev() {
+            let from = history_rotation_path(path, index);
+            let to = history_rotation_path(path, index + 1);
+            if tokio::fs::rename(&from, &to).await.is_err() {}
+        }
+        let _ = tokio::fs::rename(path, history_rotation_path(path, 1)).await;
+    }
+    let compact = json!({
+        "sampledAtUtc": snapshot.pointer("/eventLoop/sampledAtUtc"),
+        "pid": snapshot.pointer("/process/pid"),
+        "p95Ms": snapshot.pointer("/eventLoop/p95Ms"),
+        "p99Ms": snapshot.pointer("/eventLoop/p99Ms"),
+        "maxMs": snapshot.pointer("/eventLoop/maxMs"),
+        "timerDriftMaxMs": snapshot.pointer("/eventLoop/timerDriftMaxMs"),
+        "rss": snapshot.pointer("/process/memory/rss"),
+        "private": snapshot.pointer("/process/memory/private"),
+        "allocatorCurrent": snapshot.pointer("/process/memory/allocator/currentRequestedBytes"),
+        "cpuTotalMs": snapshot.pointer("/process/platform/cpuTotalMs"),
+    });
+    let mut bytes = serde_json::to_vec(&compact).map_err(std::io::Error::other)?;
+    bytes.push(b'\n');
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await?;
+    file.write_all(&bytes).await
+}
+
+fn history_rotation_path(path: &std::path::Path, index: usize) -> PathBuf {
+    PathBuf::from(format!("{}.{index}", path.display()))
 }
 
 fn snapshot_value(state: &Arc<Mutex<PerformanceWindow>>, started_at: Instant) -> Value {

--- a/rust-mcp/src/process.rs
+++ b/rust-mcp/src/process.rs
@@ -3,18 +3,19 @@ use std::{
     ffi::OsString,
     path::PathBuf,
     process::{ExitStatus, Stdio},
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
     process::{Child, Command},
-    sync::mpsc::UnboundedSender,
+    sync::mpsc::{Sender, UnboundedSender},
 };
 use tokio_util::sync::CancellationToken;
 
 pub const MAX_PROCESS_ERROR_MESSAGE_CHARS: usize = 4096;
+const POST_EXIT_PIPE_DRAIN: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputStream {
@@ -36,7 +37,7 @@ pub struct ProcessOptions {
     pub termination_grace: Duration,
     pub max_capture_chars: Option<usize>,
     pub input: Option<Vec<u8>>,
-    pub output_tx: Option<UnboundedSender<OutputChunk>>,
+    pub output_tx: Option<Sender<OutputChunk>>,
     pub pid_tx: Option<UnboundedSender<u32>>,
 }
 
@@ -86,11 +87,18 @@ impl std::fmt::Display for ProcessError {
 
 impl std::error::Error for ProcessError {}
 
+struct CaptureTask {
+    task: tokio::task::JoinHandle<()>,
+    captured: Arc<Mutex<String>>,
+}
+
 struct SpawnedProcess {
     child: Child,
     pid: u32,
-    stdout_task: tokio::task::JoinHandle<String>,
-    stderr_task: tokio::task::JoinHandle<String>,
+    stdout_task: CaptureTask,
+    stderr_task: CaptureTask,
+    #[cfg(windows)]
+    job: Option<crate::windows_job::WindowsJob>,
 }
 
 #[derive(Debug)]
@@ -109,9 +117,21 @@ enum ForcedFailure {
 struct ProcessTreeDropGuard {
     pid: u32,
     armed: bool,
+    #[cfg(windows)]
+    job: Option<crate::windows_job::WindowsJob>,
 }
 
 impl ProcessTreeDropGuard {
+    #[cfg(windows)]
+    const fn new(pid: u32, job: Option<crate::windows_job::WindowsJob>) -> Self {
+        Self {
+            pid,
+            armed: pid > 0,
+            job,
+        }
+    }
+
+    #[cfg(not(windows))]
     const fn new(pid: u32) -> Self {
         Self {
             pid,
@@ -127,6 +147,9 @@ impl ProcessTreeDropGuard {
 impl Drop for ProcessTreeDropGuard {
     fn drop(&mut self) {
         if self.armed {
+            #[cfg(windows)]
+            terminate_process_tree_on_drop(self.pid, self.job.as_ref());
+            #[cfg(not(windows))]
             terminate_process_tree_on_drop(self.pid);
         }
     }
@@ -148,10 +171,15 @@ pub async fn spawn_process(
 ) -> Result<ProcessOutput, ProcessError> {
     let started = Instant::now();
     let mut spawned = start_process(file, args, &options, started)?;
+    #[cfg(windows)]
+    let mut drop_guard = ProcessTreeDropGuard::new(spawned.pid, spawned.job.take());
+    #[cfg(not(windows))]
     let mut drop_guard = ProcessTreeDropGuard::new(spawned.pid);
     let (status, forced_failure) = wait_for_process(
         &mut spawned.child,
         spawned.pid,
+        #[cfg(windows)]
+        drop_guard.job.as_ref(),
         options.timeout,
         options.termination_grace,
         cancellation,
@@ -159,12 +187,9 @@ pub async fn spawn_process(
     .await;
     drop_guard.disarm();
 
-    if status.is_none() {
-        spawned.stdout_task.abort();
-        spawned.stderr_task.abort();
-    }
-    let stdout = join_capture(spawned.stdout_task).await;
-    let stderr = join_capture(spawned.stderr_task).await;
+    let drain = status.map(|_| POST_EXIT_PIPE_DRAIN);
+    let stdout = join_capture(spawned.stdout_task, drain).await;
+    let stderr = join_capture(spawned.stderr_task, drain).await;
     classify_process_result(
         file,
         args,
@@ -202,6 +227,18 @@ fn start_process(
         .spawn()
         .map_err(|error| launch_error(file, args, error.to_string(), started))?;
     let pid = child.id().unwrap_or(0);
+    #[cfg(windows)]
+    let job = if pid > 0 {
+        match crate::windows_job::WindowsJob::assign(pid) {
+            Ok(job) => Some(job),
+            Err(error) => {
+                tracing::warn!(pid, %error, "failed to assign Windows child to Job Object; native process-tree fallback will be used");
+                None
+            }
+        }
+    } else {
+        None
+    };
     if pid > 0
         && let Some(pid_tx) = options.pid_tx.as_ref()
     {
@@ -224,23 +261,25 @@ fn start_process(
             started,
         )
     })?;
-    let stdout_task = tokio::spawn(capture_stream(
+    let stdout_task = start_capture_task(
         stdout,
         OutputStream::Stdout,
         options.max_capture_chars,
         options.output_tx.clone(),
-    ));
-    let stderr_task = tokio::spawn(capture_stream(
+    );
+    let stderr_task = start_capture_task(
         stderr,
         OutputStream::Stderr,
         options.max_capture_chars,
         options.output_tx.clone(),
-    ));
+    );
     Ok(SpawnedProcess {
         child,
         pid,
         stdout_task,
         stderr_task,
+        #[cfg(windows)]
+        job,
     })
 }
 
@@ -260,6 +299,7 @@ fn start_stdin_writer(stdin: Option<tokio::process::ChildStdin>, input: Option<V
 async fn wait_for_process(
     child: &mut Child,
     pid: u32,
+    #[cfg(windows)] job: Option<&crate::windows_job::WindowsJob>,
     timeout: Option<Duration>,
     termination_grace: Duration,
     cancellation: CancellationToken,
@@ -285,6 +325,9 @@ async fn wait_for_process(
     match outcome {
         WaitOutcome::Exited(status) => (status.ok(), None),
         WaitOutcome::Cancelled => {
+            #[cfg(windows)]
+            terminate_spawned_tree(pid, job);
+            #[cfg(not(windows))]
             terminate_process_tree(pid).await;
             (
                 wait_after_termination(&mut wait, termination_grace).await,
@@ -292,6 +335,9 @@ async fn wait_for_process(
             )
         }
         WaitOutcome::TimedOut(timeout) => {
+            #[cfg(windows)]
+            terminate_spawned_tree(pid, job);
+            #[cfg(not(windows))]
             terminate_process_tree(pid).await;
             (
                 wait_after_termination(&mut wait, termination_grace).await,
@@ -437,16 +483,37 @@ pub fn summarize_process_failure(file: &str, code: i32, stdout: &str, stderr: &s
     }
 }
 
+fn start_capture_task<R>(
+    reader: R,
+    stream: OutputStream,
+    max_capture_chars: Option<usize>,
+    output_tx: Option<Sender<OutputChunk>>,
+) -> CaptureTask
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let captured = Arc::new(Mutex::new(String::new()));
+    let shared = captured.clone();
+    let task = tokio::spawn(capture_stream(
+        reader,
+        stream,
+        max_capture_chars,
+        output_tx,
+        shared,
+    ));
+    CaptureTask { task, captured }
+}
+
 async fn capture_stream<R>(
     mut reader: R,
     stream: OutputStream,
     max_capture_chars: Option<usize>,
-    output_tx: Option<UnboundedSender<OutputChunk>>,
-) -> String
-where
+    output_tx: Option<Sender<OutputChunk>>,
+    captured: Arc<Mutex<String>>,
+) where
     R: AsyncRead + Unpin,
 {
-    let mut captured = String::new();
+    let mut local = String::new();
     let mut buffer = vec![0_u8; 16 * 1024];
     let mut pending_utf8 = Vec::with_capacity(4);
     loop {
@@ -456,23 +523,31 @@ where
         };
         let bytes = &buffer[..count];
         if let Some(tx) = output_tx.as_ref() {
-            let _ = tx.send(OutputChunk {
-                stream,
-                bytes: Arc::from(bytes),
-            });
+            let _ = tx
+                .send(OutputChunk {
+                    stream,
+                    bytes: Arc::from(bytes),
+                })
+                .await;
         }
-        append_stream_utf8(&mut captured, &mut pending_utf8, bytes);
+        append_stream_utf8(&mut local, &mut pending_utf8, bytes);
         if let Some(limit) = max_capture_chars {
-            retain_tail_chars(&mut captured, limit);
+            retain_tail_chars(&mut local, limit);
         }
+        captured
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone_from(&local);
     }
     if !pending_utf8.is_empty() {
-        captured.push_str(&String::from_utf8_lossy(&pending_utf8));
+        local.push_str(&String::from_utf8_lossy(&pending_utf8));
         if let Some(limit) = max_capture_chars {
-            retain_tail_chars(&mut captured, limit);
+            retain_tail_chars(&mut local, limit);
         }
     }
-    captured
+    *captured
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = local;
 }
 
 fn append_stream_utf8(captured: &mut String, pending: &mut Vec<u8>, bytes: &[u8]) {
@@ -503,8 +578,24 @@ fn append_stream_utf8(captured: &mut String, pending: &mut Vec<u8>, bytes: &[u8]
     }
 }
 
-async fn join_capture(task: tokio::task::JoinHandle<String>) -> String {
-    task.await.unwrap_or_default()
+async fn join_capture(mut capture: CaptureTask, timeout: Option<Duration>) -> String {
+    if let Some(timeout) = timeout {
+        if tokio::time::timeout(timeout, &mut capture.task)
+            .await
+            .is_err()
+        {
+            capture.task.abort();
+            let _ = capture.task.await;
+        }
+    } else {
+        capture.task.abort();
+        let _ = capture.task.await;
+    }
+    capture
+        .captured
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
 }
 
 fn retain_tail_chars(value: &mut String, max_chars: usize) {
@@ -544,20 +635,21 @@ fn configure_process_group(command: &mut Command) {
 fn configure_process_group(_command: &mut Command) {}
 
 #[cfg(windows)]
-fn terminate_process_tree_on_drop(pid: u32) {
-    use std::os::windows::process::CommandExt as _;
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+fn terminate_process_tree_on_drop(pid: u32, job: Option<&crate::windows_job::WindowsJob>) {
+    terminate_spawned_tree(pid, job);
+}
+
+#[cfg(windows)]
+fn terminate_spawned_tree(pid: u32, job: Option<&crate::windows_job::WindowsJob>) {
     if pid == 0 {
         return;
     }
-    let mut command = std::process::Command::new("taskkill.exe");
-    command
-        .args(["/pid", &pid.to_string(), "/t", "/f"])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .creation_flags(CREATE_NO_WINDOW);
-    let _ = command.spawn();
+    if let Some(job) = job {
+        let _ = job.terminate(1);
+    }
+    // Always sweep the native process tree as well. A child could theoretically
+    // create a descendant in the tiny interval between CreateProcess and Job Object assignment.
+    crate::windows_job::terminate_process_tree_fallback(pid, 1);
 }
 
 #[cfg(unix)]
@@ -576,21 +668,7 @@ fn terminate_process_tree_on_drop(_pid: u32) {}
 
 #[cfg(windows)]
 pub(crate) async fn terminate_process_tree(pid: u32) {
-    use std::os::windows::process::CommandExt as _;
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-
-    if pid == 0 {
-        return;
-    }
-    let mut command = Command::new("taskkill.exe");
-    command
-        .args(["/pid", &pid.to_string(), "/t", "/f"])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .as_std_mut()
-        .creation_flags(CREATE_NO_WINDOW);
-    let _ = tokio::time::timeout(Duration::from_secs(5), command.status()).await;
+    crate::windows_job::terminate_process_tree_fallback(pid, 1);
 }
 
 #[cfg(unix)]
@@ -729,6 +807,65 @@ mod tests {
         assert!(
             !process_is_alive(pid).await,
             "dropped process future left PID {pid} alive"
+        );
+    }
+
+    #[tokio::test]
+    async fn parent_exit_is_not_blocked_by_grandchild_inheriting_pipes() {
+        let script = "const {spawn}=require('node:child_process'); const c=spawn(process.execPath,['-e','setTimeout(()=>{},3000)'],{stdio:['ignore','inherit','inherit']}); c.unref(); process.stdout.write('parent-done');";
+        let started = Instant::now();
+        let output = spawn_process(
+            "node",
+            &["-e".to_owned(), script.to_owned()],
+            ProcessOptions {
+                timeout: Some(Duration::from_secs(5)),
+                ..ProcessOptions::default()
+            },
+            CancellationToken::new(),
+        )
+        .await
+        .expect("parent process should complete without waiting for inherited grandchild pipes");
+        assert_eq!(output.exit_code, 0);
+        assert!(output.stdout.contains("parent-done"));
+        assert!(started.elapsed() < Duration::from_millis(2500));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn windows_timeout_terminates_job_object_descendants() {
+        let temp = tempfile::tempdir().unwrap();
+        let pid_path = temp.path().join("descendant.pid");
+        let pid_path_js = pid_path
+            .to_string_lossy()
+            .replace('\\', "\\\\")
+            .replace('\'', "\\'");
+        let script = format!(
+            "const fs=require('node:fs'); const {{spawn}}=require('node:child_process'); const c=spawn(process.execPath,['-e','setTimeout(()=>{{}},30000)'],{{stdio:['ignore','ignore','ignore']}}); fs.writeFileSync('{pid_path_js}',String(c.pid)); setTimeout(()=>{{}},30000);"
+        );
+        let error = spawn_process(
+            "node",
+            &["-e".to_owned(), script],
+            ProcessOptions {
+                timeout: Some(Duration::from_millis(1200)),
+                ..ProcessOptions::default()
+            },
+            CancellationToken::new(),
+        )
+        .await
+        .expect_err("parent should time out");
+        assert!(error.timed_out);
+        let child_pid = std::fs::read_to_string(&pid_path)
+            .expect("parent should persist descendant pid before timeout")
+            .trim()
+            .parse::<u32>()
+            .expect("valid descendant pid");
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline && crate::windows_process::process_alive(child_pid) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            !crate::windows_process::process_alive(child_pid),
+            "Job Object timeout left descendant PID {child_pid} alive"
         );
     }
 

--- a/rust-mcp/src/process.rs
+++ b/rust-mcp/src/process.rs
@@ -522,6 +522,20 @@ async fn capture_stream<R>(
             Ok(count) => count,
         };
         let bytes = &buffer[..count];
+        let previous_len = local.len();
+        append_stream_utf8(&mut local, &mut pending_utf8, bytes);
+        if let Some(limit) = max_capture_chars {
+            retain_tail_chars(&mut local, limit);
+            captured
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone_from(&local);
+        } else if local.len() > previous_len {
+            captured
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push_str(&local[previous_len..]);
+        }
         if let Some(tx) = output_tx.as_ref() {
             let _ = tx
                 .send(OutputChunk {
@@ -530,14 +544,6 @@ async fn capture_stream<R>(
                 })
                 .await;
         }
-        append_stream_utf8(&mut local, &mut pending_utf8, bytes);
-        if let Some(limit) = max_capture_chars {
-            retain_tail_chars(&mut local, limit);
-        }
-        captured
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone_from(&local);
     }
     if !pending_utf8.is_empty() {
         local.push_str(&String::from_utf8_lossy(&pending_utf8));
@@ -644,12 +650,15 @@ fn terminate_spawned_tree(pid: u32, job: Option<&crate::windows_job::WindowsJob>
     if pid == 0 {
         return;
     }
+    let root_instance = crate::windows_process::process_instance(pid);
     if let Some(job) = job {
         let _ = job.terminate(1);
     }
     // Always sweep the native process tree as well. A child could theoretically
     // create a descendant in the tiny interval between CreateProcess and Job Object assignment.
-    crate::windows_job::terminate_process_tree_fallback(pid, 1);
+    // Carry the pre-termination creation fingerprint because the Job Object may already
+    // have ended the root process before this fallback traversal begins.
+    crate::windows_job::terminate_process_tree_fallback_with_instance(pid, root_instance, 1);
 }
 
 #[cfg(unix)]

--- a/rust-mcp/src/runtime.rs
+++ b/rust-mcp/src/runtime.rs
@@ -10,7 +10,10 @@ use std::{
 use futures::future::join_all;
 #[cfg(windows)]
 use tokio::sync::OnceCell;
-use tokio::sync::{Mutex, mpsc::UnboundedSender};
+use tokio::sync::{
+    Mutex,
+    mpsc::{Sender, UnboundedSender},
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -27,7 +30,7 @@ pub struct ProgramRequest {
     pub timeout: Duration,
     pub user: String,
     pub max_capture_chars: Option<usize>,
-    pub output_tx: Option<UnboundedSender<OutputChunk>>,
+    pub output_tx: Option<Sender<OutputChunk>>,
     pub pid_tx: Option<UnboundedSender<u32>>,
 }
 
@@ -38,7 +41,7 @@ pub struct ShellRequest {
     pub timeout: Duration,
     pub user: String,
     pub max_capture_chars: Option<usize>,
-    pub output_tx: Option<UnboundedSender<OutputChunk>>,
+    pub output_tx: Option<Sender<OutputChunk>>,
     pub pid_tx: Option<UnboundedSender<u32>>,
 }
 
@@ -201,6 +204,9 @@ impl RuntimeExecutor {
                 ("git", &["--version"]),
                 ("gh", &["--version"]),
                 ("python", &["--version"]),
+                ("pwsh", &["--version"]),
+                ("rg", &["--version"]),
+                ("curl", &["--version"]),
             ]
         } else {
             vec![
@@ -687,6 +693,8 @@ mod tests {
             job_heartbeat_ms: 5_000,
             job_orphan_stale_ms: 15_000,
             job_retention_hours: 168,
+            job_store_max_bytes: 2 * 1024 * 1024 * 1024,
+            job_store_max_terminal_jobs: 5_000,
             screen_capture_attempt_timeout_ms: 8_000,
             screen_capture_retries: 1,
             screen_capture_queue_timeout_ms: 5_000,

--- a/rust-mcp/src/runtime.rs
+++ b/rust-mcp/src/runtime.rs
@@ -635,73 +635,10 @@ mod tests {
     }
 
     fn test_config(root: &std::path::Path) -> Arc<Config> {
-        Arc::new(Config {
-            project_root: root.to_path_buf(),
-            host: "127.0.0.1".to_owned(),
-            port: 0,
-            auth_mode: crate::AuthMode::None,
-            runtime_mode: RuntimeMode::Host,
-            platform: crate::Platform::detect(),
-            public_base_url: None,
-            gateway_bridge: crate::config::GatewayBridgeConfig {
-                enabled: false,
-                origins: vec![
-                    "https://chatgpt.com".to_owned(),
-                    "https://chat.openai.com".to_owned(),
-                ],
-            },
-            oauth_state_file_path: root.join("oauth-state.json"),
-            cloudflare_access_team_domain: None,
-            cloudflare_access_aud: String::new(),
-            cloudflare_access_jwks_url: None,
-            host_workspace_path: root.to_path_buf(),
-            devbox_workspace_path: root.to_path_buf(),
-            devbox_container_name: "unused".to_owned(),
-            devbox_image_name: "chatgpt-devbox-runtime:local".to_owned(),
-            devbox_tmp_volume_name: "chatgpt-devbox-runtime-tmp".to_owned(),
-            devbox_retired_container_grace_ms: 300_000,
-            devbox_auto_start: true,
-            devbox_version_cache_ms: 120_000,
-            docker_command_timeout_ms: 120_000,
-            devbox_default_user: String::new(),
-            host_default_workdir: root.to_path_buf(),
-            host_shell: if cfg!(windows) { "cmd.exe" } else { "/bin/sh" }.to_owned(),
-            power_shell_exe: if cfg!(windows) { "pwsh.exe" } else { "" }.to_owned(),
-            power_shell_fallback_exe: if cfg!(windows) { "powershell.exe" } else { "" }.to_owned(),
-            node_exe: "node".to_owned(),
-            host_program_allowlist: vec!["rustc".to_owned()],
-            host_search_backend: crate::config::HostSearchBackend::Auto,
-            devbox_program_allowlist: vec!["rustc".to_owned()],
-            host_exec_enabled: true,
-            allow_windows_host_exec_uac: false,
-            execution_slot_root: root.join("execution-slots"),
-            jobs_root: root.join("jobs"),
-            mcp_performance_state_path: root.join("mcp-performance.json"),
-            usage_log: crate::config::UsageLogConfig {
-                max_bytes: 16 * 1024 * 1024,
-                rotations: 3,
-            },
-            mcp_json_body_limit_bytes: 16 * 1024 * 1024,
-            exec_max_concurrent: 6,
-            exec_reserved_interactive: 1,
-            exec_queue_timeout_ms: 15_000,
-            background_queue_timeout_ms: 300_000,
-            watch_max_concurrent: 4,
-            exec_heavy_weight: 2,
-            job_log_max_bytes: 32 * 1024 * 1024,
-            job_log_rotations: 2,
-            job_heartbeat_ms: 5_000,
-            job_orphan_stale_ms: 15_000,
-            job_retention_hours: 168,
-            job_store_max_bytes: 2 * 1024 * 1024 * 1024,
-            job_store_max_terminal_jobs: 5_000,
-            screen_capture_attempt_timeout_ms: 8_000,
-            screen_capture_retries: 1,
-            screen_capture_queue_timeout_ms: 5_000,
-            max_wait_seconds: 300.0,
-            command_output_limit_chars: 65_536,
-            max_mcp_transfer_chars: 4_000_000,
-        })
+        let mut config = crate::config::test_config(root);
+        config.host_program_allowlist = vec!["rustc".to_owned()];
+        config.devbox_program_allowlist = vec!["rustc".to_owned()];
+        Arc::new(config)
     }
 
     #[tokio::test]

--- a/rust-mcp/src/runtime/windows_host_shell.rs
+++ b/rust-mcp/src/runtime/windows_host_shell.rs
@@ -22,7 +22,7 @@ struct PowerShellSpawnRequest {
     cwd: PathBuf,
     timeout: Duration,
     max_capture_chars: Option<usize>,
-    output_tx: Option<tokio::sync::mpsc::UnboundedSender<OutputChunk>>,
+    output_tx: Option<tokio::sync::mpsc::Sender<OutputChunk>>,
     pid_tx: Option<tokio::sync::mpsc::UnboundedSender<u32>>,
 }
 
@@ -206,8 +206,8 @@ impl RuntimeExecutor {
         let exit_code_text = read_text_file_or_empty(&exit_code_path).await;
         let stdout = windows_shell::clean_output(&stdout);
         let stderr = windows_shell::clean_output(&stderr);
-        emit_buffered_output(request.output_tx.as_ref(), OutputStream::Stdout, &stdout);
-        emit_buffered_output(request.output_tx.as_ref(), OutputStream::Stderr, &stderr);
+        emit_buffered_output(request.output_tx.as_ref(), OutputStream::Stdout, &stdout).await;
+        emit_buffered_output(request.output_tx.as_ref(), OutputStream::Stderr, &stderr).await;
         let Ok(exit_code) = exit_code_text.trim().parse::<i32>() else {
             return Err(RuntimeExecError::Process(ProcessError {
                 message: "The elevated PowerShell command did not report an exit code.".to_owned(),
@@ -399,8 +399,8 @@ async fn read_text_file_or_empty(path: &std::path::Path) -> String {
     tokio::fs::read_to_string(path).await.unwrap_or_default()
 }
 
-fn emit_buffered_output(
-    output_tx: Option<&tokio::sync::mpsc::UnboundedSender<OutputChunk>>,
+async fn emit_buffered_output(
+    output_tx: Option<&tokio::sync::mpsc::Sender<OutputChunk>>,
     stream: OutputStream,
     value: &str,
 ) {
@@ -410,10 +410,12 @@ fn emit_buffered_output(
     if value.is_empty() {
         return;
     }
-    let _ = output_tx.send(OutputChunk {
-        stream,
-        bytes: Arc::<[u8]>::from(value.as_bytes()),
-    });
+    let _ = output_tx
+        .send(OutputChunk {
+            stream,
+            bytes: Arc::<[u8]>::from(value.as_bytes()),
+        })
+        .await;
 }
 
 fn elapsed_ms(duration: Duration) -> u64 {

--- a/rust-mcp/src/search.rs
+++ b/rust-mcp/src/search.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use regex::{Regex, RegexBuilder};
 use serde_json::Value;
-use tokio::{fs, sync::mpsc::unbounded_channel};
+use tokio::{fs, sync::mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -106,7 +106,7 @@ impl SearchService {
         let (program, args, cwd) = self.process_command(args);
         let process_cancel = cancellation.child_token();
         let task_cancel = process_cancel.clone();
-        let (tx, mut rx) = unbounded_channel();
+        let (tx, mut rx) = mpsc::channel(128);
         let max_capture_chars = self.config.max_mcp_transfer_chars.clamp(1, 65_536);
         let timeout = request.timeout;
         let task = tokio::spawn(async move {

--- a/rust-mcp/src/server.rs
+++ b/rust-mcp/src/server.rs
@@ -2289,6 +2289,7 @@ fn spawn_job_maintenance(handler: &DevboxMcp, config: &Config, cancellation: Can
                             let value = match maintenance_store.reconcile_maintenance_batch(100).await {
                                 Ok(summary) => {
                                     let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+                                    heartbeat.tick();
                                     json!({ "sampledAtUtc": chrono::Utc::now().to_rfc3339(), "durationMs": duration_ms, "summary": summary })
                                 }
                                 Err(error) => {
@@ -2297,7 +2298,6 @@ fn spawn_job_maintenance(handler: &DevboxMcp, config: &Config, cancellation: Can
                                 }
                             };
                             let _ = write_json_snapshot(&maintenance_state_path, &value).await;
-                            heartbeat.tick();
                         }
                     }
                 }
@@ -2312,7 +2312,7 @@ fn spawn_version_refresh(handler: &DevboxMcp, cancellation: CancellationToken) {
         .config
         .devbox_version_cache_ms
         .saturating_div(2)
-        .clamp(1_000, 120_000);
+        .clamp(30_000, 120_000);
     handler.background.spawn_supervised(
         "version-refresh",
         cancellation,
@@ -2320,6 +2320,7 @@ fn spawn_version_refresh(handler: &DevboxMcp, cancellation: CancellationToken) {
             let runtime = runtime.clone();
             async move {
                 let mut interval = tokio::time::interval(Duration::from_millis(refresh_ms));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 loop {
                     tokio::select! {
                         () = cancellation.cancelled() => return Ok(()),
@@ -2420,6 +2421,9 @@ pub async fn serve(
     config: Arc<Config>,
     cancellation: CancellationToken,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<std::io::Result<()>>)> {
+    tokio::fs::create_dir_all(&config.jobs_root)
+        .await
+        .with_context(|| format!("create Rust MCP jobs root {}", config.jobs_root.display()))?;
     let address = format!("{}:{}", config.host, config.port);
     let listener = tokio::net::TcpListener::bind(&address)
         .await
@@ -2558,12 +2562,12 @@ fn snapshot_age_ms(timestamp: Option<&str>) -> Option<u64> {
 
 async fn readyz(State(state): State<HttpState>) -> Response {
     let checks = tokio::time::timeout(Duration::from_millis(750), async {
-        let jobs = tokio::fs::create_dir_all(&state.config.jobs_root)
+        let jobs = tokio::fs::metadata(&state.config.jobs_root)
             .await
-            .is_ok();
+            .is_ok_and(|metadata| metadata.is_dir() && !metadata.permissions().readonly());
         let scheduler = state.handler.scheduler.snapshot().await.is_ok();
-        let tool_count = state.handler.tool_router.list_all().len();
-        let tool_contract = tool_count == crate::contract::TARGET_TOOL_NAMES.len();
+        let tool_contract =
+            state.handler.tool_router.list_all().len() == crate::contract::TARGET_TOOL_NAMES.len();
         let background = state.handler.background.snapshot();
         let critical = [
             "performance-sampler",
@@ -2579,21 +2583,16 @@ async fn readyz(State(state): State<HttpState>) -> Response {
                     .and_then(Value::as_u64)
                     .is_some_and(|age| age < 180_000)
         });
-        (
-            jobs,
-            scheduler,
-            tool_contract,
-            tool_count,
-            tasks,
-            background,
-        )
+        jobs && scheduler && tool_contract && tasks
     })
     .await;
-    match checks {
-        Ok((jobs, scheduler, tool_contract, tool_count, tasks, _background)) if jobs && scheduler && tool_contract && tasks => (StatusCode::OK, Json(json!({"ok": true, "jobStoreReady": jobs, "schedulerReady": scheduler, "toolContractComplete": tool_contract, "toolCount": tool_count, "backgroundTasksHealthy": tasks}))).into_response(),
-        Ok((jobs, scheduler, tool_contract, tool_count, tasks, _background)) => (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"ok": false, "jobStoreReady": jobs, "schedulerReady": scheduler, "toolContractComplete": tool_contract, "toolCount": tool_count, "backgroundTasksHealthy": tasks}))).into_response(),
-        Err(_) => (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"ok": false, "error": "readiness check timed out"}))).into_response(),
-    }
+    let ok = matches!(checks, Ok(true));
+    let status = if ok {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(json!({ "ok": ok }))).into_response()
 }
 
 async fn healthz() -> &'static str {
@@ -3430,73 +3429,12 @@ mod tests {
     #[tokio::test]
     async fn host_large_file_tools_keep_base64_out_of_text_content() {
         let temp = tempfile::tempdir().expect("temp dir");
-        let config = Arc::new(Config {
-            project_root: temp.path().to_path_buf(),
-            host: "127.0.0.1".to_owned(),
-            port: 0,
-            auth_mode: crate::AuthMode::None,
-            runtime_mode: RuntimeMode::Host,
-            platform: crate::Platform::detect(),
-            public_base_url: None,
-            gateway_bridge: crate::config::GatewayBridgeConfig {
-                enabled: false,
-                origins: vec![
-                    "https://chatgpt.com".to_owned(),
-                    "https://chat.openai.com".to_owned(),
-                ],
-            },
-            oauth_state_file_path: temp.path().join("oauth-state.json"),
-            cloudflare_access_team_domain: None,
-            cloudflare_access_aud: String::new(),
-            cloudflare_access_jwks_url: None,
-            host_workspace_path: temp.path().to_path_buf(),
-            devbox_workspace_path: temp.path().to_path_buf(),
-            devbox_container_name: "chatgpt-devbox-runtime".to_owned(),
-            devbox_image_name: "chatgpt-devbox-runtime:local".to_owned(),
-            devbox_tmp_volume_name: "chatgpt-devbox-runtime-tmp".to_owned(),
-            devbox_retired_container_grace_ms: 300_000,
-            devbox_auto_start: true,
-            devbox_version_cache_ms: 120_000,
-            docker_command_timeout_ms: 120_000,
-            devbox_default_user: "root".to_owned(),
-            host_default_workdir: temp.path().to_path_buf(),
-            host_shell: "unused".to_owned(),
-            power_shell_exe: "pwsh".to_owned(),
-            power_shell_fallback_exe: "powershell.exe".to_owned(),
-            node_exe: "node".to_owned(),
-            host_program_allowlist: vec!["node".to_owned()],
-            host_search_backend: crate::config::HostSearchBackend::Auto,
-            devbox_program_allowlist: vec!["node".to_owned()],
-            host_exec_enabled: true,
-            allow_windows_host_exec_uac: false,
-            execution_slot_root: temp.path().join("execution-slots"),
-            jobs_root: temp.path().join("jobs"),
-            mcp_performance_state_path: temp.path().join("mcp-performance.json"),
-            usage_log: crate::config::UsageLogConfig {
-                max_bytes: 16 * 1024 * 1024,
-                rotations: 3,
-            },
-            mcp_json_body_limit_bytes: 16 * 1024 * 1024,
-            exec_max_concurrent: 6,
-            exec_reserved_interactive: 1,
-            exec_queue_timeout_ms: 15_000,
-            background_queue_timeout_ms: 300_000,
-            watch_max_concurrent: 4,
-            exec_heavy_weight: 2,
-            job_log_max_bytes: 32 * 1024 * 1024,
-            job_log_rotations: 2,
-            job_heartbeat_ms: 5_000,
-            job_orphan_stale_ms: 15_000,
-            job_retention_hours: 168,
-            job_store_max_bytes: 2 * 1024 * 1024 * 1024,
-            job_store_max_terminal_jobs: 5_000,
-            screen_capture_attempt_timeout_ms: 8_000,
-            screen_capture_retries: 1,
-            screen_capture_queue_timeout_ms: 5_000,
-            max_wait_seconds: 300.0,
-            command_output_limit_chars: 65_536,
-            max_mcp_transfer_chars: 4_000_000,
-        });
+        let mut config = crate::config::test_config(temp.path());
+        config.devbox_default_user = "root".to_owned();
+        config.host_shell = "unused".to_owned();
+        config.host_program_allowlist = vec!["node".to_owned()];
+        config.devbox_program_allowlist = vec!["node".to_owned()];
+        let config = Arc::new(config);
         let server = DevboxMcp::new(config);
         let write = server
             .windows_host_write_large_file(Parameters(HostLargeWriteRequest {
@@ -3590,7 +3528,7 @@ mod tests {
 
     #[test]
     fn command_error_trimming_uses_javascript_utf16_units_and_marker() {
-        let input = format!("{}END", "ðŸ˜€".repeat(80));
+        let input = format!("{}END", "😀".repeat(80));
         let (trimmed, truncated) = trim_javascript_text(&input, 100);
         assert!(truncated);
         assert!(trimmed.encode_utf16().count() <= 100);

--- a/rust-mcp/src/server.rs
+++ b/rust-mcp/src/server.rs
@@ -38,6 +38,7 @@ use tower_http::trace::TraceLayer;
 
 use crate::{
     AuthMode, Config, RuntimeMode,
+    background::BackgroundTaskRegistry,
     capture::CaptureService,
     docker_files::{DockerFileBackend, DockerListOptions},
     execution::{AcquireRequest, ExecutionScheduler, SchedulerConfig},
@@ -72,6 +73,7 @@ pub struct DevboxMcp {
     performance: Arc<PerformanceMonitor>,
     usage: Arc<UsageService>,
     active_requests: Arc<ActiveRequestRegistry>,
+    background: Arc<BackgroundTaskRegistry>,
     tool_router: ToolRouter<Self>,
 }
 
@@ -94,13 +96,16 @@ impl DevboxMcp {
             lifecycle.clone(),
         ));
         let capture = Arc::new(CaptureService::new(config.clone()));
+        let background = Arc::new(BackgroundTaskRegistry::new());
         let performance = Arc::new(PerformanceMonitor::new(
             config.mcp_performance_state_path.clone(),
+            &background,
         ));
         let usage = Arc::new(UsageService::new(
             &config.project_root,
             config.usage_log.max_bytes,
             config.usage_log.rotations,
+            &background,
         ));
         let active_requests = Arc::new(ActiveRequestRegistry::new());
         Self {
@@ -113,6 +118,7 @@ impl DevboxMcp {
             performance,
             usage,
             active_requests,
+            background,
             config,
             files: Arc::new(FileService::new()),
             docker_files: Arc::new(DockerFileBackend::new()),
@@ -707,12 +713,7 @@ impl DevboxMcp {
                     .join("run")
                     .join("startup-state.json")
             ),
-            read_json_snapshot(
-                self.config
-                    .project_root
-                    .join("run")
-                    .join("job-maintenance.json")
-            ),
+            read_job_maintenance_snapshot(&self.config),
         );
         let mut data = info.as_object().cloned().unwrap_or_default();
         data.insert(
@@ -734,10 +735,18 @@ impl DevboxMcp {
             job_maintenance.unwrap_or(Value::Null),
         );
         data.insert("execution".to_owned(), json!(execution));
-        data.insert("performance".to_owned(), self.performance.snapshot());
+        let performance = self.performance.snapshot();
+        data.insert("performance".to_owned(), performance);
+        data.insert("backgroundTasks".to_owned(), self.background.snapshot());
+        data.insert("usageTelemetry".to_owned(), self.usage.metrics_snapshot());
+        let active_including_current = self.active_requests.active_count();
+        data.insert(
+            "activeRequestsIncludingCurrent".to_owned(),
+            json!(active_including_current),
+        );
         data.insert(
             "activeRequests".to_owned(),
-            json!(self.active_requests.active_count()),
+            json!(active_including_current.saturating_sub(1)),
         );
         #[cfg(windows)]
         data.insert(
@@ -2264,61 +2273,70 @@ struct HttpState {
 fn spawn_job_maintenance(handler: &DevboxMcp, config: &Config, cancellation: CancellationToken) {
     let maintenance_store = handler.jobs.store().clone();
     let maintenance_state_path = config.project_root.join("run").join("job-maintenance.json");
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(60));
-        loop {
-            tokio::select! {
-                () = cancellation.cancelled() => return,
-                _ = interval.tick() => {
-                    let started = Instant::now();
-                    match maintenance_store.reconcile_maintenance_batch(100).await {
-                        Ok(summary) => {
-                            let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
-                            tracing::debug!(
-                                discovered = summary.discovered,
-                                scanned = summary.scanned,
-                                batch_limited = summary.batch_limited,
-                                interrupted = summary.interrupted,
-                                terminal = summary.terminal,
-                                deleted = summary.deleted,
-                                errors = summary.errors,
-                                duration_ms,
-                                "Rust MCP job maintenance pass completed"
-                            );
-                            let _ = write_json_snapshot(
-                                &maintenance_state_path,
-                                &json!({
-                                    "sampledAtUtc": chrono::Utc::now().to_rfc3339(),
-                                    "durationMs": duration_ms,
-                                    "summary": summary,
-                                }),
-                            ).await;
-                        },
-                        Err(error) => {
-                            tracing::warn!(%error, "Rust MCP job maintenance pass failed");
-                            let _ = write_json_snapshot(
-                                &maintenance_state_path,
-                                &json!({
-                                    "sampledAtUtc": chrono::Utc::now().to_rfc3339(),
-                                    "durationMs": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
-                                    "error": error.to_string(),
-                                }),
-                            ).await;
-                        },
+    handler.background.spawn_supervised(
+        "job-maintenance",
+        cancellation,
+        move |cancellation, heartbeat| {
+            let maintenance_store = maintenance_store.clone();
+            let maintenance_state_path = maintenance_state_path.clone();
+            async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(60));
+                loop {
+                    tokio::select! {
+                        () = cancellation.cancelled() => return Ok(()),
+                        _ = interval.tick() => {
+                            let started = Instant::now();
+                            let value = match maintenance_store.reconcile_maintenance_batch(100).await {
+                                Ok(summary) => {
+                                    let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+                                    json!({ "sampledAtUtc": chrono::Utc::now().to_rfc3339(), "durationMs": duration_ms, "summary": summary })
+                                }
+                                Err(error) => {
+                                    tracing::warn!(%error, "Rust MCP job maintenance pass failed");
+                                    json!({ "sampledAtUtc": chrono::Utc::now().to_rfc3339(), "durationMs": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX), "error": error.to_string() })
+                                }
+                            };
+                            let _ = write_json_snapshot(&maintenance_state_path, &value).await;
+                            heartbeat.tick();
+                        }
                     }
                 }
             }
-        }
-    });
+        },
+    );
+}
+
+fn spawn_version_refresh(handler: &DevboxMcp, cancellation: CancellationToken) {
+    let runtime = handler.runtime.clone();
+    let refresh_ms = handler
+        .config
+        .devbox_version_cache_ms
+        .saturating_div(2)
+        .clamp(1_000, 120_000);
+    handler.background.spawn_supervised(
+        "version-refresh",
+        cancellation,
+        move |cancellation, heartbeat| {
+            let runtime = runtime.clone();
+            async move {
+                let mut interval = tokio::time::interval(Duration::from_millis(refresh_ms));
+                loop {
+                    tokio::select! {
+                        () = cancellation.cancelled() => return Ok(()),
+                        _ = interval.tick() => {
+                            let _ = runtime.get_versions(true, cancellation.child_token()).await;
+                            heartbeat.tick();
+                        }
+                    }
+                }
+            }
+        },
+    );
 }
 
 pub fn build_router(config: Arc<Config>, cancellation: CancellationToken) -> Router {
     let handler = DevboxMcp::new(config.clone());
-    let warm_runtime = handler.runtime.clone();
-    let warm_cancellation = cancellation.child_token();
-    tokio::spawn(async move {
-        let _ = warm_runtime.get_versions(false, warm_cancellation).await;
-    });
+    spawn_version_refresh(&handler, cancellation.child_token());
     let warm_host_runtime = handler.runtime.clone();
     let warm_host_cancellation = cancellation.child_token();
     tokio::spawn(async move {
@@ -2364,6 +2382,8 @@ pub fn build_router(config: Arc<Config>, cancellation: CancellationToken) -> Rou
                 .delete(mcp_delete),
         )
         .route("/healthz", get(healthz))
+        .route("/livez", get(healthz))
+        .route("/readyz", get(readyz))
         .route(
             "/mcp",
             get(mcp_sse_probe).post_service(mcp).delete(mcp_delete),
@@ -2478,7 +2498,7 @@ async fn read_json_snapshot(path: PathBuf) -> Option<Value> {
 }
 
 async fn read_guardian_status_snapshot(config: &Config) -> Option<Value> {
-    let state = read_json_snapshot(
+    let snapshot = read_json_snapshot(
         config
             .project_root
             .join("run")
@@ -2486,21 +2506,94 @@ async fn read_guardian_status_snapshot(config: &Config) -> Option<Value> {
             .join("state.json"),
     )
     .await?;
+    let age_ms = snapshot_age_ms(snapshot.get("ObservedAtUtc").and_then(Value::as_str));
+    let is_stale = age_ms.is_none_or(|age| age > 30_000);
+    let mut reasons = snapshot
+        .get("Reasons")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+    if is_stale && let Some(items) = reasons.as_array_mut() {
+        items.push(json!("guardian state snapshot is stale"));
+    }
     Some(json!({
-        "observedAtUtc": state.get("ObservedAtUtc").cloned().unwrap_or(Value::Null),
-        "isHealthy": state.get("IsHealthy").cloned().unwrap_or(Value::Null),
-        "needsRepair": state.get("NeedsRepair").cloned().unwrap_or(Value::Null),
-        "mcpElevated": state.get("McpElevated").cloned().unwrap_or(Value::Null),
-        "publicTunnelHealthy": state.get("PublicTunnelHealthy").cloned().unwrap_or(Value::Null),
-        "cloudflaredRunning": state.get("CloudflaredRunning").cloned().unwrap_or(Value::Null),
-        "cloudflaredMetrics": state.get("CloudflaredMetrics").cloned().unwrap_or(Value::Null),
-        "cloudflaredMetricsDelta": state.get("CloudflaredMetricsDelta").cloned().unwrap_or(Value::Null),
-        "tunnelTransportHealthy": state.get("TunnelTransportHealthy").cloned().unwrap_or(Value::Null),
-        "tunnelTransportDegraded": state.get("TunnelTransportDegraded").cloned().unwrap_or(json!(false)),
-        "tunnelTransportReasons": state.get("TunnelTransportReasons").cloned().unwrap_or_else(|| json!([])),
-        "readiness": state.get("Readiness").cloned().unwrap_or(Value::Null),
-        "reasons": state.get("Reasons").cloned().unwrap_or_else(|| json!([])),
+        "observedAtUtc": snapshot.get("ObservedAtUtc").cloned().unwrap_or(Value::Null),
+        "ageMs": age_ms,
+        "stale": is_stale,
+        "isHealthy": if is_stale { json!(false) } else { snapshot.get("IsHealthy").cloned().unwrap_or(Value::Null) },
+        "needsRepair": snapshot.get("NeedsRepair").cloned().unwrap_or(Value::Null),
+        "mcpElevated": snapshot.get("McpElevated").cloned().unwrap_or(Value::Null),
+        "publicTunnelHealthy": snapshot.get("PublicTunnelHealthy").cloned().unwrap_or(Value::Null),
+        "cloudflaredRunning": snapshot.get("CloudflaredRunning").cloned().unwrap_or(Value::Null),
+        "cloudflaredMetrics": snapshot.get("CloudflaredMetrics").cloned().unwrap_or(Value::Null),
+        "cloudflaredMetricsDelta": snapshot.get("CloudflaredMetricsDelta").cloned().unwrap_or(Value::Null),
+        "tunnelTransportHealthy": snapshot.get("TunnelTransportHealthy").cloned().unwrap_or(Value::Null),
+        "tunnelTransportDegraded": snapshot.get("TunnelTransportDegraded").cloned().unwrap_or(json!(false)),
+        "tunnelTransportReasons": snapshot.get("TunnelTransportReasons").cloned().unwrap_or_else(|| json!([])),
+        "readiness": snapshot.get("Readiness").cloned().unwrap_or(Value::Null),
+        "reasons": reasons,
     }))
+}
+
+async fn read_job_maintenance_snapshot(config: &Config) -> Option<Value> {
+    let mut snapshot =
+        read_json_snapshot(config.project_root.join("run").join("job-maintenance.json")).await?;
+    let age_ms = snapshot_age_ms(snapshot.get("sampledAtUtc").and_then(Value::as_str));
+    let is_stale = age_ms.is_none_or(|age| age > 150_000);
+    if let Some(object) = snapshot.as_object_mut() {
+        object.insert("ageMs".to_owned(), json!(age_ms));
+        object.insert("stale".to_owned(), json!(is_stale));
+    }
+    Some(snapshot)
+}
+
+fn snapshot_age_ms(timestamp: Option<&str>) -> Option<u64> {
+    let timestamp = chrono::DateTime::parse_from_rfc3339(timestamp?)
+        .ok()?
+        .with_timezone(&chrono::Utc);
+    let age = chrono::Utc::now()
+        .signed_duration_since(timestamp)
+        .num_milliseconds();
+    u64::try_from(age.max(0)).ok()
+}
+
+async fn readyz(State(state): State<HttpState>) -> Response {
+    let checks = tokio::time::timeout(Duration::from_millis(750), async {
+        let jobs = tokio::fs::create_dir_all(&state.config.jobs_root)
+            .await
+            .is_ok();
+        let scheduler = state.handler.scheduler.snapshot().await.is_ok();
+        let tool_count = state.handler.tool_router.list_all().len();
+        let tool_contract = tool_count == crate::contract::TARGET_TOOL_NAMES.len();
+        let background = state.handler.background.snapshot();
+        let critical = [
+            "performance-sampler",
+            "performance-persistence",
+            "job-maintenance",
+            "version-refresh",
+        ];
+        let tasks = critical.iter().all(|name| {
+            let task = &background[*name];
+            task.get("running").and_then(Value::as_bool) == Some(true)
+                && task
+                    .get("lastTickAgeMs")
+                    .and_then(Value::as_u64)
+                    .is_some_and(|age| age < 180_000)
+        });
+        (
+            jobs,
+            scheduler,
+            tool_contract,
+            tool_count,
+            tasks,
+            background,
+        )
+    })
+    .await;
+    match checks {
+        Ok((jobs, scheduler, tool_contract, tool_count, tasks, _background)) if jobs && scheduler && tool_contract && tasks => (StatusCode::OK, Json(json!({"ok": true, "jobStoreReady": jobs, "schedulerReady": scheduler, "toolContractComplete": tool_contract, "toolCount": tool_count, "backgroundTasksHealthy": tasks}))).into_response(),
+        Ok((jobs, scheduler, tool_contract, tool_count, tasks, _background)) => (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"ok": false, "jobStoreReady": jobs, "schedulerReady": scheduler, "toolContractComplete": tool_contract, "toolCount": tool_count, "backgroundTasksHealthy": tasks}))).into_response(),
+        Err(_) => (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"ok": false, "error": "readiness check timed out"}))).into_response(),
+    }
 }
 
 async fn healthz() -> &'static str {
@@ -3395,6 +3488,8 @@ mod tests {
             job_heartbeat_ms: 5_000,
             job_orphan_stale_ms: 15_000,
             job_retention_hours: 168,
+            job_store_max_bytes: 2 * 1024 * 1024 * 1024,
+            job_store_max_terminal_jobs: 5_000,
             screen_capture_attempt_timeout_ms: 8_000,
             screen_capture_retries: 1,
             screen_capture_queue_timeout_ms: 5_000,
@@ -3495,7 +3590,7 @@ mod tests {
 
     #[test]
     fn command_error_trimming_uses_javascript_utf16_units_and_marker() {
-        let input = format!("{}END", "😀".repeat(80));
+        let input = format!("{}END", "ðŸ˜€".repeat(80));
         let (trimmed, truncated) = trim_javascript_text(&input, 100);
         assert!(truncated);
         assert!(trimmed.encode_utf16().count() <= 100);

--- a/rust-mcp/src/usage.rs
+++ b/rust-mcp/src/usage.rs
@@ -61,6 +61,7 @@ pub struct UsageLogger {
     sink: Arc<UsageLogSink>,
     tx: mpsc::Sender<Value>,
     metrics: Arc<UsageQueueMetrics>,
+    cancellation: Option<CancellationToken>,
 }
 
 impl UsageLogger {
@@ -86,8 +87,18 @@ impl UsageLogger {
                     }
                 }
             });
+        } else {
+            tracing::warn!(
+                path = %sink.path.display(),
+                "usage-log writer could not start because no Tokio runtime handle is available"
+            );
         }
-        Self { sink, tx, metrics }
+        Self {
+            sink,
+            tx,
+            metrics,
+            cancellation: None,
+        }
     }
 
     #[must_use]
@@ -109,9 +120,10 @@ impl UsageLogger {
         let receiver = Arc::new(Mutex::new(rx));
         let writer_sink = sink.clone();
         let writer_metrics = metrics.clone();
+        let cancellation = CancellationToken::new();
         background.spawn_supervised(
             task_name,
-            CancellationToken::new(),
+            cancellation.clone(),
             move |cancellation, heartbeat| {
                 let receiver = receiver.clone();
                 let sink = writer_sink.clone();
@@ -126,6 +138,7 @@ impl UsageLogger {
                             }
                         };
                         let Some(event) = event else {
+                            cancellation.cancelled().await;
                             return Ok(());
                         };
                         if sink.append(&event).await.is_err() {
@@ -136,7 +149,12 @@ impl UsageLogger {
                 }
             },
         );
-        Self { sink, tx, metrics }
+        Self {
+            sink,
+            tx,
+            metrics,
+            cancellation: Some(cancellation),
+        }
     }
 
     /// Queue telemetry without blocking the tool or HTTP request on filesystem I/O.
@@ -168,6 +186,14 @@ impl UsageLogger {
     /// Returns filesystem or serialization errors from the underlying usage-log sink.
     pub async fn append(&self, event: &Value) -> Result<()> {
         self.sink.append(event).await
+    }
+}
+
+impl Drop for UsageLogger {
+    fn drop(&mut self) {
+        if let Some(cancellation) = self.cancellation.as_ref() {
+            cancellation.cancel();
+        }
     }
 }
 
@@ -818,6 +844,27 @@ fn elapsed_ms(duration: Duration) -> u64 {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn supervised_writer_stops_without_restart_when_logger_is_dropped() {
+        let temp = tempfile::tempdir().unwrap();
+        let background = BackgroundTaskRegistry::new();
+        {
+            let logger = UsageLogger::new_supervised(
+                temp.path().join("usage.jsonl"),
+                4096,
+                1,
+                "usage-test-writer",
+                &background,
+            );
+            logger.enqueue(json!({"event": 1}));
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(650)).await;
+        let snapshot = background.snapshot();
+        assert_eq!(snapshot["usage-test-writer"]["starts"], 1);
+        assert_eq!(snapshot["usage-test-writer"]["running"], false);
+    }
+
     #[test]
     fn sensitive_arguments_are_redacted_and_large_values_are_bounded() {
         let mut arguments = JsonObject::new();
@@ -851,7 +898,12 @@ mod tests {
         });
         let metrics = Arc::new(UsageQueueMetrics::default());
         let (tx, _rx) = mpsc::channel(1);
-        let logger = UsageLogger { sink, tx, metrics };
+        let logger = UsageLogger {
+            sink,
+            tx,
+            metrics,
+            cancellation: None,
+        };
         logger.enqueue(json!({"event": 1}));
         logger.enqueue(json!({"event": 2}));
         let snapshot = logger.metrics_snapshot();

--- a/rust-mcp/src/usage.rs
+++ b/rust-mcp/src/usage.rs
@@ -20,10 +20,18 @@ use rmcp::{
 };
 use serde_json::{Map, Value, json};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
-use tokio::{io::AsyncWriteExt as _, sync::Mutex};
+use tokio::{
+    io::AsyncWriteExt as _,
+    sync::{Mutex, mpsc},
+};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use crate::{oauth::OAuthRequestInfo, request_control::DisconnectCancellation};
+use crate::{
+    background::BackgroundTaskRegistry, oauth::OAuthRequestInfo,
+    request_control::DisconnectCancellation,
+};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const MAX_USAGE_PREVIEW_CHARS: usize = 240;
 const MAX_TOOL_SUMMARY_CHARS: usize = 4_096;
@@ -34,24 +42,136 @@ struct UsageLogState {
 }
 
 #[derive(Debug)]
-pub struct UsageLogger {
+struct UsageLogSink {
     path: PathBuf,
     max_bytes: u64,
     rotations: usize,
     state: Mutex<UsageLogState>,
 }
 
+#[derive(Debug, Default)]
+struct UsageQueueMetrics {
+    enqueued: AtomicU64,
+    dropped: AtomicU64,
+    write_failures: AtomicU64,
+}
+
+#[derive(Debug)]
+pub struct UsageLogger {
+    sink: Arc<UsageLogSink>,
+    tx: mpsc::Sender<Value>,
+    metrics: Arc<UsageQueueMetrics>,
+}
+
 impl UsageLogger {
     #[must_use]
     pub fn new(path: PathBuf, max_bytes: u64, rotations: usize) -> Self {
-        Self {
+        let sink = Arc::new(UsageLogSink {
             path,
             max_bytes,
             rotations,
             state: Mutex::new(UsageLogState { bytes: None }),
+        });
+        let metrics = Arc::new(UsageQueueMetrics::default());
+        let (tx, mut rx) = mpsc::channel::<Value>(1024);
+        let writer_sink = sink.clone();
+        let writer_metrics = metrics.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                while let Some(event) = rx.recv().await {
+                    if writer_sink.append(&event).await.is_err() {
+                        writer_metrics
+                            .write_failures
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            });
+        }
+        Self { sink, tx, metrics }
+    }
+
+    #[must_use]
+    pub fn new_supervised(
+        path: PathBuf,
+        max_bytes: u64,
+        rotations: usize,
+        task_name: &'static str,
+        background: &BackgroundTaskRegistry,
+    ) -> Self {
+        let sink = Arc::new(UsageLogSink {
+            path,
+            max_bytes,
+            rotations,
+            state: Mutex::new(UsageLogState { bytes: None }),
+        });
+        let metrics = Arc::new(UsageQueueMetrics::default());
+        let (tx, rx) = mpsc::channel::<Value>(1024);
+        let receiver = Arc::new(Mutex::new(rx));
+        let writer_sink = sink.clone();
+        let writer_metrics = metrics.clone();
+        background.spawn_supervised(
+            task_name,
+            CancellationToken::new(),
+            move |cancellation, heartbeat| {
+                let receiver = receiver.clone();
+                let sink = writer_sink.clone();
+                let metrics = writer_metrics.clone();
+                async move {
+                    loop {
+                        let event = {
+                            let mut rx = receiver.lock().await;
+                            tokio::select! {
+                                () = cancellation.cancelled() => return Ok(()),
+                                event = rx.recv() => event,
+                            }
+                        };
+                        let Some(event) = event else {
+                            return Ok(());
+                        };
+                        if sink.append(&event).await.is_err() {
+                            metrics.write_failures.fetch_add(1, Ordering::Relaxed);
+                        }
+                        heartbeat.tick();
+                    }
+                }
+            },
+        );
+        Self { sink, tx, metrics }
+    }
+
+    /// Queue telemetry without blocking the tool or HTTP request on filesystem I/O.
+    pub fn enqueue(&self, event: Value) {
+        match self.tx.try_send(event) {
+            Ok(()) => {
+                self.metrics.enqueued.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(_) => {
+                self.metrics.dropped.fetch_add(1, Ordering::Relaxed);
+            }
         }
     }
 
+    #[must_use]
+    pub fn metrics_snapshot(&self) -> Value {
+        json!({
+            "enqueued": self.metrics.enqueued.load(Ordering::Relaxed),
+            "dropped": self.metrics.dropped.load(Ordering::Relaxed),
+            "writeFailures": self.metrics.write_failures.load(Ordering::Relaxed),
+            "capacityEvents": self.tx.max_capacity(),
+            "queuedEvents": self.tx.max_capacity().saturating_sub(self.tx.capacity()),
+        })
+    }
+
+    /// Direct append retained for deterministic rotation tests and maintenance utilities.
+    ///
+    /// # Errors
+    /// Returns filesystem or serialization errors from the underlying usage-log sink.
+    pub async fn append(&self, event: &Value) -> Result<()> {
+        self.sink.append(event).await
+    }
+}
+
+impl UsageLogSink {
     /// Append one compact JSON object and rotate before crossing the configured byte limit.
     ///
     /// # Errors
@@ -121,18 +241,27 @@ pub struct UsageService {
 
 impl UsageService {
     #[must_use]
-    pub fn new(project_root: &Path, max_bytes: u64, rotations: usize) -> Self {
+    pub fn new(
+        project_root: &Path,
+        max_bytes: u64,
+        rotations: usize,
+        background: &BackgroundTaskRegistry,
+    ) -> Self {
         let run = project_root.join("run");
         Self {
-            tool: Arc::new(UsageLogger::new(
+            tool: Arc::new(UsageLogger::new_supervised(
                 run.join("tool-usage.jsonl"),
                 max_bytes,
                 rotations,
+                "usage-tool-writer",
+                background,
             )),
-            http: Arc::new(UsageLogger::new(
+            http: Arc::new(UsageLogger::new_supervised(
                 run.join("http-usage.jsonl"),
                 max_bytes,
                 rotations,
+                "usage-http-writer",
+                background,
             )),
         }
     }
@@ -145,6 +274,14 @@ impl UsageService {
     #[must_use]
     pub fn http_logger(&self) -> Arc<UsageLogger> {
         self.http.clone()
+    }
+
+    #[must_use]
+    pub fn metrics_snapshot(&self) -> Value {
+        json!({
+            "tool": self.tool.metrics_snapshot(),
+            "http": self.http.metrics_snapshot(),
+        })
     }
 }
 
@@ -210,7 +347,7 @@ impl HttpUsageGuard {
         self.disconnect.take();
         let logger = self.logger.clone();
         let event = self.event("finished", Some(status));
-        spawn_usage_append(logger, event);
+        spawn_usage_append(&logger, event);
     }
 
     fn abort_in_background(&mut self) {
@@ -227,7 +364,7 @@ impl HttpUsageGuard {
         self.completed = true;
         let logger = self.logger.clone();
         let event = self.event("client_aborted", None);
-        spawn_usage_append(logger, event);
+        spawn_usage_append(&logger, event);
     }
 
     fn event(&self, outcome: &str, status: Option<StatusCode>) -> Value {
@@ -299,12 +436,8 @@ impl Drop for LoggedBodyStream {
     }
 }
 
-fn spawn_usage_append(logger: Arc<UsageLogger>, event: Value) {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        handle.spawn(async move {
-            logger.append(&event).await.ok();
-        });
-    }
+fn spawn_usage_append(logger: &UsageLogger, event: Value) {
+    logger.enqueue(event);
 }
 
 fn header_text(headers: &HeaderMap, name: header::HeaderName) -> String {
@@ -352,7 +485,7 @@ impl Drop for ToolUsageDropGuard {
             return;
         }
         spawn_usage_append(
-            self.logger.clone(),
+            &self.logger,
             self.invocation
                 .throw_event("MCP HTTP client disconnected before the tool result was delivered."),
         );
@@ -705,6 +838,26 @@ mod tests {
         assert!(summary.get("requestId").is_none());
         assert!(!summary.to_string().contains("super-secret-value"));
         assert!(!summary.to_string().contains("nested-secret-value"));
+    }
+
+    #[tokio::test]
+    async fn telemetry_enqueue_is_bounded_and_never_waits_for_disk() {
+        let temp = tempfile::tempdir().expect("temp");
+        let sink = Arc::new(UsageLogSink {
+            path: temp.path().join("usage.jsonl"),
+            max_bytes: 1024,
+            rotations: 1,
+            state: Mutex::new(UsageLogState { bytes: None }),
+        });
+        let metrics = Arc::new(UsageQueueMetrics::default());
+        let (tx, _rx) = mpsc::channel(1);
+        let logger = UsageLogger { sink, tx, metrics };
+        logger.enqueue(json!({"event": 1}));
+        logger.enqueue(json!({"event": 2}));
+        let snapshot = logger.metrics_snapshot();
+        assert_eq!(snapshot["enqueued"], 1);
+        assert_eq!(snapshot["dropped"], 1);
+        assert_eq!(snapshot["queuedEvents"], 1);
     }
 
     #[tokio::test]

--- a/rust-mcp/src/windows_job.rs
+++ b/rust-mcp/src/windows_job.rs
@@ -82,10 +82,21 @@ impl Drop for WindowsJob {
 /// Native fallback used if a process could not be assigned to a Job Object.
 /// Descendants are terminated before the root to reduce the chance of orphaning children.
 pub fn terminate_process_tree_fallback(root_pid: u32, exit_code: u32) {
+    let root_created = crate::windows_process::process_instance(root_pid);
+    terminate_process_tree_fallback_with_instance(root_pid, root_created, exit_code);
+}
+
+/// Native fallback with a caller-captured root creation fingerprint. This is used after
+/// Job Object termination, when the root process may already have exited and its PID may recycle.
+pub fn terminate_process_tree_fallback_with_instance(
+    root_pid: u32,
+    root_created: Option<u64>,
+    exit_code: u32,
+) {
     if root_pid == 0 {
         return;
     }
-    let descendants = descendant_pids(root_pid);
+    let descendants = descendant_pids(root_pid, root_created);
     for pid in descendants
         .into_iter()
         .rev()
@@ -105,7 +116,11 @@ fn terminate_pid(pid: u32, exit_code: u32) {
     }
 }
 
-fn descendant_pids(root_pid: u32) -> Vec<u32> {
+fn creation_is_safe(root_created: Option<u64>, child_created: Option<u64>) -> bool {
+    root_created.is_none_or(|root| child_created.is_some_and(|child| child >= root))
+}
+
+fn descendant_pids(root_pid: u32, root_created: Option<u64>) -> Vec<u32> {
     unsafe {
         let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
         if snapshot == INVALID_HANDLE_VALUE {
@@ -132,7 +147,11 @@ fn descendant_pids(root_pid: u32) -> Vec<u32> {
         while let Some(parent) = stack.pop() {
             if let Some(items) = children.get(&parent) {
                 for &child in items {
-                    if child != root_pid && seen.insert(child) {
+                    let creation_safe = creation_is_safe(
+                        root_created,
+                        crate::windows_process::process_instance(child),
+                    );
+                    if child != root_pid && creation_safe && seen.insert(child) {
                         result.push(child);
                         stack.push(child);
                     }
@@ -140,5 +159,19 @@ fn descendant_pids(root_pid: u32) -> Vec<u32> {
             }
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::creation_is_safe;
+
+    #[test]
+    fn descendant_creation_filter_rejects_older_or_unknown_children_when_root_is_known() {
+        assert!(creation_is_safe(None, None));
+        assert!(creation_is_safe(Some(100), Some(100)));
+        assert!(creation_is_safe(Some(100), Some(101)));
+        assert!(!creation_is_safe(Some(100), Some(99)));
+        assert!(!creation_is_safe(Some(100), None));
     }
 }

--- a/rust-mcp/src/windows_job.rs
+++ b/rust-mcp/src/windows_job.rs
@@ -1,0 +1,144 @@
+#![allow(unsafe_code)]
+
+//! Native Windows Job Object and process-tree termination primitives.
+
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+};
+
+use windows_sys::Win32::{
+    Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
+    System::{
+        Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
+            TH32CS_SNAPPROCESS,
+        },
+        JobObjects::{AssignProcessToJobObject, CreateJobObjectW, TerminateJobObject},
+        Threading::{
+            OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
+            TerminateProcess,
+        },
+    },
+};
+
+#[derive(Debug)]
+pub struct WindowsJob {
+    handle: usize,
+}
+
+impl WindowsJob {
+    /// Assign an existing process to a new Windows Job Object.
+    ///
+    /// # Errors
+    /// Returns the underlying Win32 error if the job/process cannot be opened or assigned.
+    pub fn assign(pid: u32) -> io::Result<Self> {
+        unsafe {
+            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if job.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            let process = OpenProcess(
+                PROCESS_SET_QUOTA | PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION,
+                0,
+                pid,
+            );
+            if process.is_null() {
+                let error = io::Error::last_os_error();
+                let _ = CloseHandle(job);
+                return Err(error);
+            }
+            let assigned = AssignProcessToJobObject(job, process);
+            let assign_error = if assigned == 0 {
+                Some(io::Error::last_os_error())
+            } else {
+                None
+            };
+            let _ = CloseHandle(process);
+            if let Some(error) = assign_error {
+                let _ = CloseHandle(job);
+                return Err(error);
+            }
+            Ok(Self {
+                handle: job as usize,
+            })
+        }
+    }
+
+    #[must_use]
+    pub fn terminate(&self, exit_code: u32) -> bool {
+        unsafe { TerminateJobObject(self.handle as HANDLE, exit_code) != 0 }
+    }
+}
+
+impl Drop for WindowsJob {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.handle as HANDLE);
+        }
+    }
+}
+
+/// Native fallback used if a process could not be assigned to a Job Object.
+/// Descendants are terminated before the root to reduce the chance of orphaning children.
+pub fn terminate_process_tree_fallback(root_pid: u32, exit_code: u32) {
+    if root_pid == 0 {
+        return;
+    }
+    let descendants = descendant_pids(root_pid);
+    for pid in descendants
+        .into_iter()
+        .rev()
+        .chain(std::iter::once(root_pid))
+    {
+        terminate_pid(pid, exit_code);
+    }
+}
+
+fn terminate_pid(pid: u32, exit_code: u32) {
+    unsafe {
+        let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
+        if !handle.is_null() {
+            let _ = TerminateProcess(handle, exit_code);
+            let _ = CloseHandle(handle);
+        }
+    }
+}
+
+fn descendant_pids(root_pid: u32) -> Vec<u32> {
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snapshot == INVALID_HANDLE_VALUE {
+            return Vec::new();
+        }
+        let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+        let mut entry: PROCESSENTRY32W = std::mem::zeroed();
+        entry.dwSize = u32::try_from(std::mem::size_of::<PROCESSENTRY32W>()).unwrap_or(u32::MAX);
+        if Process32FirstW(snapshot, &raw mut entry) != 0 {
+            loop {
+                children
+                    .entry(entry.th32ParentProcessID)
+                    .or_default()
+                    .push(entry.th32ProcessID);
+                if Process32NextW(snapshot, &raw mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        let _ = CloseHandle(snapshot);
+        let mut seen = HashSet::new();
+        let mut stack = vec![root_pid];
+        let mut result = Vec::new();
+        while let Some(parent) = stack.pop() {
+            if let Some(items) = children.get(&parent) {
+                for &child in items {
+                    if child != root_pid && seen.insert(child) {
+                        result.push(child);
+                        stack.push(child);
+                    }
+                }
+            }
+        }
+        result
+    }
+}

--- a/rust-mcp/src/windows_process.rs
+++ b/rust-mcp/src/windows_process.rs
@@ -83,7 +83,10 @@ pub fn process_matches_instance(pid: u32, expected: Option<u64>) -> bool {
     if !process_alive(pid) {
         return false;
     }
-    expected.is_none_or(|expected| process_instance(pid) == Some(expected))
+    match (expected, process_instance(pid)) {
+        (Some(expected), Some(actual)) => expected == actual,
+        _ => true,
+    }
 }
 
 #[must_use]
@@ -99,4 +102,22 @@ pub fn metrics_snapshot() -> Value {
         "maxMs": maximum.as_secs_f64() * 1_000.0,
         "backend": "win32-openprocess",
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_process_matching_uses_instance_only_when_both_are_known() {
+        let pid = std::process::id();
+        assert!(process_matches_instance(pid, None));
+        if let Some(instance) = process_instance(pid) {
+            assert!(process_matches_instance(pid, Some(instance)));
+            assert!(!process_matches_instance(
+                pid,
+                Some(instance.wrapping_add(1))
+            ));
+        }
+    }
 }

--- a/rust-mcp/src/windows_process.rs
+++ b/rust-mcp/src/windows_process.rs
@@ -9,8 +9,11 @@ use std::{
 
 use serde_json::{Value, json};
 use windows_sys::Win32::{
-    Foundation::{CloseHandle, ERROR_ACCESS_DENIED, GetLastError, WAIT_TIMEOUT},
-    System::Threading::{OpenProcess, PROCESS_SYNCHRONIZE, WaitForSingleObject},
+    Foundation::{CloseHandle, ERROR_ACCESS_DENIED, FILETIME, GetLastError, WAIT_TIMEOUT},
+    System::Threading::{
+        GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
+        WaitForSingleObject,
+    },
 };
 
 static PROBE_COUNT: AtomicU64 = AtomicU64::new(0);
@@ -40,6 +43,47 @@ pub fn process_alive(pid: u32) -> bool {
     PROBE_TOTAL_NS.fetch_add(nanos, Ordering::Relaxed);
     PROBE_MAX_NS.fetch_max(nanos, Ordering::Relaxed);
     alive
+}
+
+/// Stable process-instance fingerprint based on the Win32 creation FILETIME.
+/// A PID that has been recycled will have a different fingerprint.
+#[must_use]
+pub fn process_instance(pid: u32) -> Option<u64> {
+    if pid == 0 {
+        return None;
+    }
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return None;
+        }
+        let mut created: FILETIME = std::mem::zeroed();
+        let mut exited: FILETIME = std::mem::zeroed();
+        let mut kernel: FILETIME = std::mem::zeroed();
+        let mut user: FILETIME = std::mem::zeroed();
+        let ok = GetProcessTimes(
+            handle,
+            &raw mut created,
+            &raw mut exited,
+            &raw mut kernel,
+            &raw mut user,
+        ) != 0;
+        let _ = CloseHandle(handle);
+        ok.then(|| (u64::from(created.dwHighDateTime) << 32) | u64::from(created.dwLowDateTime))
+    }
+}
+
+#[must_use]
+pub fn current_process_instance() -> Option<u64> {
+    process_instance(std::process::id())
+}
+
+#[must_use]
+pub fn process_matches_instance(pid: u32, expected: Option<u64>) -> bool {
+    if !process_alive(pid) {
+        return false;
+    }
+    expected.is_none_or(|expected| process_instance(pid) == Some(expected))
 }
 
 #[must_use]

--- a/rust-mcp/src/windows_shell.rs
+++ b/rust-mcp/src/windows_shell.rs
@@ -139,9 +139,10 @@ if ($null -eq $process) {{
 Set-Content -LiteralPath '{}' -Value ([string]$process.Id) -Encoding ascii
 if (-not $process.WaitForExit({})) {{
   try {{
-    & taskkill.exe /PID $process.Id /T /F *> $null
+    $process.Kill($true)
     $process.WaitForExit()
   }} catch {{
+    try {{ $process.Kill() }} catch {{ }}
   }}
   throw 'Command timed out after {} ms.'
 }}
@@ -268,7 +269,8 @@ mod tests {
         assert!(launcher.contains("Start-Process"));
         assert!(launcher.contains("-Verb RunAs"));
         assert!(launcher.contains("WaitForExit(30000)"));
-        assert!(launcher.contains("taskkill.exe /PID $process.Id /T /F"));
+        assert!(launcher.contains("$process.Kill($true)"));
+        assert!(!launcher.contains("taskkill.exe"));
         assert!(launcher.contains("elevated-pid.txt"));
         let wrapper = elevated_wrapper(
             Path::new(r"C:\Temp\it's\command.ps1"),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.91.1"
+profile = "minimal"
+components = ["rustfmt", "clippy"]

--- a/scripts/Ensure-ChatGptDevboxGuardian.ps1
+++ b/scripts/Ensure-ChatGptDevboxGuardian.ps1
@@ -22,6 +22,9 @@ $guardianPidPath = Join-Path $guardianDir 'guardian.pid'
 $heartbeatPath = Join-Path $guardianDir 'heartbeat.json'
 $ensureLogPath = Join-Path $guardianDir 'ensure.log'
 $staleObservationPath = Join-Path $guardianDir 'ensure-stale-observation.json'
+$ensureLogMaxBytes = 1MB
+$ensureLogRotations = 3
+$guardianArtifactRetentionDays = 7
 $guardianSourcePaths = @(
     $guardianScript,
     $powerShellResolver,
@@ -33,12 +36,37 @@ if (-not (Test-Path $guardianDir)) {
     New-Item -ItemType Directory -Path $guardianDir | Out-Null
 }
 
+function Rotate-EnsureLogIfNeeded {
+    if (-not (Test-Path -LiteralPath $ensureLogPath)) { return }
+    $length = (Get-Item -LiteralPath $ensureLogPath -ErrorAction SilentlyContinue).Length
+    if ($length -lt $ensureLogMaxBytes) { return }
+    $oldest = "$ensureLogPath.$ensureLogRotations"
+    Remove-Item -LiteralPath $oldest -Force -ErrorAction SilentlyContinue
+    for ($index = $ensureLogRotations - 1; $index -ge 1; $index--) {
+        $from = "$ensureLogPath.$index"
+        $to = "$ensureLogPath.$($index + 1)"
+        if (Test-Path -LiteralPath $from) { Move-Item -LiteralPath $from -Destination $to -Force -ErrorAction SilentlyContinue }
+    }
+    Move-Item -LiteralPath $ensureLogPath -Destination "$ensureLogPath.1" -Force -ErrorAction SilentlyContinue
+}
+
+function Remove-StaleGuardianArtifacts {
+    $cutoff = [DateTime]::UtcNow.AddDays(-$guardianArtifactRetentionDays)
+    Get-ChildItem -LiteralPath $guardianDir -File -ErrorAction SilentlyContinue |
+        Where-Object {
+            ($_.Name -like '*.tmp' -or $_.Name -like '*.bak') -and
+            $_.LastWriteTimeUtc -lt $cutoff
+        } |
+        ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+}
+
 function Write-EnsureLog {
     param(
         [Parameter(Mandatory = $true)][string]$Message,
         [string]$Level = 'INFO'
     )
 
+    Rotate-EnsureLogIfNeeded
     $line = '{0} [{1}] {2}' -f ([DateTime]::UtcNow.ToString('o')), $Level.ToUpperInvariant(), $Message
     Add-Content -Path $ensureLogPath -Value $line -Encoding UTF8
 }
@@ -180,6 +208,8 @@ function Test-GuardianHeartbeatFresh {
         return $false
     }
 }
+
+Remove-StaleGuardianArtifacts
 
 $existing = Get-LiveGuardianProcess
 $heartbeatFresh = Test-GuardianHeartbeatFresh

--- a/scripts/Start-ChatGptDevboxMcp.ps1
+++ b/scripts/Start-ChatGptDevboxMcp.ps1
@@ -170,7 +170,7 @@ Fix: re-run scripts\Install-ChatGptDevboxGuardian.ps1 from an elevated PowerShel
     for ($i = 0; $i -lt 45; $i++) {
         Start-Sleep -Seconds 2
         try {
-            $response = Invoke-WebRequest -Uri "$localUrl/healthz" -UseBasicParsing -TimeoutSec 5
+            $response = Invoke-WebRequest -Uri "$localUrl/readyz" -UseBasicParsing -TimeoutSec 5
             if ($response.Content -match 'ok') {
                 Write-Host "Elevated MCP is healthy at $localUrl"
                 return
@@ -1162,7 +1162,7 @@ function Wait-ForHealthyPublicEndpoint {
         [string]$HostCloudflaredPidFile = ''
     )
 
-    $healthUrl = "$($PublicBaseUrl.TrimEnd('/'))/healthz"
+    $healthUrl = "$($PublicBaseUrl.TrimEnd('/'))/readyz"
     for ($i = 0; $i -lt 30; $i++) {
         Assert-StartupDeadline -Phase 'waiting-public-health'
         Start-Sleep -Seconds 2
@@ -1701,7 +1701,7 @@ for ($i = 0; $i -lt 30; $i++) {
     Assert-StartupDeadline -Phase 'waiting-local-health'
     Start-Sleep -Seconds 2
     try {
-        $response = Invoke-WebRequest -Uri "$localUrl/healthz" -UseBasicParsing -TimeoutSec 5
+        $response = Invoke-WebRequest -Uri "$localUrl/readyz" -UseBasicParsing -TimeoutSec 5
         if ($response.Content -match "ok") {
             break
         }
@@ -1711,7 +1711,7 @@ for ($i = 0; $i -lt 30; $i++) {
 
 Assert-StartupDeadline -Phase 'waiting-local-health'
 try {
-    $health = Invoke-WebRequest -Uri "$localUrl/healthz" -UseBasicParsing -TimeoutSec 5
+    $health = Invoke-WebRequest -Uri "$localUrl/readyz" -UseBasicParsing -TimeoutSec 5
     if ($health.Content -notmatch "ok") {
         throw "Health probe did not return ok."
     }
@@ -1739,12 +1739,38 @@ if ($Public) {
 }
 
 if ($mcpImplementation -eq 'rust' -and $launchSpec.CandidateManifestPath) {
-    Write-JsonStateFile -Path ([string]$launchSpec.CandidateManifestPath) -Value @{
+    $startedAtUtc = [DateTime]::UtcNow.ToString('o')
+    $promotedAtUtc = $startedAtUtc
+    $firstPromotedAtUtc = $startedAtUtc
+    $manifestPath = [string]$launchSpec.CandidateManifestPath
+    if (Test-Path -LiteralPath $manifestPath) {
+        try {
+            $previousManifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+            $sameCandidate =
+                ([string]$previousManifest.GitSha -eq [string]$launchSpec.GitSha) -and
+                ([string]$previousManifest.Sha256 -eq [string]$launchSpec.Sha256) -and
+                ([string]$previousManifest.Generation -eq [string]$launchSpec.Generation) -and
+                ([string]$previousManifest.FilePath -eq [string]$launchSpec.FilePath)
+            if ($sameCandidate) {
+                if ($previousManifest.PromotedAtUtc) { $promotedAtUtc = [string]$previousManifest.PromotedAtUtc }
+                if ($previousManifest.FirstPromotedAtUtc) {
+                    $firstPromotedAtUtc = [string]$previousManifest.FirstPromotedAtUtc
+                } elseif ($previousManifest.PromotedAtUtc) {
+                    $firstPromotedAtUtc = [string]$previousManifest.PromotedAtUtc
+                }
+            }
+        } catch {
+            # A corrupt previous manifest must not prevent a successfully validated candidate from promotion.
+        }
+    }
+    Write-JsonStateFile -Path $manifestPath -Value @{
         GitSha = [string]$launchSpec.GitSha
         Sha256 = [string]$launchSpec.Sha256
         Generation = [string]$launchSpec.Generation
         FilePath = [string]$launchSpec.FilePath
-        PromotedAtUtc = [DateTime]::UtcNow.ToString('o')
+        PromotedAtUtc = $promotedAtUtc
+        FirstPromotedAtUtc = $firstPromotedAtUtc
+        LastStartedAtUtc = $startedAtUtc
     }
     # Keep the current candidate plus two recent rollback candidates. Older locked
     # binaries are harmless and will be retried on the next successful start.
@@ -1762,6 +1788,7 @@ Write-StartupPhase -Phase 'ready' -Status 'ready' -Extra @{
     SelectedRuntime = $selectedRuntime
     DeploymentGeneration = $(if ($launchSpec.Generation) { [string]$launchSpec.Generation } else { $null })
     GitSha = $(if ($launchSpec.GitSha) { [string]$launchSpec.GitSha } else { $null })
+    LastStartedAtUtc = [DateTime]::UtcNow.ToString('o')
 }
 
 Write-Host "Local MCP URL: $localUrl"
@@ -1809,7 +1836,7 @@ Write-Host "MCP implementation: $mcpImplementation"
     if (-not $TunnelOnly -and $selectedRuntime -eq 'host' -and $Public) {
         $originStillHealthy = $false
         try {
-            $originCheck = Invoke-WebRequest -Uri "http://127.0.0.1:$port/healthz" -UseBasicParsing -TimeoutSec 3
+            $originCheck = Invoke-WebRequest -Uri "http://127.0.0.1:$port/readyz" -UseBasicParsing -TimeoutSec 3
             $originStillHealthy = $originCheck.Content -match 'ok'
         } catch {
         }

--- a/scripts/Watch-ChatGptDevboxGuardian.ps1
+++ b/scripts/Watch-ChatGptDevboxGuardian.ps1
@@ -25,7 +25,15 @@ $ProjectRoot = [System.IO.Path]::GetFullPath($ProjectRoot)
 $supervisorScript = Join-Path $ProjectRoot 'scripts\devbox-guardian.mjs'
 $guardianDir = Join-Path $ProjectRoot 'run\guardian'
 $guardianLogPath = Join-Path $guardianDir 'guardian.log'
-$mutexName = 'Global\ChatGptDevboxGuardian'
+function Get-GuardianMutexName {
+    param([Parameter(Mandatory = $true)][string]$Root)
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Root.TrimEnd('\').ToLowerInvariant())
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try { $hash = $sha.ComputeHash($bytes) } finally { $sha.Dispose() }
+    $suffix = ([BitConverter]::ToString($hash).Replace('-', '').Substring(0, 16))
+    return "Global\ChatGptDevboxGuardian-$suffix"
+}
+$mutexName = Get-GuardianMutexName -Root $ProjectRoot
 
 if (-not (Test-Path $guardianDir)) {
     New-Item -ItemType Directory -Path $guardianDir | Out-Null

--- a/scripts/ci/run-linux-distro-container-e2e.sh
+++ b/scripts/ci/run-linux-distro-container-e2e.sh
@@ -43,7 +43,7 @@ docker run --rm \
     cat /etc/os-release || true
     echo '=== toolchain ==='
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh
-    sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain 1.97.1 --no-modify-path
+    sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain 1.91.1 --no-modify-path
     rm -f /tmp/rustup-init.sh
     export PATH="\$HOME/.cargo/bin:\$PATH"
     node --version

--- a/scripts/ci/run-windows-runtime-e2e.ps1
+++ b/scripts/ci/run-windows-runtime-e2e.ps1
@@ -43,10 +43,43 @@ try {
     $env:PUBLIC_BASE_URL = ''
 
     & (Join-Path $root 'scripts\Start-ChatGptDevboxMcp.ps1') -Runtime host
-    $health = Invoke-WebRequest -Uri "http://127.0.0.1:$port/healthz" -UseBasicParsing -TimeoutSec 5
+    $health = Invoke-WebRequest -Uri "http://127.0.0.1:$port/readyz" -UseBasicParsing -TimeoutSec 5
     if ($health.StatusCode -ne 200 -or $health.Content -notmatch 'ok') { throw 'Rust MCP health gate failed.' }
 
+    $trackedDirty = ((& git -C $root status --porcelain --untracked-files=no | Out-String).Trim()).Length -gt 0
+    if (-not $trackedDirty) {
+        $currentRustManifestPath = Join-Path $root 'run\bin\current-rust.json'
+        $firstManifest = Get-Content $currentRustManifestPath -Raw -ErrorAction Stop | ConvertFrom-Json
+        Start-Sleep -Seconds 1
+        & (Join-Path $root 'scripts\Start-ChatGptDevboxMcp.ps1') -Runtime host
+        $secondManifest = Get-Content $currentRustManifestPath -Raw -ErrorAction Stop | ConvertFrom-Json
+        if ([string]$secondManifest.PromotedAtUtc -ne [string]$firstManifest.PromotedAtUtc) {
+            throw 'Restarting the same immutable Rust candidate changed PromotedAtUtc.'
+        }
+        if ([string]$secondManifest.FirstPromotedAtUtc -ne [string]$firstManifest.FirstPromotedAtUtc) {
+            throw 'Restarting the same immutable Rust candidate changed FirstPromotedAtUtc.'
+        }
+        if ([DateTime]$secondManifest.LastStartedAtUtc -le [DateTime]$firstManifest.LastStartedAtUtc) {
+            throw 'Restarting the same immutable Rust candidate did not advance LastStartedAtUtc.'
+        }
+        $health = Invoke-WebRequest -Uri "http://127.0.0.1:$port/readyz" -UseBasicParsing -TimeoutSec 5
+        if ($health.StatusCode -ne 200) { throw 'Rust MCP readiness failed after same-candidate restart.' }
+
+    } else {
+        Write-Host 'Skipping same-candidate restart provenance assertion because the local checkout has tracked modifications.'
+    }
+
+    $guardianDir = Join-Path $root 'run\guardian'
+    New-Item -ItemType Directory -Path $guardianDir -Force | Out-Null
+    $staleGuardianArtifact = Join-Path $guardianDir 'ci-stale-artifact.tmp'
+    [IO.File]::WriteAllText($staleGuardianArtifact, 'stale', [Text.UTF8Encoding]::new($false))
+    (Get-Item $staleGuardianArtifact).LastWriteTimeUtc = [DateTime]::UtcNow.AddDays(-8)
+    $ensureLog = Join-Path $guardianDir 'ensure.log'
+    [IO.File]::WriteAllText($ensureLog, ('x' * (1MB + 1024)), [Text.UTF8Encoding]::new($false))
+
     & (Join-Path $root 'scripts\Install-ChatGptDevboxGuardian.ps1') -Runtime host -TaskPrefix $taskPrefix | Out-Host
+    if (Test-Path $staleGuardianArtifact) { throw 'Guardian Ensure did not prune stale atomic-write debris.' }
+    if (-not (Test-Path "$ensureLog.1")) { throw 'Guardian Ensure did not rotate the oversized auxiliary log.' }
     $startupTask = Get-ScheduledTask -TaskName "$taskPrefix-Startup"
     $logonTask = Get-ScheduledTask -TaskName "$taskPrefix-Logon"
     $startupTriggerTypes = @($startupTask.Triggers | ForEach-Object { $_.CimClass.CimClassName })
@@ -141,6 +174,8 @@ try {
         Remove-Item $envPath -Force -ErrorAction SilentlyContinue
     }
     Remove-Item $runtimeEnv -Force -ErrorAction SilentlyContinue
+    Remove-Item (Join-Path $root 'run\guardian\ci-stale-artifact.tmp') -Force -ErrorAction SilentlyContinue
+    Remove-Item (Join-Path $root 'run\guardian\ensure.log.1') -Force -ErrorAction SilentlyContinue
     foreach ($name in $isolatedEnvNames) {
         [Environment]::SetEnvironmentVariable($name, $previousProcessEnvironment[$name], 'Process')
     }

--- a/scripts/ci/test-windows-startup-contract.ps1
+++ b/scripts/ci/test-windows-startup-contract.ps1
@@ -105,8 +105,9 @@ if (Test-Path $legacy) {
     $escapedOwnership = $ownershipPath.Replace("'", "''")
     $escapedInstall = $installPath.Replace("'", "''")
     $escapedEnsureGuardian = $ensureGuardianPath.Replace("'", "''")
+    $escapedWatchGuardian = $watchGuardianPath.Replace("'", "''")
     $command = @"
-`$ErrorActionPreference='Stop'; foreach(`$f in @('$escapedStart','$escapedStop','$escapedOwnership','$escapedInstall','$escapedEnsureGuardian')) { `$t=`$null; `$e=`$null; [System.Management.Automation.Language.Parser]::ParseFile(`$f,[ref]`$t,[ref]`$e) | Out-Null; if(`$e.Count -gt 0) { throw (`$e | Out-String) } }
+`$ErrorActionPreference='Stop'; foreach(`$f in @('$escapedStart','$escapedStop','$escapedOwnership','$escapedInstall','$escapedEnsureGuardian','$escapedWatchGuardian')) { `$t=`$null; `$e=`$null; [System.Management.Automation.Language.Parser]::ParseFile(`$f,[ref]`$t,[ref]`$e) | Out-Null; if(`$e.Count -gt 0) { throw (`$e | Out-String) } }
 "@
     & $legacy -NoLogo -NoProfile -NonInteractive -Command $command
     if ($LASTEXITCODE -ne 0) { throw "Windows PowerShell 5.1 parse validation failed with exit code $LASTEXITCODE." }

--- a/scripts/ci/test-windows-startup-contract.ps1
+++ b/scripts/ci/test-windows-startup-contract.ps1
@@ -6,6 +6,7 @@ $stopPath = Join-Path $root 'scripts\Stop-ChatGptDevboxMcp.ps1'
 $ownershipPath = Join-Path $root 'scripts\DevboxMcpOwnership.ps1'
 $installPath = Join-Path $root 'scripts\Install-ChatGptDevboxGuardian.ps1'
 $ensureGuardianPath = Join-Path $root 'scripts\Ensure-ChatGptDevboxGuardian.ps1'
+$watchGuardianPath = Join-Path $root 'scripts\Watch-ChatGptDevboxGuardian.ps1'
 $vbsPath = Join-Path $root 'scripts\Run-Start-ChatGptDevboxMcp.vbs'
 
 function Assert-Contains {
@@ -25,11 +26,15 @@ $stop = Get-Content -LiteralPath $stopPath -Raw
 $ownership = Get-Content -LiteralPath $ownershipPath -Raw
 $install = Get-Content -LiteralPath $installPath -Raw
 $ensureGuardian = Get-Content -LiteralPath $ensureGuardianPath -Raw
+$watchGuardian = Get-Content -LiteralPath $watchGuardianPath -Raw
 $vbs = Get-Content -LiteralPath $vbsPath -Raw
 
 Assert-Contains $start '$script:lifecycleMutex.WaitOne(0, $false)' 'Lifecycle mutex must reject concurrent starts instead of queueing them.'
 Assert-Contains $start "Join-Path `$RunDir 'startup-state.json'" 'Startup phase journal is missing.'
 Assert-Contains $start "Write-StartupPhase -Phase 'waiting-local-health'" 'Local-health phase journaling is missing.'
+Assert-Contains $start '/readyz' 'Managed startup must gate candidate acceptance on operational readiness, not only liveness.'
+Assert-Contains $start 'FirstPromotedAtUtc' 'Rust candidate provenance must preserve first promotion time.'
+Assert-Contains $start 'LastStartedAtUtc' 'Rust candidate provenance must distinguish process restart time from promotion time.'
 Assert-Contains $start "Write-StartupPhase -Phase 'waiting-public-health'" 'Public-health phase journaling is missing.'
 Assert-Contains $start 'Assert-StartupDeadline' 'Startup deadline enforcement is missing.'
 Assert-Contains $start "Assert-StartupDeadline -Phase 'stopping-existing-mcp'" 'Owned MCP stop must honor the startup deadline.'
@@ -81,8 +86,10 @@ Assert-Contains $ensureGuardian "'-File', ('`"{0}`"' -f `$guardianScript)" 'Guar
 Assert-Contains $ensureGuardian 'Start-Process -FilePath $powerShellExe -ArgumentList $arguments -WorkingDirectory $ProjectRoot -WindowStyle Hidden' 'Guardian Ensure must launch the watcher directly through the resolved PowerShell executable.'
 Assert-Contains $ensureGuardian 'function Get-LiveGuardianSupervisorProcess' 'Guardian Ensure must identify a verified orphan supervisor separately from the watcher.'
 Assert-Contains $ensureGuardian 'guardian watcher failed to start persistently' 'Guardian Ensure must require a persistent watcher before reporting success.'
+Assert-Contains $watchGuardian 'function Get-GuardianMutexName' 'Guardian mutex ownership must be scoped to the project root.'
+Assert-Contains $watchGuardian 'Global\ChatGptDevboxGuardian-' 'Guardian mutex must use a root-derived namespace.'
 
-foreach ($file in @($startPath, $stopPath, $ownershipPath, $installPath, $ensureGuardianPath)) {
+foreach ($file in @($startPath, $stopPath, $ownershipPath, $installPath, $ensureGuardianPath, $watchGuardianPath)) {
     $tokens = $null
     $errors = $null
     [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$tokens, [ref]$errors) | Out-Null

--- a/scripts/devbox-guardian.mjs
+++ b/scripts/devbox-guardian.mjs
@@ -922,9 +922,10 @@ const main = async () => {
     const publicEnabled = settings.Public === true || Boolean(publicBaseUrl);
     const mcpProcess = await findMcpProcess(paths.runDir);
     const localBaseUrl = `http://127.0.0.1:${port}`;
-    const [localHealth, publicHealth, mcpPerformance] = await Promise.all([
-      testHealth(`${localBaseUrl}/healthz`),
-      publicEnabled ? testHealth(`${publicBaseUrl}/healthz`) : Promise.resolve(null),
+    const [localLiveness, localHealth, publicHealth, mcpPerformance] = await Promise.all([
+      testHealth(`${localBaseUrl}/livez`),
+      testHealth(`${localBaseUrl}/readyz`),
+      publicEnabled ? testHealth(`${publicBaseUrl}/readyz`) : Promise.resolve(null),
       readMcpPerformanceState(options.projectRoot, environment),
     ]);
     const pressureIntervalMs = Math.max(10000, Number.parseInt(environment.GUARDIAN_HOST_PRESSURE_SAMPLE_MS ?? "60000", 10) || 60000);
@@ -1100,6 +1101,7 @@ const main = async () => {
       McpProcessId: mcpProcess.pid,
       McpElevated: mcpElevated,
       RequireMcpElevated: requireMcpElevated,
+      LocalLiveness: localLiveness,
       LocalHealth: localHealth,
       PublicHealth: publicHealth,
       McpPerformance: mcpPerformance,

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadEnvFile } from "./env.js";
-import { defaultHostProgramAllowlist, detectPlatform, resolveHostShell, resolveRuntimeMode } from "./platform.js";
+import { defaultHostProgramAllowlist, detectPlatform, mergeHostProgramAllowlist, resolveHostShell, resolveRuntimeMode } from "./platform.js";
 
 const parseInteger = (value, fallback) => {
   const parsed = Number.parseInt(value ?? "", 10);
@@ -114,7 +114,15 @@ const powerShellFallbackExe = platform.isWindows
   ? [configuredPowerShellFallbackExe, legacyWindowsPowerShellExe].find(isUsablePowerShellCandidate) || "powershell.exe"
   : "";
 const hostShell = process.env.HOST_SHELL?.trim() || (platform.isWindows ? powerShellExe : resolveHostShell(process.env, platform));
-const hostProgramAllowlist = parseCsv(process.env.HOST_PROGRAM_ALLOWLIST, defaultHostProgramAllowlist(platform));
+const hostProgramDefaults = defaultHostProgramAllowlist(platform);
+const hostProgramConfigured = parseCsv(process.env.HOST_PROGRAM_ALLOWLIST, []);
+const hostProgramExtra = parseCsv(process.env.HOST_PROGRAM_ALLOWLIST_EXTRA, []);
+const hostProgramAllowlist = mergeHostProgramAllowlist({
+  defaults: hostProgramDefaults,
+  configured: hostProgramConfigured,
+  extra: hostProgramExtra,
+  replace: parseBoolean(process.env.HOST_PROGRAM_ALLOWLIST_REPLACE, false),
+});
 const defaultDevboxProgramAllowlist = runtimeMode === "host"
   ? hostProgramAllowlist
   : ["bash", "sh", "git", "gh", "node", "npm", "npx", "python", "python3", "pip", "pip3", "rg", "curl"];

--- a/src/platform.js
+++ b/src/platform.js
@@ -44,6 +44,13 @@ export const defaultHostProgramAllowlist = (platform) =>
     ? ["powershell", "pwsh", "cmd", "git", "gh", "docker", "node", "npm", "npx", "python", "py", "pip", "rg", "curl", "winget"]
     : ["bash", "sh", "git", "gh", "node", "npm", "npx", "python", "python3", "pip", "pip3", "rg", "curl"];
 
+export const mergeHostProgramAllowlist = ({ defaults = [], configured = [], extra = [], replace = false } = {}) => {
+  const normalize = (items) => items.map((value) => String(value).trim().toLowerCase()).filter(Boolean);
+  const base = replace && configured.length > 0 ? normalize(configured) : normalize(defaults);
+  const additions = replace ? [] : [...normalize(configured), ...normalize(extra)];
+  return [...new Set([...base, ...additions])];
+};
+
 export const resolveHostShell = (env = process.env, platform = detectPlatform(env)) => {
   if (platform?.isWindows) {
     return String(env.HOST_SHELL ?? env.POWERSHELL_EXE ?? "powershell.exe").trim() || "powershell.exe";

--- a/src/server.js
+++ b/src/server.js
@@ -2200,6 +2200,24 @@ app.get("/", async (_req, res) => {
 app.get("/healthz", (_req, res) => {
   res.type("text/plain").send("ok");
 });
+app.get("/livez", (_req, res) => {
+  res.type("text/plain").send("ok");
+});
+app.get("/readyz", async (_req, res) => {
+  try {
+    const jobsRoot = path.join(runDir, "jobs");
+    await mkdir(jobsRoot, { recursive: true });
+    const devbox = await getDevboxInfo();
+    const ready = devbox?.running === true;
+    res.status(ready ? 200 : 503).json({
+      ok: ready,
+      jobStoreReady: true,
+      runtimeReady: ready,
+    });
+  } catch (error) {
+    res.status(503).json({ ok: false, error: error instanceof Error ? error.message : String(error) });
+  }
+});
 
 if (legacyProtectedResourceMetadata) {
   app.get("/.well-known/oauth-protected-resource/mcp", (_req, res) => {

--- a/src/server.js
+++ b/src/server.js
@@ -73,6 +73,8 @@ import {
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const runDir = path.join(projectRoot, "run");
+const jobsRoot = path.join(runDir, "jobs");
+const jobsRootReady = mkdir(jobsRoot, { recursive: true });
 const guardianDesiredStatePath = path.join(runDir, "guardian.desired-state.json");
 const toolUsageLogPath = path.join(runDir, "tool-usage.jsonl");
 const httpUsageLogPath = path.join(runDir, "http-usage.jsonl");
@@ -2205,17 +2207,20 @@ app.get("/livez", (_req, res) => {
 });
 app.get("/readyz", async (_req, res) => {
   try {
-    const jobsRoot = path.join(runDir, "jobs");
-    await mkdir(jobsRoot, { recursive: true });
+    if (!Number.isFinite(config.dockerCommandTimeoutMs) || config.dockerCommandTimeoutMs <= 0) {
+      throw new Error("DOCKER_COMMAND_TIMEOUT_MS must be greater than zero for readiness checks.");
+    }
+    await jobsRootReady;
+    const jobsMetadata = await stat(jobsRoot);
+    if (!jobsMetadata.isDirectory()) {
+      throw new Error("Job store path is not a directory.");
+    }
     const devbox = await getDevboxInfo();
     const ready = devbox?.running === true;
-    res.status(ready ? 200 : 503).json({
-      ok: ready,
-      jobStoreReady: true,
-      runtimeReady: ready,
-    });
+    res.status(ready ? 200 : 503).json({ ok: ready });
   } catch (error) {
-    res.status(503).json({ ok: false, error: error instanceof Error ? error.message : String(error) });
+    console.warn("Readiness probe failed", error);
+    res.status(503).json({ ok: false });
   }
 });
 

--- a/test/mcp-http.test.js
+++ b/test/mcp-http.test.js
@@ -88,6 +88,7 @@ const startServer = async (t, {
   maxCommandOutputChars = "65536",
   execMaxConcurrent = "16",
   execReservedInteractive = "1",
+  dockerCommandTimeoutMs = "120000",
 } = {}) => {
   const port = await getFreePort();
   const executionSlotRoot = await mkdtemp(path.join(os.tmpdir(), "docker-chatgpt-devbox-mcp-slots-"));
@@ -113,6 +114,7 @@ const startServer = async (t, {
       MCP_JOBS_ROOT: jobsRoot,
       MCP_EXEC_MAX_CONCURRENT: execMaxConcurrent,
       MCP_EXEC_RESERVED_INTERACTIVE: execReservedInteractive,
+      DOCKER_COMMAND_TIMEOUT_MS: dockerCommandTimeoutMs,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -404,10 +406,14 @@ test("GET /readyz reports operational readiness without exposing detailed diagno
   const response = await fetch(`http://127.0.0.1:${port}/readyz`, { signal: AbortSignal.timeout(5000) });
   assert.equal(response.status, 200);
   const body = await response.json();
-  assert.equal(body.ok, true);
-  assert.equal(body.jobStoreReady, true);
-  assert.equal(body.runtimeReady, true);
-  assert.equal(Object.hasOwn(body, "runtimeMode"), false);
+  assert.deepEqual(body, { ok: true });
+});
+
+test("GET /readyz rejects a zero Docker command timeout without leaking error details", async (t) => {
+  const { port } = await startServer(t, { dockerCommandTimeoutMs: "0" });
+  const response = await fetch(`http://127.0.0.1:${port}/readyz`, { signal: AbortSignal.timeout(5000) });
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), { ok: false });
 });
 
 test("GET / returns an SSE content type for stream probes", async (t) => {

--- a/test/mcp-http.test.js
+++ b/test/mcp-http.test.js
@@ -399,6 +399,17 @@ const assertSseProbeResponse = async (response, errorMessage) => {
   await reader?.cancel();
 };
 
+test("GET /readyz reports operational readiness without exposing detailed diagnostics", async (t) => {
+  const { port } = await startServer(t);
+  const response = await fetch(`http://127.0.0.1:${port}/readyz`, { signal: AbortSignal.timeout(5000) });
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.jobStoreReady, true);
+  assert.equal(body.runtimeReady, true);
+  assert.equal(Object.hasOwn(body, "runtimeMode"), false);
+});
+
 test("GET / returns an SSE content type for stream probes", async (t) => {
   const { port, stdout, stderr } = await startServer(t);
 

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -5,6 +5,7 @@ import {
   buildHostShellArgs,
   detectPlatform,
   defaultHostProgramAllowlist,
+  mergeHostProgramAllowlist,
   resolveRuntimeMode,
   resolveHostShell,
 } from "../src/platform.js";
@@ -38,6 +39,22 @@ test("Windows host program allowlist includes direct search and HTTP tools", () 
   const allowlist = defaultHostProgramAllowlist(detectPlatform({}, "win32"));
   assert.equal(allowlist.includes("rg"), true);
   assert.equal(allowlist.includes("curl"), true);
+});
+
+test("configured host allowlist is additive unless replacement is explicit", () => {
+  const defaults = ["git", "rg", "curl"];
+  assert.deepEqual(
+    mergeHostProgramAllowlist({ defaults, configured: ["git", "custom"], extra: ["extra"] }),
+    ["git", "rg", "curl", "custom", "extra"],
+  );
+  assert.deepEqual(
+    mergeHostProgramAllowlist({ defaults, configured: ["custom"], replace: true }),
+    ["custom"],
+  );
+  assert.deepEqual(
+    mergeHostProgramAllowlist({ defaults, configured: [], replace: true }),
+    defaults,
+  );
 });
 
 test("resolveHostShell prefers SHELL on posix and PowerShell on Windows", () => {

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -55,6 +55,10 @@ test("configured host allowlist is additive unless replacement is explicit", () 
     mergeHostProgramAllowlist({ defaults, configured: [], replace: true }),
     defaults,
   );
+  assert.deepEqual(
+    mergeHostProgramAllowlist({ defaults, configured: [" Git ", "CURL", "git"], extra: [" Curl "] }),
+    ["git", "rg", "curl"],
+  );
 });
 
 test("resolveHostShell prefers SHELL on posix and PowerShell on Windows", () => {


### PR DESCRIPTION
## Summary
- move tool/HTTP telemetry off request latency with bounded supervised writers
- supervise critical Rust background loops and expose freshness/age diagnostics
- add `/livez` and bounded operational `/readyz`; deployment/Guardian now gate on readiness
- cache performance snapshots and persist a bounded multi-restart history ring
- index job maintenance, add global job-store quotas, adaptive FIFO polling, PID instance fingerprints
- bound inherited-pipe completion and job output; use native Windows Job Objects/process-tree cleanup
- make host program allowlists additive by default and keep versions refreshed in the background
- split promotion vs restart provenance; rotate/prune Guardian auxiliary artifacts
- pin production/CI Rust 1.91.1 with a separate 1.88 MSRV check
- merge routine dependency upgrades including sha2 0.11 compatibility and group future Dependabot updates

## Local validation
- Rust: 130/130 tests, Clippy -D warnings, fmt, Rust 1.88 MSRV check
- JS unit: 133 pass / 1 intentional skip
- Rust SDK smoke: 37 tools + health/liveness/readiness + version refresh
- Windows contention: four 8s waits; 73 readiness probes max ~4.85ms; devbox_status ~6.78ms
- JS/Rust observable parity: 41/41, zero differences
- schema parity: 37/37 across host/docker/constrained/unlimited profiles
- gateway/OAuth/Cloudflare-OAuth/disconnect smokes pass
- native Windows launcher + Guardian lifecycle E2E passes, including clean-tree same-candidate provenance, ensure.log rotation and stale-artifact cleanup
- cargo audit: no reported RustSec vulnerabilities
- npm production audit: 0 vulnerabilities

Production is intentionally untouched pending PR CI/review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/livez` and `/readyz` health endpoints with detailed readiness checks.
  * Added configurable host-program allowlists supporting extensions or replacement of defaults.
  * Added background task health, usage telemetry, performance data, and refreshed version information.
  * Added retained-job storage limits of 2 GiB and 5,000 terminal jobs, with automatic eviction.

* **Bug Fixes**
  * Improved Windows process-tree termination and prevented cleanup of reused process IDs.
  * Improved output handling and bounded queues for more reliable execution.
  * Improved guardian monitoring, log rotation, and stale-artifact cleanup.

* **Documentation**
  * Expanded configuration and job-retention guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->