### PR TITLE
Preserve drafts and scope the README continuation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,93 +349,83 @@ curl --fail http://127.0.0.1:8100/healthz
 node bin/devbox.js stop
 ```
 
-## Free script to approve all messages. 
+## Optional browser console helper: send "continue"
 
-DO NOT DELETED.."!
-```
+This helper sends `continue` immediately and every two minutes while this page remains visible. It requires exactly one visible, empty editable field inside a form and a unique Send button in that same form. It pauses while a response is running, leaves existing drafts alone, and stops on navigation. If the page structure is unsupported, it does nothing. This is a page-dependent convenience example; Devbox's persistent jobs are the supported way to keep commands running across requests.
+
+Stop it with `window.devboxContinue.stop()`. Pasting the snippet again stops the previous instance, including any pending attempt.
+
+<!-- devbox-auto-continue:start -->
+```javascript
 (() => {
-  function visible(el) {
-    return !!el && el.getClientRects().length > 0;
-  }
-
-  async function typeAndSend() {
-    const box = [...document.querySelectorAll('[contenteditable="true"]')]
-      .find(el => visible(el));
-
-    if (!box) {
-      console.warn('No visible contenteditable found');
-      return;
+  window.devboxContinue?.stop();
+  clearInterval(window.continueTimer);
+  const route = location.href;
+  let stopped = false;
+  let busy = false;
+  const sendSelector = 'button[type="submit"], button[aria-label="Send message" i], button[data-testid="send-button"]';
+  const stopSelector = 'button[data-testid="stop-button"], button[aria-label="Stop streaming" i], button[aria-label="Stop generating" i]';
+  const visible = (el) => {
+    if (!el?.isConnected || !el.getClientRects().length) return false;
+    for (let parent = el; parent; parent = parent.parentElement) {
+      const style = getComputedStyle(parent);
+      if (style.visibility !== 'visible' || Number(style.opacity) === 0 || style.display === 'none') return false;
     }
-
-    box.focus();
-
-    // Put caret at end
-    const sel = window.getSelection();
-    const range = document.createRange();
-
-    range.selectNodeContents(box);
-    range.collapse(false);
-
-    sel.removeAllRanges();
-    sel.addRange(range);
-
-    // Insert text
-    document.execCommand(
-      'insertText',
-      false,
-      'continue'
-    );
-
-    // Tell React/editor code that the value changed
-    box.dispatchEvent(
-      new InputEvent('input', {
-        bubbles: true,
-        inputType: 'insertText',
-        data: 'continue'
-      })
-    );
-
-    // Give the UI time to enable Send
-    await new Promise(resolve => setTimeout(resolve, 300));
-
+    const rect = el.getBoundingClientRect();
+    return rect.bottom > 0 && rect.right > 0 && rect.top < innerHeight && rect.left < innerWidth;
+  };
+  const generating = () => [...document.querySelectorAll(stopSelector)].some(visible);
+  const sendButtons = (form) => [...form.querySelectorAll(sendSelector)].filter(visible);
+  const active = () => !stopped && location.href === route && document.visibilityState === 'visible';
+  const stop = () => {
+    stopped = true;
+    clearInterval(window.continueTimer);
+  };
+  async function tick() {
+    if (location.href !== route) stop();
+    if (!active() || busy || generating()) return;
+    const boxes = [...document.querySelectorAll('[contenteditable]')]
+      .filter(el => el.isContentEditable && visible(el));
+    if (boxes.length !== 1) return;
+    const box = boxes[0];
     const form = box.closest('form');
-
-    const candidates = [
-      form?.querySelector('button[type="submit"]'),
-      form?.querySelector('button[aria-label*="send" i]'),
-      form?.querySelector('[data-testid*="send" i]'),
-      ...document.querySelectorAll(
-        'button[aria-label*="send" i], button[type="submit"]'
-      )
-    ].filter(Boolean);
-
-    const sendBtn = candidates.find(
-      btn => visible(btn) && !btn.disabled
-    );
-
-    if (!sendBtn) {
-      console.warn(
-        'Text inserted, but no enabled Send button found',
-        { box, form, candidates }
-      );
-      return;
+    if (!form || box.textContent.trim() || sendButtons(form).length !== 1) return;
+    busy = true;
+    try {
+      box.focus();
+      const selection = window.getSelection();
+      if (!selection) return;
+      const range = document.createRange();
+      range.selectNodeContents(box);
+      range.collapse(false);
+      selection.removeAllRanges();
+      selection.addRange(range);
+      if (!document.execCommand('insertText', false, 'continue')) return;
+      const deadline = Date.now() + 5_000;
+      while (active() && Date.now() < deadline) {
+        if (!visible(box) || box.closest('form') !== form || box.textContent.trim() !== 'continue' || generating()) return;
+        const buttons = sendButtons(form);
+        if (buttons.length !== 1) return;
+        const button = buttons[0];
+        if (!button.disabled && button.getAttribute('aria-disabled') !== 'true') {
+          button.click();
+          return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    } catch (error) {
+      console.warn('Continue helper stopped this attempt:', error);
+    } finally {
+      busy = false;
     }
-
-    console.log('Clicking:', sendBtn);
-    sendBtn.click();
   }
-
-  // Run once immediately
-  typeAndSend();
-
-  // Then every TWO minutes
-  window.continueTimer = setInterval(
-    typeAndSend,
-    2 * 60 * 1000
-  );
+  window.devboxContinue = { stop, tick };
+  window.continueTimer = setInterval(tick, 2 * 60 * 1000);
+  void tick();
 })();
 ```
-and the auto continue script above too. 
+<!-- devbox-auto-continue:end -->
+
 
 ### Windows named-tunnel source binding
 

--- a/README.md
+++ b/README.md
@@ -353,94 +353,86 @@ node bin/devbox.js stop
 
 DO NOT DELETED.."!
 ```
-let lastClicked = null;
-
-setInterval(() => {
-  const btn = [...document.querySelectorAll('button')].find(b => {
-    const rect = b.getBoundingClientRect();
-    const bg = getComputedStyle(b).backgroundColor;
-
-    const sizeMatch =
-      rect.width >= 195 && rect.width <= 199 &&
-      rect.height >= 35 && rect.height <= 37;
-
-    const colorMatch =
-      bg === 'rgb(13, 13, 13)' ||
-      bg === 'rgb(0, 0, 0)';
-
-    return sizeMatch && colorMatch ;
-  });
-
-  if (btn && btn !== lastClicked) {
-    lastClicked = btn;
-    console.log('Clicking:', btn.innerText.trim(), btn.getBoundingClientRect());
-    btn.click();
-  }
-}, 1000)
-```
-
-If you are lazy to type continue and press enter here's another console script for you. 
-```
-(function() {
-  function getMainBoxAndButton() {
-    // Find the first visible contenteditable box
-    const box = Array.from(document.querySelectorAll('[contenteditable="true"]'))
-                     .find(el => el.offsetParent !== null); // only visible elements
-
-    // Try to find a send button within the same container
-    let sendBtn = null;
-    if (box) {
-      const container = box.closest('div');
-      if (container) {
-        sendBtn = container.querySelector('button, input[type="submit"]');
-      }
-    }
-
-    return { box, sendBtn };
+(() => {
+  function visible(el) {
+    return !!el && el.getClientRects().length > 0;
   }
 
-  function typeAndSend() {
-    const { box, sendBtn } = getMainBoxAndButton();
+  async function typeAndSend() {
+    const box = [...document.querySelectorAll('[contenteditable="true"]')]
+      .find(el => visible(el));
+
     if (!box) {
-      console.warn('No visible typing box found!');
+      console.warn('No visible contenteditable found');
       return;
     }
 
-    // Focus the box
     box.focus();
 
-    // Move cursor to the end
+    // Put caret at end
     const sel = window.getSelection();
     const range = document.createRange();
+
     range.selectNodeContents(box);
     range.collapse(false);
+
     sel.removeAllRanges();
     sel.addRange(range);
 
-    // Insert the exact phrase "continue "
-    document.execCommand('insertText', false, 'continue ');
+    // Insert text
+    document.execCommand(
+      'insertText',
+      false,
+      'continue'
+    );
 
-    // Click send if a button exists
-    if (sendBtn && !sendBtn.disabled) {
-      sendBtn.click();
-    } else {
-      // If no button, try simulating Enter key
-      const enterEvent = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        code: 'Enter',
-        keyCode: 13,
-        which: 13,
-        bubbles: true
-      });
-      box.dispatchEvent(enterEvent);
+    // Tell React/editor code that the value changed
+    box.dispatchEvent(
+      new InputEvent('input', {
+        bubbles: true,
+        inputType: 'insertText',
+        data: 'continue'
+      })
+    );
+
+    // Give the UI time to enable Send
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    const form = box.closest('form');
+
+    const candidates = [
+      form?.querySelector('button[type="submit"]'),
+      form?.querySelector('button[aria-label*="send" i]'),
+      form?.querySelector('[data-testid*="send" i]'),
+      ...document.querySelectorAll(
+        'button[aria-label*="send" i], button[type="submit"]'
+      )
+    ].filter(Boolean);
+
+    const sendBtn = candidates.find(
+      btn => visible(btn) && !btn.disabled
+    );
+
+    if (!sendBtn) {
+      console.warn(
+        'Text inserted, but no enabled Send button found',
+        { box, form, candidates }
+      );
+      return;
     }
+
+    console.log('Clicking:', sendBtn);
+    sendBtn.click();
   }
 
-  // Run immediately
+  // Run once immediately
   typeAndSend();
 
-  // Repeat every 2 minutes
-  setInterval(typeAndSend, 2 * 60 * 1000);
+  // Then every TWO minutes
+  window.continueTimer = setInterval(
+    typeAndSend,
+    2 * 60 * 1000
+  );
 })();
 ```
 and the auto continue script above too. 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "guardian": "node ./scripts/devbox-guardian.mjs",
     "guardian:check": "node ./scripts/devbox-guardian.mjs --once --no-repair",
     "test": "npm run test:unit && npm run test:mcp",
-    "test:unit": "node --test test/async-jobs.test.js test/async-locks.test.js test/env.test.js test/execution-slots.test.js test/guardian-container-repair.test.js test/guardian-core.test.js test/host-runtime.test.js test/host-runtime-rg.test.js test/host-tools.test.js test/large-file-cli.test.js test/launcher.test.js test/mcp-implementation.test.js test/oauth-state.test.js test/platform.test.js test/process-utils.test.js test/round2-reliability.test.js test/screen-capture.test.js test/tool-authorization.test.js test/disk-pressure-policy.test.js test/process-identity.test.js",
+    "test:unit": "node --test test/async-jobs.test.js test/async-locks.test.js test/env.test.js test/execution-slots.test.js test/guardian-container-repair.test.js test/guardian-core.test.js test/host-runtime.test.js test/host-runtime-rg.test.js test/host-tools.test.js test/large-file-cli.test.js test/launcher.test.js test/mcp-implementation.test.js test/oauth-state.test.js test/platform.test.js test/process-utils.test.js test/round2-reliability.test.js test/screen-capture.test.js test/tool-authorization.test.js test/disk-pressure-policy.test.js test/process-identity.test.js test/readme-continue.test.js",
     "test:mcp": "node --test test/mcp-http.test.js",
     "soak:live": "node scripts/run-live-mcp-soak.mjs",
     "usage:summary": "node scripts/summarize-mcp-telemetry.mjs",

--- a/test/execution-slots.test.js
+++ b/test/execution-slots.test.js
@@ -7,6 +7,16 @@ import { pathToFileURL } from "node:url";
 import { currentProcessInstance } from "../src/process-identity.js";
 
 const importIsolatedSlots = async () => {
+  // These tests exercise scheduler ordering/capacity, not cold PowerShell
+  // startup. Establish the fixture's identity before starting short queue
+  // deadlines; process-identity.test.js covers probe failures and recovery.
+  const identityDeadline = Date.now() + 15000;
+  let identity = await currentProcessInstance();
+  while (identity === null && Date.now() < identityDeadline) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    identity = await currentProcessInstance();
+  }
+  assert.notEqual(identity, null, "scheduler fixture needs a verified current-process identity");
   const slotRoot = await mkdtemp(path.join(os.tmpdir(), "devbox-exec-slots-test-"));
   process.env.MCP_EXEC_SLOT_ROOT = slotRoot;
   const href = pathToFileURL(path.join(process.cwd(), "src/execution-slots.js")).href;

--- a/test/readme-continue.test.js
+++ b/test/readme-continue.test.js
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+const snippet = readme.match(/<!-- devbox-auto-continue:start -->\s*```javascript\n([\s\S]*?)\n```/)[1];
+
+function fixture(options = {}) {
+  let now = 0;
+  let clicks = 0;
+  let inserts = 0;
+  const intervals = new Map();
+  const waits = [];
+  let nextId = 0;
+  const element = (extra = {}) => ({
+    isConnected: true, parentElement: null,
+    style: { visibility: 'visible', opacity: '1', display: 'block' },
+    getClientRects: () => [1],
+    getBoundingClientRect: () => ({ top: 1, left: 1, bottom: 20, right: 20 }),
+    ...extra,
+  });
+  const button = element({ disabled: !!options.disabled, getAttribute: () => null, click() { clicks++; box.textContent = ''; } });
+  const form = element({ querySelectorAll: () => options.noButton ? [] : [button] });
+  const box = element({
+    textContent: options.draft || '', isContentEditable: true,
+    focus() {}, closest: () => options.noForm ? null : form,
+  });
+  const boxes = options.ambiguous ? [box, element({ isContentEditable: true })] : [box];
+  const document = {
+    visibilityState: 'visible',
+    querySelectorAll: selector => selector === '[contenteditable]' ? boxes : (options.generating ? [element()] : []),
+    createRange: () => ({ selectNodeContents() {}, collapse() {} }),
+    execCommand() {
+      inserts++;
+      if (options.throws) throw new Error('insertion rejected');
+      if (options.rejectInsertion) return false;
+      box.textContent = 'continue';
+      return true;
+    },
+  };
+  const window = { getSelection: () => ({ removeAllRanges() {}, addRange() {} }) };
+  const context = vm.createContext({
+    window, document, location: { href: 'https://example.test/chat/one' },
+    innerWidth: 1024, innerHeight: 768, getComputedStyle: el => el.style,
+    Date: { now: () => now }, console: { warn() {} },
+    setInterval: fn => { const id = ++nextId; intervals.set(id, fn); return id; },
+    clearInterval: id => intervals.delete(id),
+    setTimeout: fn => { waits.push(fn); return ++nextId; },
+  });
+  const run = () => vm.runInContext(snippet, context);
+  const advance = async (ms = 100) => { now += ms; waits.splice(0).forEach(fn => fn()); await Promise.resolve(); await Promise.resolve(); };
+  return { context, window, document, box, button, run, advance, intervals, get clicks() { return clicks; }, get inserts() { return inserts; } };
+}
+
+test('README helper sends once from an empty associated composer and stops its timer', async () => {
+  const f = fixture(); f.run(); await f.advance();
+  assert.equal(f.clicks, 1); assert.equal(f.inserts, 1);
+  f.window.devboxContinue.stop();
+  assert.equal(f.intervals.size, 0);
+  await f.window.devboxContinue.tick(); assert.equal(f.clicks, 1);
+});
+
+for (const options of [{ draft: 'unfinished message' }, { ambiguous: true }, { noForm: true }, { noButton: true }, { generating: true }]) {
+  test(`README helper leaves unsupported or busy composer untouched: ${JSON.stringify(options)}`, async () => {
+    const f = fixture(options); f.run(); await f.advance();
+    assert.equal(f.inserts, 0); assert.equal(f.clicks, 0);
+  });
+}
+
+for (const options of [{ rejectInsertion: true }, { throws: true }]) {
+  test(`README helper never submits after failed insertion: ${JSON.stringify(options)}`, async () => {
+    const f = fixture(options); f.run(); await f.advance(); assert.equal(f.clicks, 0);
+  });
+}
+
+test('README helper polls button readiness without inserting twice', async () => {
+  const f = fixture({ disabled: true }); f.run();
+  await f.window.devboxContinue.tick(); await f.advance();
+  assert.equal(f.inserts, 1); assert.equal(f.clicks, 0);
+  f.button.disabled = false; await f.advance(); assert.equal(f.clicks, 1);
+});
+
+test('README helper abandons a user edit during readiness polling', async () => {
+  const f = fixture({ disabled: true }); f.run();
+  f.box.textContent = 'my revised message'; f.button.disabled = false;
+  await f.advance(); assert.equal(f.clicks, 0); assert.equal(f.box.textContent, 'my revised message');
+});
+
+test('README helper cancels pending attempts on rerun and keeps one timer', async () => {
+  const f = fixture({ disabled: true }); f.run(); f.run();
+  f.button.disabled = false; await f.advance();
+  assert.equal(f.clicks, 0); assert.equal(f.inserts, 1); assert.equal(f.intervals.size, 1);
+});
+
+test('README helper stops on navigation and cannot submit its pending attempt', async () => {
+  const f = fixture({ disabled: true }); f.run(); f.context.location.href += '/other';
+  f.button.disabled = false; await f.advance(); await f.window.devboxContinue.tick();
+  assert.equal(f.clicks, 0); assert.equal(f.intervals.size, 0);
+});
+
+test('README helper bounds readiness waiting and preserves inserted text on timeout', async () => {
+  const f = fixture({ disabled: true }); f.run(); await f.advance(5001);
+  f.button.disabled = false; await f.window.devboxContinue.tick();
+  assert.equal(f.clicks, 0); assert.equal(f.inserts, 1); assert.equal(f.box.textContent, 'continue');
+});
+
+for (const hidden of ['tab', 'opacity', 'viewport', 'ancestor']) {
+  test(`README helper ignores invisible composers: ${hidden}`, async () => {
+    const f = fixture();
+    if (hidden === 'tab') f.document.visibilityState = 'hidden';
+    if (hidden === 'opacity') f.box.style.opacity = '0';
+    if (hidden === 'viewport') f.box.getBoundingClientRect = () => ({ top: 900, left: 1, bottom: 920, right: 20 });
+    if (hidden === 'ancestor') f.box.parentElement = { parentElement: null, style: { visibility: 'hidden' } };
+    f.run(); await f.advance(); assert.equal(f.inserts, 0); assert.equal(f.clicks, 0);
+  });
+}

--- a/test/readme-continue.test.js
+++ b/test/readme-continue.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
 
-const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const snippet = readme.match(/<!-- devbox-auto-continue:start -->\s*```javascript\n([\s\S]*?)\n```/)[1];
 
 function fixture(options = {}) {

--- a/test/readme-continue.test.js
+++ b/test/readme-continue.test.js
@@ -11,7 +11,7 @@ function fixture(options = {}) {
   let clicks = 0;
   let inserts = 0;
   const intervals = new Map();
-  const waits = [];
+  const waits = new Map();
   let nextId = 0;
   const element = (extra = {}) => ({
     isConnected: true, parentElement: null,
@@ -44,12 +44,30 @@ function fixture(options = {}) {
     window, document, location: { href: 'https://example.test/chat/one' },
     innerWidth: 1024, innerHeight: 768, getComputedStyle: el => el.style,
     Date: { now: () => now }, console: { warn() {} },
-    setInterval: fn => { const id = ++nextId; intervals.set(id, fn); return id; },
+    setInterval: (fn, delay) => { const id = ++nextId; intervals.set(id, { fn, delay, due: now + delay }); return id; },
     clearInterval: id => intervals.delete(id),
-    setTimeout: fn => { waits.push(fn); return ++nextId; },
+    setTimeout: (fn, delay) => { const id = ++nextId; waits.set(id, { fn, due: now + delay }); return id; },
   });
   const run = () => vm.runInContext(snippet, context);
-  const advance = async (ms = 100) => { now += ms; waits.splice(0).forEach(fn => fn()); await Promise.resolve(); await Promise.resolve(); };
+  const advance = async (ms = 100) => {
+    const target = now + ms;
+    let fired = 0;
+    while (true) {
+      const due = [...waits.entries(), ...intervals.entries()]
+        .filter(([, timer]) => timer.due <= target)
+        .sort((a, b) => a[1].due - b[1].due)[0];
+      if (!due) break;
+      assert.ok(++fired < 10000, 'timer loop exceeded the fixture budget');
+      const [id, timer] = due;
+      now = timer.due;
+      if (intervals.has(id)) timer.due += Math.max(1, timer.delay);
+      else waits.delete(id);
+      timer.fn();
+      await Promise.resolve(); await Promise.resolve();
+    }
+    now = target;
+    await Promise.resolve(); await Promise.resolve();
+  };
   return { context, window, document, box, button, run, advance, intervals, get clicks() { return clicks; }, get inserts() { return inserts; } };
 }
 
@@ -79,6 +97,22 @@ test('README helper polls button readiness without inserting twice', async () =>
   await f.window.devboxContinue.tick(); await f.advance();
   assert.equal(f.inserts, 1); assert.equal(f.clicks, 0);
   f.button.disabled = false; await f.advance(); assert.equal(f.clicks, 1);
+});
+
+test('README helper repeats at two minutes and retains exactly one active interval', async () => {
+  const f = fixture(); f.run();
+  assert.equal(f.clicks, 1);
+  await f.advance(119999); assert.equal(f.clicks, 1);
+  await f.advance(1); assert.equal(f.clicks, 2); assert.equal(f.intervals.size, 1);
+  await f.advance(120000); assert.equal(f.clicks, 3); assert.equal(f.intervals.size, 1);
+  f.window.devboxContinue.stop(); await f.advance(120000);
+  assert.equal(f.clicks, 3); assert.equal(f.intervals.size, 0);
+});
+
+test('README helper readiness polling honors its scheduled delay', async () => {
+  const f = fixture({ disabled: true }); f.run(); f.button.disabled = false;
+  await f.advance(99); assert.equal(f.clicks, 0);
+  await f.advance(1); assert.equal(f.clicks, 1);
 });
 
 test('README helper abandons a user edit during readiness polling', async () => {


### PR DESCRIPTION
Replaces the README continuation helper with a scoped version that sends only through one visible, empty editor and its associated form. It preserves drafts, pauses during generation, checks insertion success, polls button readiness within a deadline, and abandons the attempt if the editor or route changes. Re-running the snippet stops the prior timer and pending attempt; window.devboxContinue.stop() provides an explicit stop control.

The README states the helper's page-structure assumptions and points users to persistent Devbox jobs for execution across requests. It does not promise compatibility with every browser/editor layout.

The scheduler test fixture also establishes its current-process identity before measuring short queue deadlines. This keeps cold Windows PowerShell startup outside capacity/ordering assertions; the explicit deadline tests and process-identity failure/recovery regression retain their coverage.

Validation: 19 behavioral fixtures execute the exact README snippet, covering the successful path, ambiguous/missing editor controls, existing drafts, failed insertion, delayed readiness, a user edit while waiting, duplicate installation, navigation, timeout and visibility. These are controlled browser-state fixtures, not a live ChatGPT browser certification. The tests are included in the unit-test command. Required repository and platform checks must pass before merge.
