### PR TITLE
Fix interactive starvation under disk pressure

### DIFF
--- a/rust-mcp/src/execution.rs
+++ b/rust-mcp/src/execution.rs
@@ -26,7 +26,7 @@ const CORRUPT_QUEUE_TICKET_STALE: Duration = Duration::from_secs(5);
 const DISK_PRESSURE_STATE_STALE: Duration = Duration::from_secs(180);
 const DISK_PRESSURE_CACHE_TTL: Duration = Duration::from_secs(1);
 const AGED_BACKGROUND_CACHE_TTL: Duration = Duration::from_millis(250);
-type AgedBackgroundCache = BTreeMap<(PathBuf, u64), (Instant, bool)>;
+type AgedBackgroundCache = BTreeMap<(PathBuf, u64, usize, usize), (Instant, bool)>;
 static DISK_PRESSURE_CACHE: OnceLock<Mutex<BTreeMap<PathBuf, (Instant, bool)>>> = OnceLock::new();
 static AGED_BACKGROUND_CACHE: OnceLock<Mutex<AgedBackgroundCache>> = OnceLock::new();
 
@@ -37,7 +37,7 @@ fn invalidate_aged_background_cache(root: &Path) {
     cache
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .retain(|(cached_root, _), _| cached_root != root);
+        .retain(|(cached_root, _, _, _), _| cached_root != root);
 }
 #[cfg(windows)]
 const WINDOWS_SLOT_IO_RETRY_ATTEMPTS: usize = 100;
@@ -648,8 +648,9 @@ impl ExecutionScheduler {
                 continue;
             }
             if request.kind == ExecutionKind::Interactive
-                && aged_background_waiter_exists(
-                    &self.config.root,
+                && aged_background_waiter_competes(
+                    &self.config,
+                    plan,
                     self.config.background_priority_age,
                 )
                 .await?
@@ -1148,9 +1149,20 @@ async fn queue_ticket_is_head(_root: &Path, ticket: &QueueTicket) -> Result<bool
     }
 }
 
-async fn aged_background_waiter_exists(root: &Path, threshold: Duration) -> Result<bool> {
+async fn aged_background_waiter_competes(
+    config: &SchedulerConfig,
+    interactive_plan: &AcquirePlan,
+    threshold: Duration,
+) -> Result<bool> {
     let threshold_ms = duration_ms(threshold);
-    let key = (root.to_path_buf(), threshold_ms);
+    let candidate_start = interactive_plan.protected_low_slots;
+    let candidate_end = interactive_plan.usable_slots;
+    let key = (
+        config.root.clone(),
+        threshold_ms,
+        candidate_start,
+        candidate_end,
+    );
     let cache = AGED_BACKGROUND_CACHE.get_or_init(|| Mutex::new(BTreeMap::new()));
     {
         let values = cache
@@ -1162,7 +1174,8 @@ async fn aged_background_waiter_exists(root: &Path, threshold: Duration) -> Resu
             return Ok(*result);
         }
     }
-    let result = aged_background_waiter_exists_uncached(root, threshold).await?;
+    let result =
+        aged_background_waiter_competes_uncached(config, interactive_plan, threshold).await?;
     cache
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1170,8 +1183,21 @@ async fn aged_background_waiter_exists(root: &Path, threshold: Duration) -> Resu
     Ok(result)
 }
 
-async fn aged_background_waiter_exists_uncached(root: &Path, threshold: Duration) -> Result<bool> {
-    let queue_root = root.join("queue");
+fn slot_ranges_overlap(
+    first_start: usize,
+    first_end: usize,
+    second_start: usize,
+    second_end: usize,
+) -> bool {
+    first_start < second_end && second_start < first_end
+}
+
+async fn aged_background_waiter_competes_uncached(
+    config: &SchedulerConfig,
+    interactive_plan: &AcquirePlan,
+    threshold: Duration,
+) -> Result<bool> {
+    let queue_root = config.root.join("queue");
     let mut reader = match fs::read_dir(&queue_root).await {
         Ok(reader) => reader,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
@@ -1203,7 +1229,34 @@ async fn aged_background_waiter_exists_uncached(root: &Path, threshold: Duration
             .get("queuedAtUnixMs")
             .and_then(Value::as_u64)
             .unwrap_or(now_ms);
-        if now_ms.saturating_sub(queued_ms) >= threshold_ms {
+        if now_ms.saturating_sub(queued_ms) < threshold_ms {
+            continue;
+        }
+        let resource_class = ResourceClass::parse(
+            owner
+                .get("resourceClass")
+                .and_then(Value::as_str)
+                .unwrap_or("light"),
+        );
+        let weight = owner
+            .get("weight")
+            .and_then(Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+            .unwrap_or(1)
+            .max(1);
+        let background_request =
+            AcquireRequest::background("aged-background-probe", resource_class, weight);
+        let background_plan = AcquirePlan::new(
+            config,
+            &background_request,
+            interactive_plan.disk_pressure_constrained,
+        );
+        if slot_ranges_overlap(
+            interactive_plan.protected_low_slots,
+            interactive_plan.usable_slots,
+            background_plan.protected_low_slots,
+            background_plan.usable_slots,
+        ) {
             return Ok(true);
         }
     }
@@ -2134,6 +2187,73 @@ mod tests {
             "warning pressure should serialize heavy claims"
         );
         first.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn disk_pressure_light_interactive_bypasses_non_overlapping_aged_heavy_background() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(".disk-pressure.json"),
+            br#"{"diskPressure":"warning"}"#,
+        )
+        .await
+        .unwrap();
+        let scheduler = ExecutionScheduler::new(SchedulerConfig {
+            root: temp.path().to_path_buf(),
+            max_concurrent: 4,
+            reserved_interactive: 1,
+            watch_max_concurrent: 1,
+            queue_timeout: Duration::from_secs(2),
+            heavy_capacity: 4,
+            heavy_weight: 2,
+            io_heavy_capacity: 2,
+            io_heavy_weight: 2,
+            background_priority_age: Duration::from_millis(1),
+        });
+        let cancellation = CancellationToken::new();
+        let mut first = scheduler
+            .acquire(
+                AcquireRequest::interactive_weighted("pressure-holder", ResourceClass::Heavy, 2),
+                &cancellation,
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.slots, vec![0, 1]);
+
+        let background_scheduler = scheduler.clone();
+        let background_cancel = cancellation.clone();
+        let background = tokio::spawn(async move {
+            background_scheduler
+                .acquire(
+                    AcquireRequest::background("aged-heavy-background", ResourceClass::Heavy, 2),
+                    &background_cancel,
+                )
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let mut light = tokio::time::timeout(
+            Duration::from_millis(400),
+            scheduler.acquire(
+                AcquireRequest::interactive("pressure-light-after-aged-heavy"),
+                &cancellation,
+            ),
+        )
+        .await
+        .expect("light request should not yield to a non-overlapping aged heavy waiter")
+        .unwrap();
+        assert!(light.slot.is_some_and(|slot| slot >= 2));
+        assert!(!background.is_finished());
+        light.release().await.unwrap();
+        first.release().await.unwrap();
+
+        let mut background_lease = tokio::time::timeout(Duration::from_secs(1), background)
+            .await
+            .expect("aged heavy background should resume after corridor release")
+            .unwrap()
+            .unwrap();
+        assert_eq!(background_lease.slots, vec![0, 1]);
+        background_lease.release().await.unwrap();
     }
 
     #[tokio::test]

--- a/rust-mcp/src/execution.rs
+++ b/rust-mcp/src/execution.rs
@@ -26,7 +26,21 @@ const CORRUPT_QUEUE_TICKET_STALE: Duration = Duration::from_secs(5);
 const DISK_PRESSURE_STATE_STALE: Duration = Duration::from_secs(180);
 const DISK_PRESSURE_CACHE_TTL: Duration = Duration::from_secs(1);
 const AGED_BACKGROUND_CACHE_TTL: Duration = Duration::from_millis(250);
-type AgedBackgroundCache = BTreeMap<(PathBuf, u64, usize, usize), (Instant, bool)>;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct AgedBackgroundCacheKey {
+    root: PathBuf,
+    threshold_ms: u64,
+    interactive_pool: String,
+    candidate_start: usize,
+    candidate_end: usize,
+    disk_pressure_constrained: bool,
+    max_concurrent: usize,
+    reserved_interactive: usize,
+    watch_max_concurrent: usize,
+    heavy_capacity: usize,
+    io_heavy_capacity: usize,
+}
+type AgedBackgroundCache = BTreeMap<AgedBackgroundCacheKey, (Instant, bool)>;
 static DISK_PRESSURE_CACHE: OnceLock<Mutex<BTreeMap<PathBuf, (Instant, bool)>>> = OnceLock::new();
 static AGED_BACKGROUND_CACHE: OnceLock<Mutex<AgedBackgroundCache>> = OnceLock::new();
 
@@ -37,7 +51,7 @@ fn invalidate_aged_background_cache(root: &Path) {
     cache
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .retain(|(cached_root, _, _, _), _| cached_root != root);
+        .retain(|key, _| key.root != root);
 }
 #[cfg(windows)]
 const WINDOWS_SLOT_IO_RETRY_ATTEMPTS: usize = 100;
@@ -1154,15 +1168,23 @@ async fn aged_background_waiter_competes(
     interactive_plan: &AcquirePlan,
     threshold: Duration,
 ) -> Result<bool> {
+    let normalized = config.clone().normalized();
     let threshold_ms = duration_ms(threshold);
     let candidate_start = interactive_plan.protected_low_slots;
     let candidate_end = interactive_plan.usable_slots;
-    let key = (
-        config.root.clone(),
+    let key = AgedBackgroundCacheKey {
+        root: normalized.root.clone(),
         threshold_ms,
+        interactive_pool: interactive_plan.pool.clone(),
         candidate_start,
         candidate_end,
-    );
+        disk_pressure_constrained: interactive_plan.disk_pressure_constrained,
+        max_concurrent: normalized.max_concurrent,
+        reserved_interactive: normalized.reserved_interactive,
+        watch_max_concurrent: normalized.watch_max_concurrent,
+        heavy_capacity: normalized.heavy_capacity,
+        io_heavy_capacity: normalized.io_heavy_capacity,
+    };
     let cache = AGED_BACKGROUND_CACHE.get_or_init(|| Mutex::new(BTreeMap::new()));
     {
         let values = cache
@@ -1175,7 +1197,7 @@ async fn aged_background_waiter_competes(
         }
     }
     let result =
-        aged_background_waiter_competes_uncached(config, interactive_plan, threshold).await?;
+        aged_background_waiter_competes_uncached(&normalized, interactive_plan, threshold).await?;
     cache
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1251,12 +1273,14 @@ async fn aged_background_waiter_competes_uncached(
             &background_request,
             interactive_plan.disk_pressure_constrained,
         );
-        if slot_ranges_overlap(
-            interactive_plan.protected_low_slots,
-            interactive_plan.usable_slots,
-            background_plan.protected_low_slots,
-            background_plan.usable_slots,
-        ) {
+        if background_plan.pool == interactive_plan.pool
+            && slot_ranges_overlap(
+                interactive_plan.protected_low_slots,
+                interactive_plan.usable_slots,
+                background_plan.protected_low_slots,
+                background_plan.usable_slots,
+            )
+        {
             return Ok(true);
         }
     }
@@ -2187,6 +2211,100 @@ mod tests {
             "warning pressure should serialize heavy claims"
         );
         first.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn aged_background_cache_is_scoped_to_capacity_configuration() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(".disk-pressure.json"),
+            br#"{"diskPressure":"warning"}"#,
+        )
+        .await
+        .unwrap();
+        let narrow = SchedulerConfig {
+            root: temp.path().to_path_buf(),
+            max_concurrent: 4,
+            reserved_interactive: 1,
+            watch_max_concurrent: 1,
+            queue_timeout: Duration::from_secs(2),
+            heavy_capacity: 2,
+            heavy_weight: 2,
+            io_heavy_capacity: 2,
+            io_heavy_weight: 2,
+            background_priority_age: Duration::from_millis(1),
+        }
+        .normalized();
+        let wide = SchedulerConfig {
+            heavy_capacity: 3,
+            ..narrow.clone()
+        }
+        .normalized();
+        let background_request =
+            AcquireRequest::background("capacity-cache-fixture", ResourceClass::Heavy, 3);
+        let mut ticket = create_queue_ticket(
+            &narrow.root,
+            "execution-background",
+            &background_request,
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        let interactive = AcquireRequest::interactive("capacity-cache-interactive");
+        let narrow_plan = AcquirePlan::new(&narrow, &interactive, true);
+        let wide_plan = AcquirePlan::new(&wide, &interactive, true);
+        assert_eq!(narrow_plan.protected_low_slots, 2);
+        assert_eq!(wide_plan.protected_low_slots, 2);
+        assert!(
+            !aged_background_waiter_competes(&narrow, &narrow_plan, Duration::from_millis(1),)
+                .await
+                .unwrap()
+        );
+        assert!(
+            aged_background_waiter_competes(&wide, &wide_plan, Duration::from_millis(1),)
+                .await
+                .unwrap()
+        );
+        ticket.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn aged_background_from_different_pool_does_not_block_interactive_execution() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = SchedulerConfig {
+            root: temp.path().to_path_buf(),
+            max_concurrent: 4,
+            reserved_interactive: 1,
+            watch_max_concurrent: 2,
+            queue_timeout: Duration::from_secs(2),
+            heavy_capacity: 4,
+            heavy_weight: 2,
+            io_heavy_capacity: 2,
+            io_heavy_weight: 2,
+            background_priority_age: Duration::from_millis(1),
+        }
+        .normalized();
+        let malformed_watch =
+            AcquireRequest::background("legacy-watch-fixture", ResourceClass::Watch, 1);
+        let mut ticket = create_queue_ticket(
+            &config.root,
+            "execution-background",
+            &malformed_watch,
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        let interactive = AcquireRequest::interactive("execution-interactive");
+        let plan = AcquirePlan::new(&config, &interactive, false);
+        assert_eq!(plan.pool, "execution");
+        assert!(
+            !aged_background_waiter_competes(&config, &plan, Duration::from_millis(1),)
+                .await
+                .unwrap()
+        );
+        ticket.release().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/execution-slots.js
+++ b/src/execution-slots.js
@@ -19,7 +19,7 @@ const DISK_PRESSURE_STATE_STALE_MS = 180_000;
 const DISK_PRESSURE_CACHE_MS = 1_000;
 const AGED_BACKGROUND_CACHE_MS = 250;
 let diskPressureCache = { sampledAtMs: 0, constrained: false };
-let agedBackgroundCache = { sampledAtMs: 0, thresholdMs: 0, result: false };
+let agedBackgroundCache = { sampledAtMs: 0, thresholdMs: 0, planKey: "", result: false };
 
 const metrics = {
   queued: 0,
@@ -437,11 +437,27 @@ const acquirePoolClaimLock = async (pool, { signal, deadlineMs }) => {
   return null;
 };
 
-const agedBackgroundWaiterExists = async (thresholdMs) => {
+const rangesOverlap = (firstStart, firstEnd, secondStart, secondEnd) =>
+  firstStart < secondEnd && secondStart < firstEnd;
+
+const agedBackgroundWaiterCompetes = async (thresholdMs, {
+  total,
+  reserved,
+  normalizedHeavyCapacity,
+  normalizedIoHeavyCapacity,
+  pressureConstrained,
+  interactiveStart,
+  interactiveEnd,
+}) => {
   const boundedThreshold = Math.max(1, Number(thresholdMs) || 30_000);
+  const planKey = [
+    total, reserved, normalizedHeavyCapacity, normalizedIoHeavyCapacity,
+    pressureConstrained ? 1 : 0, interactiveStart, interactiveEnd,
+  ].join(":");
   const now = Date.now();
   if (
     agedBackgroundCache.thresholdMs === boundedThreshold &&
+    agedBackgroundCache.planKey === planKey &&
     now - agedBackgroundCache.sampledAtMs < AGED_BACKGROUND_CACHE_MS
   ) return agedBackgroundCache.result;
 
@@ -451,12 +467,32 @@ const agedBackgroundWaiterExists = async (thresholdMs) => {
     const owner = await readFile(path.join(queueRoot, name), "utf8").then(JSON.parse).catch(() => null);
     if (!owner || await ticketShouldReap(name, owner)) continue;
     const queuedAt = Number(owner.queuedAtUnixMs);
-    if (Number.isFinite(queuedAt) && now - queuedAt >= boundedThreshold) {
+    if (!Number.isFinite(queuedAt) || now - queuedAt < boundedThreshold) continue;
+
+    const ownerClass = normalizeResourceClass(owner.resourceClass);
+    const ownerWeight = Math.max(1, Number(owner.weight) || 1);
+    const backgroundBase = Math.max(1, total - reserved);
+    let backgroundUsable = backgroundBase;
+    if (ownerClass === "heavy") {
+      const capacity = pressureConstrained
+        ? Math.min(normalizedHeavyCapacity, ownerWeight)
+        : normalizedHeavyCapacity;
+      backgroundUsable = Math.min(backgroundBase, Math.max(ownerWeight, capacity));
+    } else if (ownerClass === "io-heavy") {
+      const capacity = pressureConstrained
+        ? Math.min(normalizedIoHeavyCapacity, ownerWeight)
+        : normalizedIoHeavyCapacity;
+      backgroundUsable = Math.min(backgroundBase, Math.max(ownerWeight, capacity));
+    }
+
+    if (rangesOverlap(interactiveStart, interactiveEnd, 0, backgroundUsable)) {
       result = true;
       break;
     }
   }
-  agedBackgroundCache = { sampledAtMs: now, thresholdMs: boundedThreshold, result };
+  agedBackgroundCache = {
+    sampledAtMs: now, thresholdMs: boundedThreshold, planKey, result,
+  };
   return result;
 };
 
@@ -546,7 +582,15 @@ export const acquireExecutionSlot = async ({
         await sleep(Math.min(pollInterval(elapsed), timeoutMs - elapsed));
         continue;
       }
-      if (kind === "interactive" && await agedBackgroundWaiterExists(backgroundPriorityAgeMs)) {
+      if (kind === "interactive" && await agedBackgroundWaiterCompetes(backgroundPriorityAgeMs, {
+        total,
+        reserved,
+        normalizedHeavyCapacity,
+        normalizedIoHeavyCapacity,
+        pressureConstrained,
+        interactiveStart: protectedLowSlots,
+        interactiveEnd: usableSlots,
+      })) {
         const elapsed = Date.now() - queuedAt;
         if (elapsed >= timeoutMs) {
           metrics.timedOut += 1;

--- a/src/execution-slots.js
+++ b/src/execution-slots.js
@@ -446,13 +446,14 @@ const agedBackgroundWaiterCompetes = async (thresholdMs, {
   normalizedHeavyCapacity,
   normalizedIoHeavyCapacity,
   pressureConstrained,
+  interactivePool,
   interactiveStart,
   interactiveEnd,
 }) => {
   const boundedThreshold = Math.max(1, Number(thresholdMs) || 30_000);
   const planKey = [
     total, reserved, normalizedHeavyCapacity, normalizedIoHeavyCapacity,
-    pressureConstrained ? 1 : 0, interactiveStart, interactiveEnd,
+    pressureConstrained ? 1 : 0, interactivePool, interactiveStart, interactiveEnd,
   ].join(":");
   const now = Date.now();
   if (
@@ -470,6 +471,8 @@ const agedBackgroundWaiterCompetes = async (thresholdMs, {
     if (!Number.isFinite(queuedAt) || now - queuedAt < boundedThreshold) continue;
 
     const ownerClass = normalizeResourceClass(owner.resourceClass);
+    const backgroundPool = poolFor({ kind: "background", resourceClass: ownerClass });
+    if (backgroundPool !== interactivePool) continue;
     const ownerWeight = Math.max(1, Number(owner.weight) || 1);
     const backgroundBase = Math.max(1, total - reserved);
     let backgroundUsable = backgroundBase;
@@ -588,6 +591,7 @@ export const acquireExecutionSlot = async ({
         normalizedHeavyCapacity,
         normalizedIoHeavyCapacity,
         pressureConstrained,
+        interactivePool: pool,
         interactiveStart: protectedLowSlots,
         interactiveEnd: usableSlots,
       })) {

--- a/test/execution-slots.test.js
+++ b/test/execution-slots.test.js
@@ -278,6 +278,48 @@ test("shared FIFO prevents a later light job from overtaking an earlier heavy wa
 
 
 
+test("aged background ticket from another pool does not block interactive execution", async () => {
+  const { acquireExecutionSlot, testSlotRoot } = await importIsolatedSlots();
+  const queueRoot = path.join(testSlotRoot, "queue");
+  await mkdir(queueRoot, { recursive: true });
+  const queueClass = "execution-background";
+  const sequence = BigInt(Date.now()) * 1_000_000n;
+  const name = `${queueClass}-${sequence.toString().padStart(32, "0")}-watchfixture.json`;
+  const ticketPath = path.join(queueRoot, name);
+  await writeFile(ticketPath, `${JSON.stringify({
+    token: "watchfixture",
+    pid: process.pid,
+    processInstance: await currentProcessInstance(),
+    class: queueClass,
+    kind: "background",
+    resourceClass: "watch",
+    weight: 1,
+    label: "legacy-watch-fixture",
+    sequence: sequence.toString(),
+    queuedAtUnixMs: 1,
+    queuedAtUtc: new Date(1).toISOString(),
+    queueTimeoutMs: 600_000,
+  })}
+`, "utf8");
+  let lease = null;
+  try {
+    lease = await acquireExecutionSlot({
+      kind: "interactive",
+      resourceClass: "light",
+      maxConcurrent: 4,
+      reservedInteractive: 1,
+      watchMaxConcurrent: 2,
+      backgroundPriorityAgeMs: 1,
+      queueTimeoutMs: 500,
+      label: "execution-interactive-with-watch-fixture",
+    });
+    assert.equal(lease.pool, "execution");
+  } finally {
+    await lease?.release().catch(() => {});
+    await rm(ticketPath, { force: true });
+  }
+});
+
 test("disk pressure light interactive bypasses a non-overlapping aged heavy background waiter", async () => {
   const { acquireExecutionSlot, testSlotRoot } = await importIsolatedSlots();
   await writeFile(path.join(testSlotRoot, ".disk-pressure.json"), JSON.stringify({ diskPressure: "warning" }));

--- a/test/execution-slots.test.js
+++ b/test/execution-slots.test.js
@@ -278,6 +278,60 @@ test("shared FIFO prevents a later light job from overtaking an earlier heavy wa
 
 
 
+test("disk pressure light interactive bypasses a non-overlapping aged heavy background waiter", async () => {
+  const { acquireExecutionSlot, testSlotRoot } = await importIsolatedSlots();
+  await writeFile(path.join(testSlotRoot, ".disk-pressure.json"), JSON.stringify({ diskPressure: "warning" }));
+  const common = {
+    maxConcurrent: 4,
+    reservedInteractive: 1,
+    heavyCapacity: 4,
+    heavyWeight: 2,
+    ioHeavyCapacity: 2,
+    ioHeavyWeight: 2,
+    backgroundPriorityAgeMs: 1,
+    queueTimeoutMs: 2000,
+  };
+  const first = await acquireExecutionSlot({
+    ...common,
+    kind: "interactive",
+    resourceClass: "heavy",
+    weight: 2,
+    label: "pressure-aging-holder",
+  });
+  let background = null;
+  let light = null;
+  try {
+    const backgroundPromise = acquireExecutionSlot({
+      ...common,
+      kind: "background",
+      resourceClass: "heavy",
+      weight: 2,
+      label: "pressure-aged-heavy-background",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const started = performance.now();
+    light = await acquireExecutionSlot({
+      ...common,
+      kind: "interactive",
+      resourceClass: "light",
+      weight: 1,
+      queueTimeoutMs: 500,
+      label: "pressure-light-after-aged-heavy",
+    });
+    assert.ok(performance.now() - started < 400, "light request yielded to non-overlapping aged heavy waiter");
+    assert.ok(light.slot >= 2, `light request stole weighted corridor slot ${light.slot}`);
+    await light.release();
+    light = null;
+    await first.release();
+    background = await backgroundPromise;
+    assert.deepEqual(background.slots, [0, 1]);
+  } finally {
+    await light?.release().catch(() => {});
+    await background?.release().catch(() => {});
+    await first.release().catch(() => {});
+  }
+});
+
 test("aged background waiter gets a bounded priority turn ahead of new interactive work", async () => {
   const { acquireExecutionSlot } = await importIsolatedSlots();
   const blocker = await acquireExecutionSlot({


### PR DESCRIPTION
Fixes the production regression where aged heavy background waiters could block unrelated light interactive work even when disk-pressure slot corridors did not overlap.

Changes:
- make aged-background fairness overlap-aware in Rust and JS
- preserve anti-starvation when candidate slot ranges actually overlap
- add production-regression coverage for pressure-constrained heavy background vs light interactive work

Validated locally:
- JS execution-slot tests: 9/9
- Rust focused aging tests: 2/2
- Rust full suite: 166/166
- strict Clippy: clean
- Rust 1.88 MSRV: clean
- Windows contention: 74 health probes, max 7.11 ms, status 5.26 ms
- 37-tool schema parity: 0 differences across four profiles
- result parity: 41 calls, 0 differences
- config/gateway/OAuth/Cloudflare/disconnect/SDK smokes: green

The detached local npm MCP suite's five GUI capture tests cannot create WinForms windows from the non-interactive service runner; all 161 unit tests passed and hosted native Windows CI remains the merge gate for GUI/lifecycle coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution scheduling so interactive requests can proceed past aged background work when their resource capacity ranges do not overlap.
  * Preserved protection for competing interactive workloads, including under disk-pressure conditions.
  * Updated scheduling decisions to account for current capacity, reservations, resource class, and workload weight.

* **Tests**
  * Added regression coverage for non-overlapping interactive and background workloads, including slot acquisition and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->