### PR TITLE
fix: make tool telemetry fully nonblocking

### DIFF
--- a/rust-mcp/scripts/smoke-client.mjs
+++ b/rust-mcp/scripts/smoke-client.mjs
@@ -206,6 +206,10 @@ try {
   assert.equal(statusData.performance?.process?.memory?.rss >= 0, true);
   assert.equal(statusData.performance?.eventLoop?.p95Ms >= 0, true);
   assert.match(statusData.performance?.eventLoop?.sampledAtUtc || "", /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(statusData.usageTelemetry?.tool?.enqueued > 0, true);
+  assert.equal(statusData.usageTelemetry?.tool?.dropped, 0);
+  assert.equal(statusData.usageTelemetry?.tool?.writeFailures, 0);
+  assert.equal(statusData.backgroundTasks?.["usage-tool-writer"]?.running, true);
   const allocator = statusData.performance?.process?.memory?.allocator;
   assert.equal(allocator?.backend, "std::alloc::System tracked requested bytes");
   assert.equal(Number.isFinite(allocator?.currentRequestedBytes), true);

--- a/rust-mcp/src/server.rs
+++ b/rust-mcp/src/server.rs
@@ -2243,7 +2243,7 @@ impl ServerHandler for DevboxMcp {
         let invocation =
             ToolUsageInvocation::new(request.name.as_ref(), request.arguments.as_ref(), &context);
         let logger = self.usage.tool_logger();
-        logger.append(&invocation.start_event()).await.ok();
+        logger.enqueue(invocation.start_event());
         let mut usage_guard = ToolUsageDropGuard::new(logger.clone(), invocation.clone());
         let _active_request = self.active_requests.register_context(&context);
         let result = self
@@ -2251,12 +2251,9 @@ impl ServerHandler for DevboxMcp {
             .call(ToolCallContext::new(self, request, context))
             .await;
         match &result {
-            Ok(response) => logger.append(&invocation.finish_event(response)).await.ok(),
-            Err(error) => logger
-                .append(&invocation.throw_event(&error.to_string()))
-                .await
-                .ok(),
-        };
+            Ok(response) => logger.enqueue(invocation.finish_event(response)),
+            Err(error) => logger.enqueue(invocation.throw_event(&error.to_string())),
+        }
         usage_guard.complete();
         result
     }

--- a/rust-mcp/src/usage.rs
+++ b/rust-mcp/src/usage.rs
@@ -58,6 +58,7 @@ struct UsageQueueMetrics {
 
 #[derive(Debug)]
 pub struct UsageLogger {
+    #[cfg(test)]
     sink: Arc<UsageLogSink>,
     tx: mpsc::Sender<Value>,
     metrics: Arc<UsageQueueMetrics>,
@@ -94,6 +95,7 @@ impl UsageLogger {
             );
         }
         Self {
+            #[cfg(test)]
             sink,
             tx,
             metrics,
@@ -150,6 +152,7 @@ impl UsageLogger {
             },
         );
         Self {
+            #[cfg(test)]
             sink,
             tx,
             metrics,
@@ -180,10 +183,12 @@ impl UsageLogger {
         })
     }
 
-    /// Direct append retained for deterministic rotation tests and maintenance utilities.
+    /// Direct append retained only for deterministic rotation tests. Production callers
+    /// must use [`Self::enqueue`] so telemetry can never block request/tool execution on disk I/O.
     ///
     /// # Errors
     /// Returns filesystem or serialization errors from the underlying usage-log sink.
+    #[cfg(test)]
     pub async fn append(&self, event: &Value) -> Result<()> {
         self.sink.append(event).await
     }


### PR DESCRIPTION
Final P1 telemetry hotfix found during post-production audit. Normal Rust MCP tool start/finish/error telemetry now uses the existing bounded supervised queue rather than awaiting filesystem appends on the tool path. Direct append is test-only so production code cannot accidentally depend on it. SDK smoke now asserts queued tool telemetry is active with zero drops/write failures. Local gates: cargo check, strict clippy, 136/136 Rust tests, fresh-binary SDK smoke.