### PR TITLE
Harden Rust agent recovery, bounded execution and production provenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,10 @@ MCP_JOB_RETENTION_HOURS=168
 # Global retained-job pressure limits; oldest terminal jobs are evicted toward a 90% low-water mark.
 MCP_JOB_STORE_MAX_BYTES=2147483648
 MCP_JOB_STORE_MAX_TERMINAL_JOBS=5000
+# Bound running AND queued runner processes; durable operation receipts are never silently evicted.
+MCP_JOB_MAX_ACTIVE_RUNNERS=16
+MCP_JOB_MAX_RUNNERS_PER_TASK=8
+MCP_JOB_MAX_OPERATION_RECEIPTS=10000
 # No-process wait ceiling and capture fail-fast policy.
 MCP_WAIT_MAX_SECONDS=300
 SCREEN_CAPTURE_ATTEMPT_TIMEOUT_MS=8000

--- a/.github/workflows/rust-mcp.yml
+++ b/.github/workflows/rust-mcp.yml
@@ -58,6 +58,7 @@ jobs:
           rustup toolchain install 1.91.1 --profile minimal --component rustfmt,clippy
           rustup default 1.91.1
       - name: Check JavaScript-to-Rust tool contract drift
+        shell: bash
         run: |
           node rust-mcp/scripts/check-contract-parity.mjs
           node scripts/check-runtime-contract.mjs

--- a/.github/workflows/rust-mcp.yml
+++ b/.github/workflows/rust-mcp.yml
@@ -58,7 +58,9 @@ jobs:
           rustup toolchain install 1.91.1 --profile minimal --component rustfmt,clippy
           rustup default 1.91.1
       - name: Check JavaScript-to-Rust tool contract drift
-        run: node rust-mcp/scripts/check-contract-parity.mjs
+        run: |
+          node rust-mcp/scripts/check-contract-parity.mjs
+          node scripts/check-runtime-contract.mjs
       - name: Check formatting
         run: cargo fmt --manifest-path rust-mcp/Cargo.toml -- --check
       - name: Run strict Clippy
@@ -82,6 +84,8 @@ jobs:
           ./scripts/ci/test-windows-managed-mcp-ownership.ps1
       - name: Build Rust MCP shadow binary
         run: cargo build --manifest-path rust-mcp/Cargo.toml --locked
+      - name: Verify native durable agent APIs and restart recovery
+        run: node rust-mcp/scripts/agent-reliability-smoke.mjs
       - name: Reproduce Windows watcher contention and hard-deadline contract
         if: runner.os == 'Windows'
         run: node rust-mcp/scripts/windows-contention-smoke-runner.mjs

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ See [bootstrap/README.md](./bootstrap/README.md) and [setup-tui/README.md](./set
 - `bootstrap/`: cross-platform Rust setup CLI and tests
 - `setup-tui/`: dependency-light C++17 interactive setup frontend
 - `bin/devbox.js`: installable `devbox` command
-- `src/server.js`: MCP server exposed over Streamable HTTP
+- `rust-mcp/`: production Rust MCP service, durable jobs, atomic checkpoints and native process control
+- `src/server.js`: retained legacy JavaScript compatibility implementation
 - `src/runtime.js`: runtime selector for Docker versus host mode
 - `src/docker-runtime.js`: Docker-backed runtime
 - `src/host-runtime.js`: host-backed runtime for Termux/Linux/macOS
@@ -140,7 +141,8 @@ The setup binaries can provision common prerequisites automatically where a supp
 
 ### All modes
 
-- Node.js 18 or newer
+- Node.js 18 or newer for the launcher and Guardian; Node.js 24 is the certified/tested supervisor profile
+- Rust/Cargo: repository toolchain 1.91.1, server MSRV 1.88.0 (the bootstrap CLI itself declares 1.74)
 - npm
 - Git when the installer needs to clone the repository
 
@@ -224,6 +226,8 @@ Windows users can also use:
 ```
 
 ## Configuration
+
+The Rust service exposes 45 tools: the 37 compatible legacy tools plus eight native agent APIs for durable submissions, job/task discovery, revisioned checkpoints, atomic files and capability inspection. See [the native agent runtime contract](docs/AGENT_RUNTIME.md). Production on Windows uses the Rust service under Guardian; ordinary Devbox shell commands honor `HOST_SHELL` and inherit the service token, while explicit `host_exec` retains the administrative PowerShell policy.
 
 Important `.env` values:
 

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -13,7 +13,7 @@ const DEFAULT_REPO_URL: &str = "https://github.com/adybag14-cyber/devbox.git";
 const CANONICAL_TERMUX_REPO: &str = "https://github.com/adybag14-cyber/termux-app";
 const MINIMUM_NODE_MAJOR: u32 = 18;
 const MINIMUM_RUST_VERSION: (u32, u32, u32) = (1, 88, 0);
-const PINNED_RUST_TOOLCHAIN: &str = "1.97.1";
+const PINNED_RUST_TOOLCHAIN: &str = "1.91.1";
 const TERMUX_PACKAGES: &[&str] = &[
     "nodejs",
     "git",

--- a/docs/AGENT_RUNTIME.md
+++ b/docs/AGENT_RUNTIME.md
@@ -10,6 +10,8 @@ Managed production startup rejects dirty tracked source, untracked Rust build in
 
 Ordinary `devbox_exec` and detached shell jobs honor `HOST_SHELL` and inherit the MCP token. Explicit Windows `host_exec` remains the administrative PowerShell interface. Guardian runs the production Rust service elevated, without per-command UAC prompts. Use a verified previous Rust candidate for operational rollback.
 
+CMD inline commands are limited to 8,000 UTF-16 units and return a clear error before launch when oversized; save longer commands to a script file. Ordinary PowerShell retains the configured-shell output behavior, while the administrative PowerShell interface retains its quiet/normalized output contract.
+
 ## Native tools
 
 | Tool | Purpose |
@@ -46,7 +48,7 @@ Exactly one of `program` or `command` is required. `args` and `input` belong to 
 
 Receipts outlive ordinary job/log retention. A retry after the retained job is gone returns `result_expired` without re-execution. Corrupted/unreadable existing job state returns `JOB_STATE_UNAVAILABLE` rather than being mislabeled as normal expiry. Receipt capacity is bounded and new operation IDs are refused when it is full; receipts are not silently evicted. Archiving operation receipts is an explicit operator action that ends their deduplication protection.
 
-`devbox_job_list` supports `task_id`, `statuses`, `limit` (1-100) and `cursor`. Ordering is by job ID. A cursor is returned only when another matching page exists. Each listing is a fresh view; restart pagination when concurrently inserted jobs must be discovered. The scan is bounded to 10,000 job directories; retention should keep the store below that bound.
+`devbox_job_list` supports `task_id`, `statuses`, `limit` (1-100) and `cursor`. Ordering is by the authoritative job directory ID. A cursor is returned only when another matching page exists. Each listing is a fresh view; restart pagination when concurrently inserted jobs must be discovered. Discovery has a five-second deadline and scans at most 10,000 job directories; retention should keep the store below that bound.
 
 Save the returned job IDs and next action with `devbox_task_put`, using `expected_revision: 0` to create a task. Later writes must use the current revision. Stale updates conflict; an identical retry returns the committed revision. Task state is capped at 65,536 bytes and the store at 10,000 records. Store large artifacts separately and retain their paths and hashes in the task state. The agent remains responsible for plans, dependencies, human approvals and artifact verification.
 
@@ -57,6 +59,8 @@ Get the previous digest/length through `devbox_file_state`. Supply that digest a
 Existing host-runtime text and large-file writes also stage complete replacement contents. Staging is flushed before atomic replacement; Windows replacement preserves the destination ACL. An overwrite or append leaves a complete old or new file after a process crash. Atomic append copies the previous contents using bounded memory, so its I/O cost grows with file size. Use an appropriate checkpoint size and separate large streaming artifacts.
 
 The service uses 256 fixed lock stripes and an OS lock protocol shared by cooperating processes under the same OS account. It never accumulates a lock object per filename. Blocking atomic I/O is limited to two workers, and a worker retains its permit even if the caller disconnects. A disconnected request may have committed: inspect/retry its intended state rather than assuming it did nothing.
+
+Persistent locks live under the account profile's `.devbox/atomic-locks-v2` directory (under `LOCALAPPDATA` on Windows and `HOME` on Unix). Unix directories must be owned by the current account and private; symlinks, publicly accessible lock files and hard-linked lock files are rejected. The shared system temporary directory is not used for this lock protocol.
 
 Valid symlinks resolve to their target. Dangling links and multiply hard-linked targets are rejected before replacement, because replacing a name cannot atomically update every hard-link alias. Cooperative API writers are serialized; arbitrary external programs must honor the same coordination or remain outside the compare-and-swap guarantee. The service also checks for changes during staging, but no ordinary rename API can provide a transaction with an uncooperative external editor.
 
@@ -79,7 +83,7 @@ Heavy capacity is weighted capacity, not a promise of five simultaneous heavy jo
 
 Cancellation is `cancel_requested` while a verified runner or child is alive. A completed cancellation is reported only after the host processes are observed stopped. Job status exposes fresh child PIDs and flags stale heartbeats even when the runner remains alive. A runner refuses to resurrect a job already marked terminal.
 
-Legacy Docker cancellation does not claim that terminating the local Docker client stopped the workload inside a shared container. It remains pending/unverified in that case. Durable host submission does not offer a misleading Docker workload-termination guarantee.
+Legacy Docker cancellation stays pending while the local runner or child remains alive. Once those local processes stop, the job becomes terminal `interrupted`, with `workloadTerminationVerified: false` and an explicit explanation. This releases local runner admission without claiming the workload inside a shared container stopped. Durable host submission does not offer a Docker workload-termination guarantee.
 
 ## Authentication, deadlines and connector refresh
 

--- a/docs/AGENT_RUNTIME.md
+++ b/docs/AGENT_RUNTIME.md
@@ -1,0 +1,104 @@
+# Native Rust agent runtime
+
+Devbox's production MCP implementation is Rust. Guardian is the Node supervisor responsible for availability and managed Windows elevation. The Rust service retains 37 legacy-compatible tool names and adds eight native tools; the JavaScript implementation is a legacy compatibility oracle, not the production profile described here.
+
+## Supported production profile and source identity
+
+Windows production uses `DEVBOX_MCP_IMPLEMENTATION=rust`, `DEVBOX_RUNTIME_MODE=host`, and the Guardian scheduled tasks. Node 24 is the certified supervisor/tool-client version; the dependency-light launcher/Guardian minimum remains Node 18. The server declares Rust MSRV 1.88.0 and the repository/installer pin Rust 1.91.1. The standalone setup CLI declares its separate MSRV 1.74. These version contracts are checked by `scripts/check-runtime-contract.mjs`.
+
+Managed production startup rejects dirty tracked source, untracked Rust build inputs, and unknown Git provenance before stopping the current MCP. Versioned binaries and `run/bin/current-rust.json` record the actual commit, Git tree and binary SHA-256. `--build-info` reports embedded source identity and whether source was dirty. Legacy manifests lacking source provenance are rebuilt instead of reused. Build metadata cannot be overridden by a stale `DEVBOX_BUILD_GIT_SHA` environment value.
+
+Ordinary `devbox_exec` and detached shell jobs honor `HOST_SHELL` and inherit the MCP token. Explicit Windows `host_exec` remains the administrative PowerShell interface. Guardian runs the production Rust service elevated, without per-command UAC prompts. Use a verified previous Rust candidate for operational rollback.
+
+## Native tools
+
+| Tool | Purpose |
+| --- | --- |
+| `devbox_capabilities` | Contract version, schema hash, tool names, source identity and effective limits; pass `tool_name` to inspect one complete schema |
+| `devbox_file_state` | Complete file SHA-256 and byte length before a conditional write |
+| `devbox_write_file_atomic` | Atomic replacement or append with previous-content/offset checks and equivalent-result retry detection |
+| `devbox_job_submit` | Durable task/operation identity and duplicate-safe submission |
+| `devbox_job_list` | Job discovery with task/status filters and bounded job-ID pagination |
+| `devbox_task_get` | Read persisted task state and revision |
+| `devbox_task_put` | Atomically update task state using an expected revision |
+| `devbox_task_list` | Discover task IDs and revisions after a lost conversation or reconnect |
+
+File state, atomic file writes and durable job submission operate on the host runtime. Task metadata is stored by the service under `run/tasks`; it is data and never grants execution permissions. OAuth read/exec scopes apply to the corresponding native tools. The default broad `mcp:tools` scope remains compatible. Task and operation IDs use 1-80 lowercase ASCII letters, digits, hyphens or underscores, avoiding platform-dependent case collisions.
+
+## Submission and recovery
+
+Submit one executable with structured arguments:
+
+```json
+{
+  "task_id": "release-check",
+  "operation_id": "build-001",
+  "label": "Build candidate",
+  "program": "node",
+  "args": ["build.mjs"],
+  "working_dir": "C:/workspace/project",
+  "timeout_seconds": 7200,
+  "resource_class": "heavy"
+}
+```
+
+Exactly one of `program` or `command` is required. `args` and `input` belong to program jobs. Retrying an identical task/operation request returns the same job with `replayed: true`; changing its payload returns `OPERATION_CONFLICT`. The submission receipt is flushed before launch. If a server dies at an uncertain point before a complete job record exists, retry returns `submission_unknown` and does not execute again. This gives at-most-once launch, not an automatic replay guarantee. Inspect the task and artifacts before deliberately choosing a new operation ID.
+
+Receipts outlive ordinary job/log retention. A retry after the retained job is gone returns `result_expired` without re-execution. Corrupted/unreadable existing job state returns `JOB_STATE_UNAVAILABLE` rather than being mislabeled as normal expiry. Receipt capacity is bounded and new operation IDs are refused when it is full; receipts are not silently evicted. Archiving operation receipts is an explicit operator action that ends their deduplication protection.
+
+`devbox_job_list` supports `task_id`, `statuses`, `limit` (1-100) and `cursor`. Ordering is by job ID. A cursor is returned only when another matching page exists. Each listing is a fresh view; restart pagination when concurrently inserted jobs must be discovered. The scan is bounded to 10,000 job directories; retention should keep the store below that bound.
+
+Save the returned job IDs and next action with `devbox_task_put`, using `expected_revision: 0` to create a task. Later writes must use the current revision. Stale updates conflict; an identical retry returns the committed revision. Task state is capped at 65,536 bytes and the store at 10,000 records. Store large artifacts separately and retain their paths and hashes in the task state. The agent remains responsible for plans, dependencies, human approvals and artifact verification.
+
+## Atomic file semantics
+
+Get the previous digest/length through `devbox_file_state`. Supply that digest as `expected_file_sha256`, or `missing` for an absent target. Append also requires `expected_offset_bytes`. The service validates the previous state; if the exact requested resulting state is already present, it returns `replayed: true` without writing again. Append replay detection checks both the previous prefix and suffix, preventing duplicate bytes after an acknowledgement is lost.
+
+Existing host-runtime text and large-file writes also stage complete replacement contents. Staging is flushed before atomic replacement; Windows replacement preserves the destination ACL. An overwrite or append leaves a complete old or new file after a process crash. Atomic append copies the previous contents using bounded memory, so its I/O cost grows with file size. Use an appropriate checkpoint size and separate large streaming artifacts.
+
+The service uses 256 fixed lock stripes and an OS lock protocol shared by cooperating processes under the same OS account. It never accumulates a lock object per filename. Blocking atomic I/O is limited to two workers, and a worker retains its permit even if the caller disconnects. A disconnected request may have committed: inspect/retry its intended state rather than assuming it did nothing.
+
+Valid symlinks resolve to their target. Dangling links and multiply hard-linked targets are rejected before replacement, because replacing a name cannot atomically update every hard-link alias. Cooperative API writers are serialized; arbitrary external programs must honor the same coordination or remain outside the compare-and-swap guarantee. The service also checks for changes during staging, but no ordinary rename API can provide a transaction with an uncooperative external editor.
+
+## Bounds and cancellation
+
+Execution slots and runner admission are separate bounds:
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `MCP_EXEC_MAX_CONCURRENT` | 6 | Weighted execution slots |
+| `MCP_EXEC_RESERVED_INTERACTIVE` | 1 | Reserved interactive capacity |
+| `MCP_EXEC_HEAVY_CAPACITY` | 4 | Slots eligible for heavy work; the owner's production override is 5 |
+| `MCP_EXEC_HEAVY_WEIGHT` | 2 | Default weight per heavy job |
+| `MCP_WATCH_MAX_CONCURRENT` | 4 | Independent passive-watch pool |
+| `MCP_JOB_MAX_ACTIVE_RUNNERS` | 16 | Total running plus queued runners, including legacy starts |
+| `MCP_JOB_MAX_RUNNERS_PER_TASK` | 8 | Running plus queued durable jobs for one task |
+| `MCP_JOB_MAX_OPERATION_RECEIPTS` | 10000 | Durable submission identities retained before admission refuses new IDs |
+
+Heavy capacity is weighted capacity, not a promise of five simultaneous heavy jobs. The existing disk-pressure policy can further constrain heavy/I/O work. Admission is serialized across server processes and fails before spawning excess runners. Replaying a known operation remains possible when the admission pool is full.
+
+Cancellation is `cancel_requested` while a verified runner or child is alive. A completed cancellation is reported only after the host processes are observed stopped. Job status exposes fresh child PIDs and flags stale heartbeats even when the runner remains alive. A runner refuses to resurrect a job already marked terminal.
+
+Legacy Docker cancellation does not claim that terminating the local Docker client stopped the workload inside a shared container. It remains pending/unverified in that case. Durable host submission does not offer a misleading Docker workload-termination guarantee.
+
+## Authentication, deadlines and connector refresh
+
+Cloudflare JWKS work runs outside the shared OAuth token/state lock. Fetching has a total ten-second deadline and a 256 KiB limit, including streamed responses. Refreshes are single-flight and briefly rate-limited; existing-token verification and registration remain responsive during a stalled refresh. Client registration is revalidated before committing a code after network verification.
+
+Launcher health requests bound both headers and body reads by the remaining startup deadline and reject oversized/unexpected health bodies. Rust capture is tested through repeated new server instances. Legacy JavaScript capture assertions include the actual bounded tool diagnostic instead of only an opaque boolean.
+
+Contract version 2 advertises tool-list change support. `devbox_status` includes the current native capability manifest so even a client with an older registered tool set can detect drift. Compare the actual client registration with `devbox_capabilities` and its schema hash. Client-side registries that persist imported schemas must refresh their connection/tool catalog; restarting the server alone cannot rewrite an external registry. Verify all 45 names and `io-heavy` after refresh.
+
+## Validation
+
+`agent-reliability-smoke.mjs` validates tool discovery, file conflicts/retries, duplicate submission, retention-safe receipts, admission limits, pagination, task revisions, restart recovery, verified cancellation and repeated native Windows capture. It runs in isolated directories and ports. Legacy 37-tool schemas/results remain checked separately; the generated native-name manifest adds eight explicitly tested tools rather than hiding drift.
+
+```sh
+cargo fmt --manifest-path rust-mcp/Cargo.toml -- --check
+cargo clippy --manifest-path rust-mcp/Cargo.toml --locked --all-targets -- -D warnings
+cargo test --manifest-path rust-mcp/Cargo.toml --locked
+cargo build --manifest-path rust-mcp/Cargo.toml --locked
+node rust-mcp/scripts/agent-reliability-smoke.mjs
+node rust-mcp/scripts/check-contract-parity.mjs
+node scripts/check-runtime-contract.mjs
+```

--- a/rust-mcp/Cargo.lock
+++ b/rust-mcp/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "devbox-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/rust-mcp/Cargo.toml
+++ b/rust-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devbox-mcp"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Native Rust replacement for Docker ChatGPT Devbox MCP"

--- a/rust-mcp/Cargo.toml
+++ b/rust-mcp/Cargo.toml
@@ -50,7 +50,7 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", features = ["process", "signal", "resource"] }
+nix = { version = "0.31", features = ["process", "signal", "resource", "user"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 sysinfo = "0.38"

--- a/rust-mcp/README.md
+++ b/rust-mcp/README.md
@@ -1,52 +1,11 @@
-# Rust MCP replacement (Draft migration)
+# Native Rust Devbox MCP
 
-This directory contains the native Rust replacement for `src/server.js`. The replacement now implements the complete 37-tool MCP contract and is the default implementation in the cutover launchers on this migration branch. The JavaScript server remains available through `DEVBOX_MCP_IMPLEMENTATION=js` as the explicit rollback path.
+The production service is the Rust Axum/Tokio/rmcp implementation. Guardian supervises it on Windows, Linux, macOS and Termux. Windows production uses the elevated Guardian profile. The JavaScript service remains a legacy compatibility implementation.
 
-The production service is not considered migrated merely because the launcher defaults have changed in the branch. The shared/live checkout stays on the previously validated service until the cutover commits, cross-platform runtime E2E, rollback drill, Guardian ownership, and final live verification are green.
+Version 0.2 exposes contract version 2: the 37 compatible legacy tools plus eight native APIs for durable job submission/discovery, versioned task state, atomic file writes and capability inspection.
 
-## Review gate
+See [the agent runtime contract](../docs/AGENT_RUNTIME.md) for supported versions, exact retry/cancellation semantics, scheduling and admission bounds, source provenance, and connector refresh requirements. See [Guardian](../docs/GUARDIAN.md) for operational ownership and supervision.
 
-PR #25 must remain **Draft** until all of these are true:
+Managed production startup builds and validates the locked Rust candidate before stopping the existing service. It requires clean committed source, records the source tree and binary hash, and verifies embedded provenance before reusing a candidate. DEVBOX_MCP_IMPLEMENTATION=rust selects Rust explicitly; production rollback should use a previously validated Rust candidate.
 
-1. All 37 MCP tools retain compatible names, schemas, outputs, cancellation, error, and platform semantics.
-2. `/`, `/healthz`, root MCP POST, `/mcp`, SSE/JSON transport behavior, protocol versions, CORS/host validation, body limits, and disconnect cancellation match the JavaScript service.
-3. `none`, `demo-oauth`, and `cloudflare-access` authentication modes remain feature complete, including discovery/resource metadata and persisted state behavior.
-4. Host and Docker profiles pass the parity oracles and runtime E2E on Windows, Linux distributions, macOS, and Android/Termux.
-5. Async jobs, weighted scheduling/watch capacity, log rotation/retention, orphan reconciliation, large-file operations, native process cancellation, search, and screen capture retain their regression coverage.
-6. Portable and managed launchers preflight the locked Rust release before replacement, preserve implementation/PID ownership metadata, and can hot-swap Rust -> JavaScript -> Rust without cross-checkout process ownership mistakes.
-7. Guardian, startup, rollback, and final live health/MCP/Chrome/authenticated-GitHub checks pass after the shared cutover.
-8. The JavaScript implementation remains available as rollback until a separate post-migration cleanup PR.
-
-Only after those gates pass should the PR be converted from Draft to Ready for Review.
-
-## Current implementation state
-
-The Rust MCP now provides:
-
-- all **37 of 37** target MCP tools
-- exact JavaScript-to-Rust input/output schema parity for host and Docker profiles
-- exact metadata parity, with platform-specific rendering for Windows, Linux, and macOS
-- a deterministic **41-call** JavaScript-to-Rust observable-result oracle in CI, plus broader SDK interoperability coverage across all tools
-- Streamable HTTP transport, root and `/mcp` routes, `/healthz`, gateway/CORS/PNA/body-limit behavior, and disconnect cancellation
-- `none`, demo OAuth, and Cloudflare Access authentication behavior
-- cancellation-aware waits, files/search, exact-byte large-file operations, hashing/base64 behavior, and JavaScript-compatible errors
-- synchronous and detached host/devbox execution, persistent jobs, cancellation, orphan recovery, weighted execution slots, passive-watch capacity, rotating logs, and retention
-- Windows host aliases, PowerShell behavior, GitHub authentication helpers, screen capture, and platform-specific compatibility semantics
-- Windows transient execution-slot contention hardening, including repeated concurrent-heavy regression coverage
-
-## Cutover behavior on this branch
-
-`DEVBOX_MCP_IMPLEMENTATION` selects the implementation:
-
-- unset or `rust`: build/preflight the locked Rust release and launch it
-- `js`: launch the retained JavaScript rollback implementation
-
-Both the portable Node launcher and the Windows managed PowerShell lifecycle preflight the selected replacement **before** stopping an existing owned MCP. The managed launcher records `run/mcp.implementation`, validates checkout-local ownership, applies the generated `.env.runtime` values authoritatively to the spawned child, and restores the parent process environment immediately afterward.
-
-The portable launcher and Windows managed launcher have both been exercised on isolated ports with Rust and JavaScript. Each implementation reached healthy status and passed the 22-tool platform runtime E2E before a clean stop. The managed drill additionally asserts the live production PID remains unchanged before, during, and after the Rust -> JavaScript rollback sequence.
-
-## CI and remaining deployment gates
-
-The Rust parity workflow runs on Windows, Linux, and macOS with formatting, strict Clippy, tests, build, schema parity, observable-result parity, and SDK smoke gates. The platform runtime workflow is being migrated to require Rust/Cargo for source installs and to assert `implementation: rust` on native macOS, Linux distribution containers, and Termux.
-
-Before the production switch, the cutover commits still need to pass the full platform matrix, be integrated into the shared replacement branch, and complete a controlled live Rust cutover plus an explicit JavaScript rollback-and-return-to-Rust drill.
+The CI matrix checks Rust formatting, strict Clippy, the declared MSRV, dependency audit, unit tests, HTTP/auth/disconnect behavior, the legacy schema/result contract, native durable APIs, and Windows/Linux/macOS/Termux runtime integration. Local probes use isolated ports and directories; they do not certify a production deployment by themselves.

--- a/rust-mcp/build.rs
+++ b/rust-mcp/build.rs
@@ -43,9 +43,54 @@ fn main() {
     println!("cargo:rerun-if-env-changed=DEVBOX_BUILD_GIT_SHA");
     println!("cargo:rerun-if-env-changed=DEVBOX_BUILD_GIT_REF");
     emit_git_rerun_metadata();
-    let sha = env::var("DEVBOX_BUILD_GIT_SHA").unwrap_or_else(|_| git(&["rev-parse", "HEAD"]));
-    let git_ref = env::var("DEVBOX_BUILD_GIT_REF")
-        .unwrap_or_else(|_| git(&["rev-parse", "--abbrev-ref", "HEAD"]));
+    emit_git_rerun_path("index");
+    let sha = git(&["rev-parse", "HEAD"]);
+    let git_ref = git(&["rev-parse", "--abbrev-ref", "HEAD"]);
+    let tree = git(&["rev-parse", "HEAD^{tree}"]);
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty());
+    let untracked = Command::new("git")
+        .args(["ls-files", "--others", "--exclude-standard", "."])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty());
+    println!("cargo:rustc-env=DEVBOX_BUILD_SOURCE_TREE={tree}");
+    println!(
+        "cargo:rustc-env=DEVBOX_BUILD_SOURCE_DIRTY={}",
+        match (dirty, untracked) {
+            (Some(a), Some(b)) =>
+                if a || b {
+                    "true"
+                } else {
+                    "false"
+                },
+            _ => "unknown",
+        }
+    );
+    // Re-run provenance when any tracked build input changes, including uncommitted edits.
+    if let Some(root) = git_optional(&["rev-parse", "--show-toplevel"])
+        && let Ok(output) = Command::new("git")
+            .args(["-C", root.as_str(), "ls-files", "-z", "--full-name"])
+            .output()
+    {
+        for file in output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|p| !p.is_empty())
+        {
+            println!(
+                "cargo:rerun-if-changed={}",
+                PathBuf::from(&root)
+                    .join(String::from_utf8_lossy(file).as_ref())
+                    .display()
+            );
+        }
+    }
     let rustc_program = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
     let rustc = Command::new(rustc_program)
         .arg("--version")

--- a/rust-mcp/parity/native-tools.json
+++ b/rust-mcp/parity/native-tools.json
@@ -1,0 +1,10 @@
+[
+  "devbox_capabilities",
+  "devbox_file_state",
+  "devbox_job_list",
+  "devbox_job_submit",
+  "devbox_task_get",
+  "devbox_task_list",
+  "devbox_task_put",
+  "devbox_write_file_atomic"
+]

--- a/rust-mcp/scripts/agent-reliability-smoke.mjs
+++ b/rust-mcp/scripts/agent-reliability-smoke.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, writeFile, rm } from 'node:fs/promises';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const repo=path.resolve(path.dirname(fileURLToPath(import.meta.url)),'../..');
+const root=await mkdtemp(path.join(os.tmpdir(),'devbox-agent-reliability-'));
+const binary=path.join(repo,'rust-mcp/target/debug',process.platform==='win32'?'devbox-mcp.exe':'devbox-mcp');
+const port=await new Promise((resolve,reject)=>{const s=net.createServer();s.once('error',reject);s.listen(0,'127.0.0.1',()=>{const p=s.address().port;s.close(()=>resolve(p));});});
+const url=new URL(`http://127.0.0.1:${port}/`);
+const sleep=ms=>new Promise(resolve=>setTimeout(resolve,ms));
+const sha=bytes=>createHash('sha256').update(bytes).digest('hex');
+const b64=text=>Buffer.from(text).toString('base64');
+const outcomes=[]; const ownedJobs=new Set();
+let server,client,exited,logs='';
+const env={...process.env,DEVBOX_PROJECT_ROOT:root,HOST:'127.0.0.1',PORT:String(port),MCP_AUTH_MODE:'none',PUBLIC_BASE_URL:'',DEVBOX_RUNTIME_MODE:'host',ENABLE_HOST_EXEC:'true',NODE_EXE:process.execPath,HOST_WORKSPACE_PATH:root,HOST_DEFAULT_WORKDIR:root,DEVBOX_WORKSPACE_PATH:root,MCP_JOBS_ROOT:path.join(root,'jobs'),MCP_EXEC_SLOT_ROOT:path.join(root,'slots'),MCP_JOB_MAX_ACTIVE_RUNNERS:'2',MCP_JOB_MAX_RUNNERS_PER_TASK:'1',MCP_EXEC_HEAVY_CAPACITY:'5',MCP_JOB_LOG_MAX_BYTES:'4096',MCP_JOB_LOG_ROTATIONS:'2'};
+async function start(){
+  server=spawn(binary,[],{cwd:repo,env,stdio:['ignore','pipe','pipe'],windowsHide:true});
+  exited=new Promise((resolve,reject)=>{server.once('error',reject);server.once('exit',resolve);});
+  for(const stream of [server.stdout,server.stderr]){stream.setEncoding('utf8');stream.on('data',chunk=>{logs=(logs+chunk).slice(-32000);});}
+  const deadline=Date.now()+20000;let ready=false;
+  while(Date.now()<deadline){if(server.exitCode!==null||server.signalCode!==null)throw new Error(`Server exited: ${logs}`);try{const r=await fetch(new URL('readyz',url),{signal:AbortSignal.timeout(500)});if(r.ok){ready=true;break;}}catch{}await sleep(100);}
+  assert(ready,`server readiness: ${logs}`);
+  client=new Client({name:'native-agent-reliability',version:'2'});
+  await client.connect(new StreamableHTTPClientTransport(url));
+}
+async function stop(){await client?.close().catch(()=>{});client=null;if(server&&server.exitCode===null&&server.signalCode===null){server.kill();await Promise.race([exited,sleep(3000)]);assert(server.exitCode!==null||server.signalCode!==null,'owned test server stopped');}}
+async function call(name,args={},failure=false){const r=await client.callTool({name,arguments:args});if(failure){assert.equal(r.isError,true,`${name} unexpectedly succeeded`);return r;}assert.equal(r.isError??false,false,`${name}: ${JSON.stringify(r.structuredContent)}`);assert.equal(r.structuredContent?.ok,true);return r.structuredContent.data;}
+async function check(name,body){const start=Date.now();await body();outcomes.push({name,ok:true,durationMs:Date.now()-start});}
+async function done(id){let value;const deadline=Date.now()+15000;do{value=await call('devbox_job_status',{job_id:id,wait_seconds:2,terminal_only:true});if(['succeeded','failed','cancelled','timed_out','interrupted'].includes(value.status))return value;}while(Date.now()<deadline);throw new Error(`Job did not reach terminal state: ${JSON.stringify(value)}`);}
+async function running(id){const deadline=Date.now()+10000;while(Date.now()<deadline){const r=await call('devbox_job_status',{job_id:id});if(r.status==='running'&&r.childPid)return r;await sleep(100);}throw new Error('job did not start');}
+let duplicated,duplicateRequest;
+try{
+  await start();
+  await check('45 discoverable tools, capability hash and heavy capacity five',async()=>{
+    const tools=(await client.listTools()).tools;assert.equal(tools.length,45);
+    const caps=await call('devbox_capabilities');assert.equal(caps.contract_version,2);assert.equal(caps.limits.heavy_capacity,5);assert.equal(caps.limits.active_runners,2);assert.match(caps.schema_sha256,/^[a-f0-9]{64}$/);
+    assert.deepEqual([...caps.tools].sort(),tools.map(t=>t.name).sort());
+    const schema=await call('devbox_capabilities',{tool_name:'devbox_job_submit'});assert.match(JSON.stringify(schema.inputSchema),/io-heavy/);
+  });
+  await check('atomic overwrite, conflict, append and replay',async()=>{
+    const file=path.join(root,'checkpoint.bin');
+    const first=await call('devbox_write_file_atomic',{path:file,content_base64:b64('first'),expected_file_sha256:'missing'});
+    assert.equal(first.current.sha256,sha('first'));
+    assert.equal((await call('devbox_write_file_atomic',{path:file,content_base64:b64('first'),expected_file_sha256:'missing'})).replayed,true);
+    await call('devbox_write_file_atomic',{path:file,content_base64:b64('wrong'),expected_file_sha256:'missing'},true);
+    const append={path:file,content_base64:b64(' + second'),expected_file_sha256:sha('first'),append:true,expected_offset_bytes:5};
+    await call('devbox_write_file_atomic',append);assert.equal((await call('devbox_write_file_atomic',append)).replayed,true);
+    assert.equal(await readFile(file,'utf8'),'first + second');
+    assert.equal((await call('devbox_file_state',{path:file})).sha256,sha('first + second'));
+  });
+  await check('concurrent duplicate submission executes once and survives retention',async()=>{
+    const counter=path.join(root,'counter');
+    duplicateRequest={task_id:'once',operation_id:'build',program:'node',args:['-e',"const fs=require('fs');const p=process.argv[1];fs.writeFileSync(p,String(Number(fs.existsSync(p)?fs.readFileSync(p,'utf8'):0)+1));console.log('x'.repeat(16000));console.log('DONE');",counter],working_dir:root};
+    const [a,b]=await Promise.all([call('devbox_job_submit',duplicateRequest),call('devbox_job_submit',duplicateRequest)]);
+    assert.equal(a.id,b.id);assert.notEqual(a.replayed,b.replayed);duplicated=a.id;ownedJobs.add(a.id);
+    assert.equal((await done(a.id)).status,'succeeded');assert.equal(await readFile(counter,'utf8'),'1');
+    await call('devbox_job_submit',{...duplicateRequest,args:['--version']},true);
+    const log=await call('devbox_job_logs',{job_id:a.id,max_chars:2000});assert.match(log.stdout,/DONE/);assert.equal(log.logs.truncated,true);
+    await rm(path.join(root,'jobs',a.id),{recursive:true,force:true});
+    const expired=await call('devbox_job_submit',duplicateRequest);assert.equal(expired.replayed,true);assert.equal(expired.job.status,'result_expired');assert.equal(await readFile(counter,'utf8'),'1');ownedJobs.delete(a.id);
+  });
+  const sleeper=(task,operation)=>({task_id:task,operation_id:operation,program:'node',args:['-e','setInterval(()=>{},1000)'],working_dir:root,timeout_seconds:120});
+  let a,b;
+  await check('global and per-task runner admission plus pagination',async()=>{
+    a=await call('devbox_job_submit',sleeper('task-a','work'));ownedJobs.add(a.id);
+    await call('devbox_job_submit',sleeper('task-a','other'),true);
+    b=await call('devbox_job_submit',sleeper('task-b','work'));ownedJobs.add(b.id);
+    await call('devbox_job_submit',sleeper('task-c','work'),true);
+    const replay=await call('devbox_job_submit',sleeper('task-a','work'));assert.equal(replay.id,a.id);assert.equal(replay.replayed,true);
+    const page=await call('devbox_job_list',{limit:1});assert.equal(page.jobs.length,1);assert(page.next_cursor);
+    const second=await call('devbox_job_list',{limit:1,cursor:page.next_cursor});assert.equal(second.jobs.length,1);assert.notEqual(page.jobs[0].id,second.jobs[0].id);
+    const filtered=await call('devbox_job_list',{task_id:'task-a'});assert.equal(filtered.jobs.length,1);assert.equal(filtered.jobs[0].id,a.id);
+  });
+  await check('task CAS and reconnect recover work without resubmission',async()=>{
+    await running(a.id);await running(b.id);
+    const state={phase:'running',job_ids:[a.id,b.id],next_action:'poll existing jobs'};
+    const request={task_id:'workflow',expected_revision:0,state};
+    assert.equal((await call('devbox_task_put',request)).record.revision,1);
+    assert.equal((await call('devbox_task_put',request)).replayed,true);
+    await call('devbox_task_put',{...request,state:{phase:'stale'}},true);
+    await stop();await start();
+    assert.deepEqual((await call('devbox_task_get',{task_id:'workflow'})).record.state,state);
+    assert.equal((await call('devbox_job_submit',sleeper('task-a','work'))).replayed,true);
+    assert.equal((await call('devbox_task_list')).tasks[0].task_id,'workflow');
+  });
+  await check('cancellation confirms both runner and child stopped',async()=>{
+    for(const job of [a,b]){const before=await running(job.id);const result=await call('devbox_job_cancel',{job_id:job.id});assert.equal(result.status,'cancelled');assert.equal(result.runnerAlive,false);try{process.kill(before.childPid,0);assert.fail('child survived cancellation');}catch(error){if(error.code!=='ESRCH')throw error;}ownedJobs.delete(job.id);}
+  });
+  if(process.platform==='win32')await check('native cold capture works through successive Rust server starts',async()=>{
+    for(let attempt=0;attempt<3;attempt++){if(attempt){await stop();await start();}const r=await client.callTool({name:'host_capture_display',arguments:{quality:50,timeout_seconds:15}});assert.equal(r.isError??false,false,JSON.stringify(r.structuredContent));assert(r.content.some(c=>c.type==='image'&&c.data.length>200));}
+  });
+  console.log(JSON.stringify({ok:true,checks:outcomes,root},null,2));
+}catch(error){console.error(JSON.stringify({ok:false,error:error.stack,checks:outcomes,serverLogs:logs,root},null,2));process.exitCode=1;}
+finally{
+  if(client)for(const id of ownedJobs){await call('devbox_job_cancel',{job_id:id}).catch(()=>{});}
+  await stop();
+  if(process.env.DEVBOX_AGENT_EVIDENCE_DIR){await writeFile(path.join(process.env.DEVBOX_AGENT_EVIDENCE_DIR,'agent-smoke.json'),JSON.stringify({ok:!process.exitCode,checks:outcomes,root},null,2));}
+  else await rm(root,{recursive:true,force:true,maxRetries:5,retryDelay:100});
+}

--- a/rust-mcp/scripts/agent-reliability-smoke.mjs
+++ b/rust-mcp/scripts/agent-reliability-smoke.mjs
@@ -103,7 +103,7 @@ try{
     assert.equal((await call('devbox_task_list')).tasks[0].task_id,'workflow');
   });
   await check('cancellation confirms both runner and child stopped',async()=>{
-    for(const job of [a,b]){const before=await running(job.id);const result=await call('devbox_job_cancel',{job_id:job.id});assert.equal(result.status,'cancelled');assert.equal(result.runnerAlive,false);try{process.kill(before.childPid,0);assert.fail('child survived cancellation');}catch(error){if(error.code!=='ESRCH')throw error;}ownedJobs.delete(job.id);}
+    for(const job of [a,b]){const before=await running(job.id);const acknowledgement=await call('devbox_job_cancel',{job_id:job.id});assert(['cancel_requested','cancelled'].includes(acknowledgement.status));const result=await done(job.id);assert.equal(result.status,'cancelled');assert.equal(result.runnerAlive,false);try{process.kill(before.childPid,0);assert.fail('child survived cancellation');}catch(error){if(error.code!=='ESRCH')throw error;}ownedJobs.delete(job.id);}
   });
   await check('nested task checkpoints retain bounded compact output',async()=>{
     let state=Array(500).fill('checkpoint');for(let i=0;i<60;i++)state={next:state};

--- a/rust-mcp/scripts/agent-reliability-smoke.mjs
+++ b/rust-mcp/scripts/agent-reliability-smoke.mjs
@@ -77,6 +77,7 @@ try{
     const page=await call('devbox_job_list',{limit:1});assert.equal(page.jobs.length,1);assert(page.next_cursor);
     const second=await call('devbox_job_list',{limit:1,cursor:page.next_cursor});assert.equal(second.jobs.length,1);assert.notEqual(page.jobs[0].id,second.jobs[0].id);
     const filtered=await call('devbox_job_list',{task_id:'task-a'});assert.equal(filtered.jobs.length,1);assert.equal(filtered.jobs[0].id,a.id);
+    assert(filtered.jobs.every(job=>Object.keys(job).every(key=>['id','status','createdAtUtc','startedAtUtc','completedAtUtc','exitCode','runnerAlive','agent'].includes(key))),'discovery omits detailed logs and process diagnostics');
   });
   await check('task CAS and reconnect recover work without resubmission',async()=>{
     await running(a.id);await running(b.id);
@@ -92,6 +93,13 @@ try{
   });
   await check('cancellation confirms both runner and child stopped',async()=>{
     for(const job of [a,b]){const before=await running(job.id);const result=await call('devbox_job_cancel',{job_id:job.id});assert.equal(result.status,'cancelled');assert.equal(result.runnerAlive,false);try{process.kill(before.childPid,0);assert.fail('child survived cancellation');}catch(error){if(error.code!=='ESRCH')throw error;}ownedJobs.delete(job.id);}
+  });
+  await check('nested task checkpoints retain bounded compact output',async()=>{
+    let state=Array(500).fill('checkpoint');for(let i=0;i<60;i++)state={next:state};
+    const r=await client.callTool({name:'devbox_task_put',arguments:{task_id:'nested',expected_revision:0,state}});
+    assert.equal(r.isError??false,false);assert.deepEqual(r.structuredContent.data.record.state,state);
+    const text=r.content.filter(c=>c.type==='text').map(c=>c.text).join('');
+    assert(text.length<JSON.stringify(r.structuredContent.data).length+300,'text rendering must not expand nested state through indentation');
   });
   if(process.platform==='win32')await check('native cold capture works through successive Rust server starts',async()=>{
     for(let attempt=0;attempt<3;attempt++){if(attempt){await stop();await start();}const r=await client.callTool({name:'host_capture_display',arguments:{quality:50,timeout_seconds:15}});assert.equal(r.isError??false,false,JSON.stringify(r.structuredContent));assert(r.content.some(c=>c.type==='image'&&c.data.length>200));}

--- a/rust-mcp/scripts/agent-reliability-smoke.mjs
+++ b/rust-mcp/scripts/agent-reliability-smoke.mjs
@@ -30,7 +30,18 @@ async function start(){
   client=new Client({name:'native-agent-reliability',version:'2'});
   await client.connect(new StreamableHTTPClientTransport(url));
 }
-async function stop(){await client?.close().catch(()=>{});client=null;if(server&&server.exitCode===null&&server.signalCode===null){server.kill();await Promise.race([exited,sleep(3000)]);assert(server.exitCode!==null||server.signalCode!==null,'owned test server stopped');}}
+async function stop({abrupt=false}={}){
+  await client?.close().catch(()=>{});client=null;
+  if(server&&server.exitCode===null&&server.signalCode===null){
+    server.kill(abrupt?'SIGKILL':'SIGTERM');
+    await Promise.race([exited,sleep(abrupt?3000:12000)]);
+    if(server.exitCode===null&&server.signalCode===null){
+      console.error(`Force-cleaning owned test server PID ${server.pid} after its shutdown deadline`);
+      server.kill('SIGKILL');await Promise.race([exited,sleep(3000)]);
+    }
+    assert(server.exitCode!==null||server.signalCode!==null,'owned test server stopped');
+  }
+}
 async function call(name,args={},failure=false){const r=await client.callTool({name,arguments:args});if(failure){assert.equal(r.isError,true,`${name} unexpectedly succeeded`);return r;}assert.equal(r.isError??false,false,`${name}: ${JSON.stringify(r.structuredContent)}`);assert.equal(r.structuredContent?.ok,true);return r.structuredContent.data;}
 async function check(name,body){const start=Date.now();await body();outcomes.push({name,ok:true,durationMs:Date.now()-start});}
 async function done(id){let value;const deadline=Date.now()+15000;do{value=await call('devbox_job_status',{job_id:id,wait_seconds:2,terminal_only:true});if(['succeeded','failed','cancelled','timed_out','interrupted'].includes(value.status))return value;}while(Date.now()<deadline);throw new Error(`Job did not reach terminal state: ${JSON.stringify(value)}`);}
@@ -86,7 +97,7 @@ try{
     assert.equal((await call('devbox_task_put',request)).record.revision,1);
     assert.equal((await call('devbox_task_put',request)).replayed,true);
     await call('devbox_task_put',{...request,state:{phase:'stale'}},true);
-    await stop();await start();
+    await stop({abrupt:true});await start();
     assert.deepEqual((await call('devbox_task_get',{task_id:'workflow'})).record.state,state);
     assert.equal((await call('devbox_job_submit',sleeper('task-a','work'))).replayed,true);
     assert.equal((await call('devbox_task_list')).tasks[0].task_id,'workflow');

--- a/rust-mcp/scripts/check-contract-parity.mjs
+++ b/rust-mcp/scripts/check-contract-parity.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -15,6 +15,14 @@ assert.equal(registered.length, 37, `Expected the JavaScript MCP to register 37 
 assert.equal(new Set(registered).size, registered.length, "JavaScript MCP tool names must be unique.");
 assert.equal(new Set(target).size, target.length, "Rust target tool names must be unique.");
 assert.deepEqual(target, registered, "Rust target-tools.json has drifted from the JavaScript MCP registerTool order/names.");
+
+const nativeSource = await readFile(path.join(rustMcpRoot, "src", "agent_tools.rs"), "utf8");
+const native = [...nativeSource.matchAll(/#\[tool\([\s\S]*?name\s*=\s*"([^"]+)"/g)].map(match => match[1]).sort();
+assert.equal(native.length, 8, "Native agent tool contract must explicitly contain eight tools");
+assert.equal(new Set([...target, ...native]).size, target.length + native.length);
+const nativePath = path.join(rustMcpRoot, "parity", "native-tools.json");
+if (process.argv.includes("--write-native")) await writeFile(nativePath, JSON.stringify(native, null, 2) + "\n");
+assert.deepEqual(JSON.parse(await readFile(nativePath, "utf8")), native, "Run check-contract-parity.mjs --write-native after an intentional native tool change");
 
 console.log(JSON.stringify({
   ok: true,

--- a/rust-mcp/scripts/cloudflare-oauth-smoke-runner.mjs
+++ b/rust-mcp/scripts/cloudflare-oauth-smoke-runner.mjs
@@ -179,7 +179,7 @@ try {
   const transport = new StreamableHTTPClientTransport(baseUrl, { requestInit: { headers: { Authorization: `Bearer ${tokens.access_token}` } } });
   await client.connect(transport);
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 37);
+  assert.equal(tools.tools.length, 45);
   await client.close();
   client = undefined;
 

--- a/rust-mcp/scripts/oauth-smoke-runner.mjs
+++ b/rust-mcp/scripts/oauth-smoke-runner.mjs
@@ -220,7 +220,7 @@ try {
   });
   await client.connect(transport);
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 37);
+  assert.equal(tools.tools.length, 45);
   const oauthWait = await client.callTool({
     name: "devbox_wait",
     arguments: { seconds: 0.05, reason: "oauth-context-smoke" },

--- a/rust-mcp/scripts/result-parity-audit.mjs
+++ b/rust-mcp/scripts/result-parity-audit.mjs
@@ -283,6 +283,7 @@ const normalizeImplementationDiagnostics = (name, value) => {
   for (const key of ["runnerProcessInstance", "childProcessInstance", "processInstance"]) delete data[key];
   if (name !== "devbox_status") return cloned;
   for (const key of [
+    "capabilities",
     "activeRequests",
     "activeRequestsIncludingCurrent",
     "backgroundTasks",

--- a/rust-mcp/scripts/schema-parity-audit.mjs
+++ b/rust-mcp/scripts/schema-parity-audit.mjs
@@ -226,7 +226,14 @@ const jsTools = await listJsTools();
 const rustTools = await listRustTools();
 const jsByName = new Map(jsTools.map((tool) => [tool.name, tool]));
 const rustByName = new Map(rustTools.map((tool) => [tool.name, tool]));
-assert.deepEqual([...rustByName.keys()].sort(), [...jsByName.keys()].sort());
+const nativeNames = JSON.parse(await readFile(path.join(projectRoot, "rust-mcp", "parity", "native-tools.json"), "utf8"));
+assert.deepEqual([...rustByName.keys()].sort(), [...jsByName.keys(), ...nativeNames].sort());
+for (const name of nativeNames) {
+  const tool = rustByName.get(name);
+  assert.equal(tool.inputSchema.type, "object");
+  assert.equal(collectNumericSchemaErrors(tool.inputSchema).length, 0, `Invalid native schema: ${name}`);
+  assert.equal(typeof tool.annotations?.readOnlyHint, "boolean", `Missing native tool annotations: ${name}`);
+}
 
 const comparableMetadata = (tool) => ({
   title: tool.title ?? null,

--- a/rust-mcp/scripts/smoke-client.mjs
+++ b/rust-mcp/scripts/smoke-client.mjs
@@ -21,8 +21,8 @@ const assertExecutionMetadata = (result) => {
   assert.equal(Object.hasOwn(execution, "slots"), false);
 };
 
-const assertShellResult = (result, { readOnly } = {}) => {
-  if (process.platform === "win32" && !expectedWindowsAdmin) {
+const assertShellResult = (result, { readOnly, administrative = false } = {}) => {
+  if (administrative && process.platform === "win32" && !expectedWindowsAdmin) {
     assert.equal(result.isError, true);
     assert.equal(result.structuredContent?.exitCode, 740);
     assert.equal(result.structuredContent?.data?.bridge_diagnostics?.suspected_elevation_gap, true);
@@ -135,7 +135,8 @@ try {
   assert.deepEqual(client.getServerCapabilities()?.logging, {});
   const listed = await client.listTools();
   const names = listed.tools.map((tool) => tool.name).sort();
-  assert.deepEqual(names, expectedTools);
+  const nativeTools = JSON.parse(await readFile(new URL("../parity/native-tools.json", import.meta.url), "utf8"));
+  assert.deepEqual(names, [...expectedTools, ...nativeTools].sort());
 
   const wait = await client.callTool({
     name: "devbox_wait",
@@ -342,7 +343,7 @@ try {
       name: toolName,
       arguments: { command: "git --version", max_output_chars: 2_000 },
     });
-    assertShellResult(hostShell);
+    assertShellResult(hostShell, { administrative: true });
   }
 
   if (process.platform === "win32" && expectedWindowsAdmin) {

--- a/rust-mcp/scripts/smoke-runner.mjs
+++ b/rust-mcp/scripts/smoke-runner.mjs
@@ -69,7 +69,7 @@ const waitForHealth = async ({ baseUrl, exited }) => {
       throw new Error(`Rust MCP exited before readiness (code=${earlyExit.result.code}, signal=${earlyExit.result.signal}).`);
     }
     try {
-      const response = await fetch(new URL("healthz", baseUrl));
+      const response = await fetch(new URL("healthz", baseUrl), { signal: AbortSignal.timeout(Math.max(1, Math.min(1000, deadline - Date.now()))) });
       if (response.ok && (await response.text()) === "ok") return;
     } catch {
       // Startup races are expected; retry until the bounded deadline.

--- a/rust-mcp/src/agent_tools.rs
+++ b/rust-mcp/src/agent_tools.rs
@@ -146,7 +146,10 @@ const fn page_size() -> usize {
 }
 fn response(summary: &str, result: anyhow::Result<Value>) -> CallToolResult {
     match result {
-        Ok(value) => ToolEnvelope::success(summary, Some(value)),
+        Ok(value) => {
+            let text = format!("{summary}\n\n{value}");
+            ToolEnvelope::success_with_text(summary, Some(value), text)
+        }
         Err(error) => ToolEnvelope::error(error.to_string(), None),
     }
 }

--- a/rust-mcp/src/agent_tools.rs
+++ b/rust-mcp/src/agent_tools.rs
@@ -1,0 +1,401 @@
+//! Rust-native agent APIs, kept separate from the frozen legacy tool family.
+use super::*;
+use crate::{atomic_file, job_control, task_store};
+
+pub(super) fn router() -> ToolRouter<DevboxMcp> {
+    DevboxMcp::agent_tool_router()
+}
+
+pub(super) fn configure_schema(schema: &mut serde_json::Map<String, Value>, config: &Config) {
+    let Some(properties) = schema.get_mut("properties").and_then(Value::as_object_mut) else {
+        return;
+    };
+    if properties.get("state") == Some(&Value::Bool(true)) {
+        properties.insert("state".into(), json!({}));
+    }
+    for name in ["path", "task_id", "operation_id", "tool_name"] {
+        if let Some(property) = properties.get_mut(name).and_then(Value::as_object_mut) {
+            property.insert("minLength".into(), json!(1));
+            if matches!(name, "task_id" | "operation_id") {
+                property.insert("maxLength".into(), json!(80));
+                property.insert("pattern".into(), json!("^[a-z0-9_-]+$"));
+            }
+        }
+    }
+    if let Some(property) = properties
+        .get_mut("expected_file_sha256")
+        .and_then(Value::as_object_mut)
+    {
+        property.insert("pattern".into(), json!("^(missing|[a-fA-F0-9]{64})$"));
+    }
+    if let Some(property) = properties
+        .get_mut("content_base64")
+        .and_then(Value::as_object_mut)
+    {
+        property.insert(
+            "maxLength".into(),
+            json!((config.max_mcp_transfer_chars as u64).min(9_007_199_254_740_991)),
+        );
+    }
+    for (name, min, max) in [
+        ("limit", 1, 100),
+        ("timeout_seconds", 1, 86400),
+        ("expected_revision", 0, 9_007_199_254_740_991_u64),
+        ("expected_offset_bytes", 0, 9_007_199_254_740_991_u64),
+    ] {
+        if let Some(property) = properties.get_mut(name).and_then(Value::as_object_mut) {
+            property.remove("format");
+            property.insert("minimum".into(), json!(min));
+            property.insert("maximum".into(), json!(max));
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct FileStateRequest {
+    path: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct AtomicWriteRequest {
+    path: String,
+    content_base64: String,
+    /// Previous complete file SHA-256, or "missing" for create-only.
+    expected_file_sha256: String,
+    #[serde(default)]
+    append: bool,
+    /// Required for retry-safe append, measured before the first attempt.
+    expected_offset_bytes: Option<u64>,
+    #[serde(default = "default_true")]
+    create_dirs: bool,
+}
+
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+enum AgentResource {
+    #[default]
+    Auto,
+    Watch,
+    Light,
+    Heavy,
+    IoHeavy,
+}
+impl AgentResource {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Watch => "watch",
+            Self::Light => "light",
+            Self::Heavy => "heavy",
+            Self::IoHeavy => "io-heavy",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SubmitRequest {
+    task_id: String,
+    operation_id: String,
+    #[serde(default)]
+    label: String,
+    program: Option<String>,
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    input: Option<String>,
+    working_dir: Option<String>,
+    #[serde(default = "default_async_timeout")]
+    timeout_seconds: u64,
+    #[serde(default)]
+    resource_class: AgentResource,
+    #[serde(default)]
+    read_only: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ListJobsRequest {
+    task_id: Option<String>,
+    #[serde(default)]
+    statuses: Vec<String>,
+    cursor: Option<String>,
+    #[serde(default = "page_size")]
+    limit: usize,
+}
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct TaskGetRequest {
+    task_id: String,
+}
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct TaskPutRequest {
+    task_id: String,
+    expected_revision: u64,
+    state: Value,
+}
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ListTasksRequest {
+    cursor: Option<String>,
+    #[serde(default = "page_size")]
+    limit: usize,
+}
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct CapabilitiesRequest {
+    tool_name: Option<String>,
+}
+const fn page_size() -> usize {
+    50
+}
+fn response(summary: &str, result: anyhow::Result<Value>) -> CallToolResult {
+    match result {
+        Ok(value) => ToolEnvelope::success(summary, Some(value)),
+        Err(error) => ToolEnvelope::error(error.to_string(), None),
+    }
+}
+
+#[tool_router(router = agent_tool_router)]
+impl DevboxMcp {
+    #[tool(name="devbox_file_state", description="Read a complete file digest and length before an atomic checkpoint write. Host runtime only.", output_schema=rmcp::handler::server::tool::schema_for_type::<ToolEnvelope>())]
+    async fn devbox_file_state(
+        &self,
+        Parameters(request): Parameters<FileStateRequest>,
+    ) -> CallToolResult {
+        let result = async {
+            self.agent_host()?;
+            let path = self.agent_path(&request.path)?;
+            let value = atomic_file::blocking(move || atomic_file::state(&path)).await?;
+            Ok(serde_json::to_value(value)?)
+        }
+        .await;
+        response("Read file version.", result)
+    }
+
+    #[tool(name="devbox_write_file_atomic", description="Atomically replace a host file after checking its previous SHA-256 (or missing). Append requires the previous offset; identical retries return replayed=true without duplicating bytes. Uses bounded-memory staging; atomic append copies the previous file.", output_schema=rmcp::handler::server::tool::schema_for_type::<ToolEnvelope>())]
+    async fn devbox_write_file_atomic(
+        &self,
+        Parameters(request): Parameters<AtomicWriteRequest>,
+    ) -> CallToolResult {
+        let result = async {
+            self.agent_host()?;
+            if request.content_base64.len() > self.config.max_mcp_transfer_chars {
+                anyhow::bail!("Payload exceeds transfer limit");
+            }
+            if request.append && request.expected_offset_bytes.is_none() {
+                anyhow::bail!("Atomic append requires expected_offset_bytes");
+            }
+            let payload = STANDARD.decode(&request.content_base64)?;
+            if STANDARD.encode(&payload) != request.content_base64 {
+                anyhow::bail!("content_base64 must be canonical");
+            }
+            let receipt = atomic_file::write(
+                self.agent_path(&request.path)?,
+                payload,
+                request.append,
+                request.create_dirs,
+                atomic_file::Preconditions {
+                    sha256: Some(request.expected_file_sha256),
+                    offset: request.expected_offset_bytes,
+                },
+            )
+            .await?;
+            Ok(serde_json::to_value(receipt)?)
+        }
+        .await;
+        response("Committed atomic file write.", result)
+    }
+
+    #[tool(name="devbox_job_submit", description="Submit a durable host job using a task_id and operation_id. Exactly one of program or command is required. Retry the identical operation after response loss: it returns the existing job, never launches a duplicate. Conflicting reuse is rejected; admission limits bound queued runners.", output_schema=rmcp::handler::server::tool::schema_for_type::<ToolEnvelope>())]
+    async fn devbox_job_submit(
+        &self,
+        Parameters(request): Parameters<SubmitRequest>,
+    ) -> CallToolResult {
+        let operation = request
+            .command
+            .as_deref()
+            .or(request.program.as_deref())
+            .unwrap_or("");
+        let class = if let Some(program) = request.program.as_ref() {
+            infer_program_resource_class(program, &request.args, request.resource_class.name())
+        } else {
+            infer_shell_resource_class(operation, request.resource_class.name())
+        };
+        if let Some(rejection) = self
+            .disk_pressure_rejection(
+                class,
+                request.program.is_none() && request.read_only,
+                operation,
+            )
+            .await
+        {
+            return rejection;
+        }
+        let result = async {
+            self.agent_host()?;
+            if !(1..=86400).contains(&request.timeout_seconds) || request.args.len() > 256 {
+                anyhow::bail!("Invalid job timeout or argument count");
+            }
+            if request.command.is_some() && (!request.args.is_empty() || request.input.is_some()) {
+                anyhow::bail!("args/input require a program job");
+            }
+            let agent = job_control::Submission {
+                task_id: request.task_id,
+                operation_id: request.operation_id,
+                label: request.label,
+            };
+            let working_dir = request.working_dir.unwrap_or_else(|| {
+                self.config
+                    .devbox_workspace_path
+                    .to_string_lossy()
+                    .into_owned()
+            });
+            let timeout = Duration::from_secs(request.timeout_seconds);
+            let resource_class = request.resource_class.name().to_owned();
+            match (request.program, request.command) {
+                (Some(program), None) if !program.trim().is_empty() => {
+                    self.jobs
+                        .submit_program(
+                            StartProgramJob {
+                                program,
+                                args: request.args,
+                                input: request.input,
+                                working_dir,
+                                timeout,
+                                user: self.config.devbox_default_user.clone(),
+                                resource_class,
+                            },
+                            agent,
+                        )
+                        .await
+                }
+                (None, Some(command)) if !command.trim().is_empty() => {
+                    self.jobs
+                        .submit_shell(
+                            crate::job_manager::StartShellJob {
+                                command,
+                                working_dir,
+                                timeout,
+                                user: self.config.devbox_default_user.clone(),
+                                read_only: request.read_only,
+                                resource_class,
+                            },
+                            agent,
+                        )
+                        .await
+                }
+                _ => anyhow::bail!("Exactly one non-empty program or command is required"),
+            }
+        }
+        .await;
+        response("Submitted or recovered durable job.", result)
+    }
+
+    #[tool(name="devbox_job_list", description="Discover persisted jobs with task/status filters and bounded job-ID pagination. Recover job IDs after reconnecting.", output_schema=rmcp::handler::server::tool::schema_for_type::<ToolEnvelope>())]
+    async fn devbox_job_list(
+        &self,
+        Parameters(request): Parameters<ListJobsRequest>,
+    ) -> CallToolResult {
+        response(
+            "Listed durable jobs.",
+            job_control::list(
+                self.jobs.store(),
+                request.task_id.as_deref(),
+                &request.statuses,
+                request.cursor.as_deref(),
+                request.limit,
+            )
+            .await,
+        )
+    }
+
+    #[tool(name="devbox_task_get", description="Read a versioned task checkpoint, including plan, job IDs and artifact references saved by the agent.", output_schema=rmcp::handler::server::tool::schema_for_type::<ToolEnvelope>())]
+    async fn devbox_task_get(
+        &self,
+        Parameters(request): Parameters<TaskGetRequest>,
+    ) -> CallToolResult {
+        response(
+            "Read task checkpoint.",
+            task_store::get(&self.task_root(), &request.task_id).await,
+        )
+    }
+
+    #[tool(name="devbox_task_put", description="Atomically save task state using expected_revision (zero creates a task). Stale updates are rejected; identical retries recover the committed revision. State is data and does not grant execution permissions.", output_schema=rmcp::handler::server::tool::schema_for_type::<ToolEnvelope>())]
+    async fn devbox_task_put(
+        &self,
+        Parameters(request): Parameters<TaskPutRequest>,
+    ) -> CallToolResult {
+        response(
+            "Saved task checkpoint.",
+            task_store::put(
+                &self.task_root(),
+                &request.task_id,
+                request.expected_revision,
+                request.state,
+            )
+            .await,
+        )
+    }
+
+    #[tool(name="devbox_task_list", description="Discover task IDs and revisions after reconnecting, without loading large task states.", output_schema=rmcp::handler::server::tool::schema_for_type::<ToolEnvelope>())]
+    async fn devbox_task_list(
+        &self,
+        Parameters(request): Parameters<ListTasksRequest>,
+    ) -> CallToolResult {
+        response(
+            "Listed task checkpoints.",
+            task_store::list(&self.task_root(), request.cursor.as_deref(), request.limit).await,
+        )
+    }
+
+    #[tool(name="devbox_capabilities", description="Read the current Rust contract version, schema hash, tools and scheduling/admission limits. Supply a tool_name for its authoritative schema to diagnose cached connector definitions.", output_schema=rmcp::handler::server::tool::schema_for_type::<ToolEnvelope>())]
+    async fn devbox_capabilities(
+        &self,
+        Parameters(request): Parameters<CapabilitiesRequest>,
+    ) -> CallToolResult {
+        let result = if let Some(name) = request.tool_name {
+            self.tool_router.get(&name).cloned().map_or_else(
+                || Err(anyhow::anyhow!("Unknown tool")),
+                |tool| serde_json::to_value(self.configured_tool(tool)).map_err(Into::into),
+            )
+        } else {
+            Ok(self.capability_manifest())
+        };
+        response("Read native Rust capabilities.", result)
+    }
+}
+
+impl DevboxMcp {
+    fn agent_host(&self) -> anyhow::Result<()> {
+        if self.config.runtime_mode != RuntimeMode::Host {
+            anyhow::bail!("Durable host APIs require host runtime");
+        }
+        if !self.config.host_exec_enabled {
+            anyhow::bail!("Host execution is disabled");
+        }
+        Ok(())
+    }
+    fn agent_path(&self, path: &str) -> anyhow::Result<PathBuf> {
+        if path.trim().is_empty() {
+            anyhow::bail!("path must not be empty");
+        }
+        let path = PathBuf::from(path);
+        Ok(if path.is_absolute() {
+            path
+        } else {
+            self.config.devbox_workspace_path.join(path)
+        })
+    }
+    fn task_root(&self) -> PathBuf {
+        self.config.project_root.join("run").join("tasks")
+    }
+    pub(super) fn capability_manifest(&self) -> Value {
+        let mut tools = self
+            .tool_router
+            .list_all()
+            .into_iter()
+            .map(|tool| self.configured_tool(tool))
+            .collect::<Vec<_>>();
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
+        let hash = crate::atomic_file::digest(
+            &serde_json::to_vec(&tools).expect("tool schemas serialize"),
+        );
+        json!({"contract_version":2,"implementation":"rust","schema_sha256":hash,"tools":tools.iter().map(|tool|tool.name.as_ref()).collect::<Vec<_>>(),"resource_classes":["auto","watch","light","heavy","io-heavy"],"limits":{"execution":self.config.exec_max_concurrent,"reserved_interactive":self.config.exec_reserved_interactive,"heavy_capacity":self.config.exec_heavy_capacity,"watch_capacity":self.config.watch_max_concurrent,"active_runners":self.config.job_max_active,"runners_per_task":self.config.job_max_per_task,"operation_receipts":self.config.job_max_operations,"task_state_bytes":task_store::MAX_STATE_BYTES},"build":crate::provenance::snapshot()})
+    }
+}

--- a/rust-mcp/src/atomic_file.rs
+++ b/rust-mcp/src/atomic_file.rs
@@ -162,6 +162,15 @@ pub(crate) async fn write(
     blocking(move || write_sync(&path, &payload, append, create_dirs, &expected)).await
 }
 
+#[cfg(unix)]
+fn reject_unix_hard_links(metadata: Option<&fs::Metadata>) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+    if metadata.is_some_and(|metadata| metadata.nlink() > 1) {
+        bail!("Atomic replacement of a hard-linked target is unsupported");
+    }
+    Ok(())
+}
+
 pub(crate) fn write_sync(
     path: &Path,
     payload: &[u8],
@@ -234,12 +243,7 @@ pub(crate) fn write_sync(
         bail!("Target is read-only");
     }
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        if metadata.nlink() > 1 {
-            bail!("Atomic replacement of a hard-linked target is unsupported");
-        }
-    }
+    reject_unix_hard_links(metadata.as_ref())?;
     let staged = tempfile::Builder::new()
         .prefix(".devbox-write-")
         .tempfile_in(target.parent().context("target parent")?)?;

--- a/rust-mcp/src/atomic_file.rs
+++ b/rust-mcp/src/atomic_file.rs
@@ -99,18 +99,87 @@ pub(crate) fn stripe(path: &Path) -> usize {
     usize::from(Sha256::digest(key.as_bytes())[0])
 }
 
-// Exactly 256 persistent lock files; never unlink a lock held by another process.
+fn private_directory(path: &Path) -> Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    match builder.create(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error.into()),
+    }
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        bail!("Atomic lock directory must be a private ordinary directory");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.uid() != nix::unistd::geteuid().as_raw() || metadata.mode() & 0o077 != 0 {
+            bail!("Atomic lock directory must be owned by this account with mode 0700");
+        }
+    }
+    Ok(())
+}
+
+fn lock_root() -> Result<PathBuf> {
+    let key = if cfg!(windows) {
+        "LOCALAPPDATA"
+    } else {
+        "HOME"
+    };
+    let profile = PathBuf::from(
+        std::env::var_os(key).context("Account profile is required for atomic locks")?,
+    );
+    if !profile.is_absolute() || !profile.is_dir() {
+        bail!("Atomic locks require an absolute account profile directory");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = fs::metadata(&profile)?;
+        if metadata.uid() != nix::unistd::geteuid().as_raw() || metadata.mode() & 0o022 != 0 {
+            bail!(
+                "Atomic lock profile must belong to this account and not be writable by other accounts"
+            );
+        }
+    }
+    let parent = profile.join(".devbox");
+    private_directory(&parent)?;
+    let root = parent.join("atomic-locks-v2");
+    private_directory(&root)?;
+    Ok(root)
+}
+
+// Exactly 256 persistent lock files per account; never unlink an active lock.
 fn lock(path: &Path) -> Result<File> {
-    let root = std::env::temp_dir().join("devbox-atomic-locks-v1");
-    fs::create_dir_all(&root)?;
+    let root = lock_root()?;
     let mut options = OpenOptions::new();
     options.create(true).truncate(false).read(true).write(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
+        options
+            .mode(0o600)
+            .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC);
     }
     let file = options.open(root.join(format!("{}.lock", stripe(path))))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = file.metadata()?;
+        if !metadata.is_file()
+            || metadata.uid() != nix::unistd::geteuid().as_raw()
+            || metadata.mode() & 0o077 != 0
+            || metadata.nlink() != 1
+        {
+            bail!("Atomic lock file must be private, account-owned and unaliased");
+        }
+    }
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         match file.try_lock_exclusive() {
@@ -388,6 +457,31 @@ fn replace(source: &Path, target: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn lock_directories_are_private_and_reject_public_or_symlinked_paths() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+        let root = tempfile::tempdir().unwrap();
+        let private = root.path().join("private");
+        private_directory(&private).unwrap();
+        assert_eq!(fs::metadata(&private).unwrap().mode() & 0o777, 0o700);
+        fs::set_permissions(&private, fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(
+            private_directory(&private)
+                .unwrap_err()
+                .to_string()
+                .contains("0700")
+        );
+        let alias = root.path().join("alias");
+        symlink(&private, &alias).unwrap();
+        assert!(
+            private_directory(&alias)
+                .unwrap_err()
+                .to_string()
+                .contains("ordinary directory")
+        );
+    }
 
     #[cfg(windows)]
     #[tokio::test]

--- a/rust-mcp/src/atomic_file.rs
+++ b/rust-mcp/src/atomic_file.rs
@@ -1,0 +1,506 @@
+//! Atomic, bounded-memory file replacement and cooperative compare-and-swap.
+use anyhow::{Context, Result, bail};
+use fs2::FileExt;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant},
+};
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Preconditions {
+    /// SHA-256 of the previous complete file, or "missing" for create-only.
+    pub sha256: Option<String>,
+    pub offset: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FileState {
+    pub exists: bool,
+    pub bytes: u64,
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct WriteReceipt {
+    pub path: String,
+    pub previous: FileState,
+    pub current: FileState,
+    pub replayed: bool,
+}
+
+pub(crate) fn digest(bytes: &[u8]) -> String {
+    crate::hex::lower_hex(Sha256::digest(bytes))
+}
+
+pub(crate) fn state(path: &Path) -> Result<FileState> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(FileState {
+                exists: false,
+                bytes: 0,
+                sha256: None,
+            });
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if !file.metadata()?.is_file() {
+        bail!("Target is not a regular file");
+    }
+    let initial_len = file.metadata()?.len();
+    let mut file = file.take(initial_len.saturating_add(1));
+    let mut hash = Sha256::new();
+    let mut buffer = vec![0; 65536];
+    let mut bytes = 0_u64;
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hash.update(&buffer[..count]);
+        bytes += count as u64;
+    }
+    if bytes != initial_len {
+        bail!("File changed while computing its version");
+    }
+    Ok(FileState {
+        exists: true,
+        bytes,
+        sha256: Some(crate::hex::lower_hex(hash.finalize())),
+    })
+}
+
+fn resolved(path: &Path) -> Result<PathBuf> {
+    if fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink()) && !path.exists() {
+        bail!("Atomic writes reject dangling symlinks");
+    }
+    if path.exists() {
+        return fs::canonicalize(path).context("resolve atomic target");
+    }
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    Ok(fs::canonicalize(parent)?.join(path.file_name().context("file name required")?))
+}
+
+pub(crate) fn stripe(path: &Path) -> usize {
+    let path = path.to_string_lossy();
+    let key = if cfg!(windows) {
+        path.to_lowercase()
+    } else {
+        path.into_owned()
+    };
+    usize::from(Sha256::digest(key.as_bytes())[0])
+}
+
+// Exactly 256 persistent lock files; never unlink a lock held by another process.
+fn lock(path: &Path) -> Result<File> {
+    let root = std::env::temp_dir().join("devbox-atomic-locks-v1");
+    fs::create_dir_all(&root)?;
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(false).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options.open(root.join(format!("{}.lock", stripe(path))))?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => break,
+            Err(error)
+                if error.kind() == std::io::ErrorKind::WouldBlock
+                    || error.raw_os_error().is_some_and(|code| {
+                        Some(code) == fs2::lock_contended_error().raw_os_error()
+                    }) => {}
+            Err(error) => return Err(error.into()),
+        }
+        if Instant::now() >= deadline {
+            bail!("Atomic file lock deadline exceeded");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Ok(file)
+}
+
+pub(crate) async fn blocking<T: Send + 'static>(
+    operation: impl FnOnce() -> Result<T> + Send + 'static,
+) -> Result<T> {
+    static WORKERS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
+    let permit = tokio::time::timeout(
+        Duration::from_secs(5),
+        WORKERS
+            .get_or_init(|| Arc::new(tokio::sync::Semaphore::new(2)))
+            .clone()
+            .acquire_owned(),
+    )
+    .await
+    .context("Atomic I/O capacity wait timed out")??;
+    // The worker owns the permit even if its HTTP caller disconnects.
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        operation()
+    })
+    .await
+    .context("join atomic I/O")?
+}
+
+pub(crate) async fn write(
+    path: PathBuf,
+    payload: Vec<u8>,
+    append: bool,
+    create_dirs: bool,
+    expected: Preconditions,
+) -> Result<WriteReceipt> {
+    blocking(move || write_sync(&path, &payload, append, create_dirs, &expected)).await
+}
+
+pub(crate) fn write_sync(
+    path: &Path,
+    payload: &[u8],
+    append: bool,
+    create_dirs: bool,
+    expected: &Preconditions,
+) -> Result<WriteReceipt> {
+    if create_dirs && let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let target = resolved(path)?;
+    let _lock = lock(&target)?;
+    let previous = state(&target)?;
+    if let Some(expected_hash) = &expected.sha256 {
+        if expected_hash != "missing"
+            && (expected_hash.len() != 64 || !expected_hash.bytes().all(|c| c.is_ascii_hexdigit()))
+        {
+            bail!("expected_file_sha256 must be a SHA-256 digest or missing");
+        }
+        let matches = if expected_hash == "missing" {
+            !previous.exists
+        } else {
+            previous.sha256.as_deref() == Some(expected_hash.to_ascii_lowercase().as_str())
+        };
+        if !(matches || append && append_replayed(&target, payload, expected)?) {
+            // An identical overwrite already fulfils the requested state after a lost response.
+            if !append && previous.sha256.as_deref() == Some(digest(payload).as_str()) {
+                return Ok(WriteReceipt {
+                    path: path.to_string_lossy().into_owned(),
+                    current: previous.clone(),
+                    previous,
+                    replayed: true,
+                });
+            }
+            bail!("File version conflict: current content differs from expected_file_sha256");
+        }
+        if !matches {
+            return Ok(WriteReceipt {
+                path: path.to_string_lossy().into_owned(),
+                current: previous.clone(),
+                previous,
+                replayed: true,
+            });
+        }
+    }
+    if let Some(offset) = expected.offset {
+        if !append {
+            bail!("expected_offset_bytes requires append=true");
+        }
+        if previous.bytes != offset {
+            if append_replayed(&target, payload, expected)? {
+                return Ok(WriteReceipt {
+                    path: path.to_string_lossy().into_owned(),
+                    current: previous.clone(),
+                    previous,
+                    replayed: true,
+                });
+            }
+            bail!("File offset conflict: append was not applied");
+        }
+    }
+    let metadata = fs::metadata(&target).ok();
+    #[cfg(windows)]
+    if previous.exists {
+        reject_windows_hard_links(&target)?;
+    }
+    if let Some(metadata) = &metadata
+        && metadata.permissions().readonly()
+    {
+        bail!("Target is read-only");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.nlink() > 1 {
+            bail!("Atomic replacement of a hard-linked target is unsupported");
+        }
+    }
+    let staged = tempfile::Builder::new()
+        .prefix(".devbox-write-")
+        .tempfile_in(target.parent().context("target parent")?)?;
+    let (mut file, staged_path) = staged.into_parts();
+    if append && previous.exists {
+        std::io::copy(&mut File::open(&target)?.take(previous.bytes), &mut file)?;
+    }
+    file.write_all(payload)?;
+    if let Some(metadata) = metadata {
+        file.set_permissions(metadata.permissions())?;
+    }
+    file.sync_all()?;
+    drop(file);
+    let current = state(&staged_path)?;
+    // Detect non-cooperating writers during staging; cooperative writers hold the OS lock.
+    let before_commit = state(&target)?;
+    if before_commit.sha256 != previous.sha256 {
+        bail!("File changed while preparing atomic replacement");
+    }
+    replace(&staged_path, &target)?;
+    #[cfg(unix)]
+    {
+        File::open(target.parent().context("target parent")?)?.sync_all()?;
+    }
+    Ok(WriteReceipt {
+        path: path.to_string_lossy().into_owned(),
+        previous,
+        current,
+        replayed: false,
+    })
+}
+
+fn append_replayed(path: &Path, payload: &[u8], expected: &Preconditions) -> Result<bool> {
+    use std::io::{Seek, SeekFrom};
+    let Some(offset) = expected.offset else {
+        return Ok(false);
+    };
+    let Ok(mut file) = File::open(path) else {
+        return Ok(false);
+    };
+    if file.metadata()?.len() != offset.saturating_add(payload.len() as u64) {
+        return Ok(false);
+    }
+    if let Some(hash) = &expected.sha256 {
+        if hash == "missing" {
+            if offset != 0 {
+                return Ok(false);
+            }
+        } else {
+            let mut prefix = Sha256::new();
+            let mut remaining = offset;
+            let mut buffer = vec![0; 65536];
+            while remaining > 0 {
+                let limit = usize::try_from(remaining.min(65536))?;
+                let count = file.read(&mut buffer[..limit])?;
+                if count == 0 {
+                    return Ok(false);
+                }
+                prefix.update(&buffer[..count]);
+                remaining -= count as u64;
+            }
+            if crate::hex::lower_hex(prefix.finalize()) != hash.to_ascii_lowercase() {
+                return Ok(false);
+            }
+        }
+    }
+    file.seek(SeekFrom::Start(offset))?;
+    let mut suffix = Vec::new();
+    file.take(payload.len() as u64 + 1)
+        .read_to_end(&mut suffix)?;
+    Ok(suffix == payload)
+}
+
+#[cfg(not(windows))]
+fn replace(source: &Path, target: &Path) -> Result<()> {
+    fs::rename(source, target).context("atomic file replacement")
+}
+
+#[cfg(windows)]
+#[allow(
+    unsafe_code,
+    reason = "native file information checks hard-link count before replacement"
+)]
+fn reject_windows_hard_links(path: &Path) -> Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+    let file = File::open(path)?;
+    let mut info = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::zeroed();
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle(), info.as_mut_ptr()) } == 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    if unsafe { info.assume_init() }.nNumberOfLinks > 1 {
+        bail!("Atomic replacement of a hard-linked target is unsupported");
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+#[allow(
+    unsafe_code,
+    reason = "ReplaceFileW preserves the destination ACL while replacing atomically"
+)]
+fn replace(source: &Path, target: &Path) -> Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::{
+        Foundation::GetLastError,
+        Storage::FileSystem::{MOVEFILE_WRITE_THROUGH, MoveFileExW, ReplaceFileW},
+    };
+    let source: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
+    let target_wide: Vec<u16> = target.as_os_str().encode_wide().chain(Some(0)).collect();
+    let success = if target.exists() {
+        unsafe {
+            ReplaceFileW(
+                target_wide.as_ptr(),
+                source.as_ptr(),
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        }
+    } else {
+        unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                target_wide.as_ptr(),
+                MOVEFILE_WRITE_THROUGH,
+            )
+        }
+    };
+    if success == 0 {
+        return Err(std::io::Error::from_raw_os_error(
+            i32::try_from(unsafe { GetLastError() }).unwrap_or(i32::MAX),
+        )
+        .into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn failed_commit_after_staging_keeps_the_previous_file() {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_READ, FILE_SHARE_WRITE};
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("checkpoint");
+        fs::write(&path, b"old checkpoint").unwrap();
+        let blocker = OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .open(&path)
+            .unwrap();
+        let error = write(
+            path.clone(),
+            vec![b'x'; 1024 * 1024],
+            false,
+            false,
+            Preconditions::default(),
+        )
+        .await
+        .unwrap_err();
+        assert!(!error.to_string().is_empty());
+        assert_eq!(fs::read(&path).unwrap(), b"old checkpoint");
+        assert_eq!(
+            fs::read_dir(root.path()).unwrap().count(),
+            1,
+            "failed staging must not strand a temporary file"
+        );
+        drop(blocker);
+        write(
+            path.clone(),
+            b"new checkpoint".to_vec(),
+            false,
+            false,
+            Preconditions::default(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(fs::read(path).unwrap(), b"new checkpoint");
+    }
+
+    #[tokio::test]
+    async fn hard_link_aliases_are_preserved_on_rejected_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("original");
+        let alias = dir.path().join("alias");
+        fs::write(&path, b"original").unwrap();
+        fs::hard_link(&path, &alias).unwrap();
+        let error = write(
+            path.clone(),
+            b"new".to_vec(),
+            false,
+            false,
+            Preconditions::default(),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("hard-linked"));
+        assert_eq!(fs::read(&path).unwrap(), b"original");
+        assert_eq!(fs::read(&alias).unwrap(), b"original");
+    }
+    #[tokio::test]
+    async fn replacement_and_append_retries_preserve_exact_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("checkpoint");
+        let create = Preconditions {
+            sha256: Some("missing".into()),
+            offset: None,
+        };
+        write(path.clone(), b"old".to_vec(), false, false, create.clone())
+            .await
+            .unwrap();
+        assert!(
+            write(path.clone(), b"different".to_vec(), false, false, create)
+                .await
+                .is_err()
+        );
+        assert_eq!(fs::read(&path).unwrap(), b"old");
+        let expected = Preconditions {
+            sha256: Some(digest(b"old")),
+            offset: Some(3),
+        };
+        let first = write(path.clone(), b"new".to_vec(), true, false, expected.clone())
+            .await
+            .unwrap();
+        assert!(!first.replayed);
+        assert!(
+            write(path.clone(), b"new".to_vec(), true, false, expected)
+                .await
+                .unwrap()
+                .replayed
+        );
+        assert_eq!(fs::read(&path).unwrap(), b"oldnew");
+    }
+    #[tokio::test]
+    async fn concurrent_compare_and_swap_has_one_winner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("checkpoint");
+        fs::write(&path, b"old").unwrap();
+        let expected = Preconditions {
+            sha256: Some(digest(b"old")),
+            offset: None,
+        };
+        let (a, b) = tokio::join!(
+            write(
+                path.clone(),
+                b"first".to_vec(),
+                false,
+                false,
+                expected.clone()
+            ),
+            write(path.clone(), b"second".to_vec(), false, false, expected)
+        );
+        assert_ne!(a.is_ok(), b.is_ok());
+        let bytes = fs::read(path).unwrap();
+        assert!(bytes == b"first" || bytes == b"second");
+    }
+}

--- a/rust-mcp/src/config.rs
+++ b/rust-mcp/src/config.rs
@@ -205,6 +205,9 @@ pub struct Config {
     pub job_retention_hours: u64,
     pub job_store_max_bytes: u64,
     pub job_store_max_terminal_jobs: usize,
+    pub job_max_active: usize,
+    pub job_max_per_task: usize,
+    pub job_max_operations: usize,
     pub screen_capture_attempt_timeout_ms: u64,
     pub screen_capture_retries: usize,
     pub screen_capture_queue_timeout_ms: u64,
@@ -240,6 +243,10 @@ impl Config {
     ///
     /// # Errors
     /// Returns an error when the project root cannot be found or runtime/auth values are invalid.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "explicit configuration-to-field mapping kept together for review"
+    )]
     pub fn load() -> Result<Self> {
         let project_root = discover_project_root()?;
         load_env_layers(&project_root);
@@ -335,6 +342,10 @@ impl Config {
             job_retention_hours: parse_env("MCP_JOB_RETENTION_HOURS", 168_u64),
             job_store_max_bytes: parse_env("MCP_JOB_STORE_MAX_BYTES", 2_u64 * 1024 * 1024 * 1024),
             job_store_max_terminal_jobs: parse_env("MCP_JOB_STORE_MAX_TERMINAL_JOBS", 5_000_usize),
+            job_max_active: parse_env("MCP_JOB_MAX_ACTIVE_RUNNERS", 16_usize).clamp(1, 128),
+            job_max_per_task: parse_env("MCP_JOB_MAX_RUNNERS_PER_TASK", 8_usize).clamp(1, 128),
+            job_max_operations: parse_env("MCP_JOB_MAX_OPERATION_RECEIPTS", 10_000_usize)
+                .clamp(1, 100_000),
             screen_capture_attempt_timeout_ms: screen_capture.attempt_timeout_ms,
             screen_capture_retries: screen_capture.retries,
             screen_capture_queue_timeout_ms: screen_capture.queue_timeout_ms,
@@ -944,6 +955,9 @@ pub(crate) fn test_config(root: &Path) -> Config {
         job_retention_hours: 168,
         job_store_max_bytes: 2 * 1024 * 1024 * 1024,
         job_store_max_terminal_jobs: 5_000,
+        job_max_active: 16,
+        job_max_per_task: 8,
+        job_max_operations: 10_000,
         screen_capture_attempt_timeout_ms: 8_000,
         screen_capture_retries: 1,
         screen_capture_queue_timeout_ms: 5_000,

--- a/rust-mcp/src/contract.rs
+++ b/rust-mcp/src/contract.rs
@@ -1,5 +1,16 @@
 use serde::Serialize;
 
+pub const AGENT_TOOL_NAMES: &[&str] = &[
+    "devbox_file_state",
+    "devbox_write_file_atomic",
+    "devbox_job_submit",
+    "devbox_job_list",
+    "devbox_task_get",
+    "devbox_task_put",
+    "devbox_task_list",
+    "devbox_capabilities",
+];
+
 pub const TARGET_TOOL_NAMES: &[&str] = &[
     "devbox_github_auth_status",
     "devbox_sync_github_auth_from_host",
@@ -82,6 +93,8 @@ pub const IMPLEMENTED_TOOL_NAMES: &[&str] = &[
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ParityReport {
+    pub contract_version: u32,
+    pub native_tools: Vec<&'static str>,
     pub target_count: usize,
     pub implemented_count: usize,
     pub missing_count: usize,
@@ -100,6 +113,8 @@ impl ParityReport {
             .collect::<Vec<_>>();
         let complete = missing.is_empty();
         Self {
+            contract_version: 2,
+            native_tools: AGENT_TOOL_NAMES.to_vec(),
             target_count: TARGET_TOOL_NAMES.len(),
             implemented_count: IMPLEMENTED_TOOL_NAMES.len(),
             missing_count: missing.len(),

--- a/rust-mcp/src/execution.rs
+++ b/rust-mcp/src/execution.rs
@@ -1829,6 +1829,53 @@ pub(crate) async fn process_alive(_: u32) -> bool {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn five_heavy_slots_preserve_the_sixth_interactive_slot() {
+        let root = tempfile::tempdir().unwrap();
+        let mut scheduler = scheduler(root.path(), 6, 1, 4);
+        scheduler.config.heavy_capacity = 5;
+        scheduler.config.heavy_weight = 1;
+        let cancellation = CancellationToken::new();
+        let mut leases = Vec::new();
+        for index in 0..5 {
+            leases.push(
+                scheduler
+                    .acquire(
+                        AcquireRequest::background(
+                            format!("heavy-{index}"),
+                            ResourceClass::Heavy,
+                            1,
+                        ),
+                        &cancellation,
+                    )
+                    .await
+                    .unwrap(),
+            );
+        }
+        assert_eq!(scheduler.snapshot().await.unwrap().occupied, 5);
+        assert!(
+            scheduler
+                .acquire(
+                    AcquireRequest {
+                        queue_timeout: Some(Duration::from_millis(80)),
+                        ..AcquireRequest::background("blocked", ResourceClass::Heavy, 1)
+                    },
+                    &cancellation
+                )
+                .await
+                .is_err()
+        );
+        let mut interactive = scheduler
+            .acquire(AcquireRequest::interactive("reserved"), &cancellation)
+            .await
+            .unwrap();
+        assert_eq!(interactive.slot, Some(5));
+        interactive.release().await.unwrap();
+        for mut lease in leases {
+            lease.release().await.unwrap();
+        }
+    }
+
     fn scheduler(root: &Path, max: usize, reserved: usize, watch: usize) -> ExecutionScheduler {
         ExecutionScheduler::new(SchedulerConfig {
             root: root.to_path_buf(),

--- a/rust-mcp/src/files.rs
+++ b/rust-mcp/src/files.rs
@@ -1,7 +1,7 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     path::{Component, Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -10,8 +10,8 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::{
-    fs::{self, File, OpenOptions},
-    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom},
+    fs::{self, File},
+    io::{AsyncReadExt, AsyncSeekExt, SeekFrom},
     sync::RwLock,
 };
 use tokio_util::sync::CancellationToken;
@@ -74,9 +74,17 @@ pub struct ListOptions {
     pub exclude_directories: Vec<String>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct FileService {
-    locks: Mutex<HashMap<PathBuf, Arc<RwLock<()>>>>,
+    locks: Vec<Arc<RwLock<()>>>,
+}
+
+impl Default for FileService {
+    fn default() -> Self {
+        Self {
+            locks: (0..256).map(|_| Arc::new(RwLock::new(()))).collect(),
+        }
+    }
 }
 
 impl FileService {
@@ -127,22 +135,14 @@ impl FileService {
     ) -> Result<ProcessResult> {
         let lock = self.lock_for(path);
         let _guard = lock.write().await;
-        ensure_parent(path, create_dirs).await?;
-        let mut options = OpenOptions::new();
-        options.write(true).create(true);
-        if append {
-            options.append(true);
-        } else {
-            options.truncate(true);
-        }
-        let mut file = options
-            .open(path)
-            .await
-            .with_context(|| format!("open {} for writing", path.display()))?;
-        file.write_all(content.as_bytes())
-            .await
-            .with_context(|| format!("write {}", path.display()))?;
-        file.flush().await.context("flush text write")?;
+        crate::atomic_file::write(
+            path.to_path_buf(),
+            content.as_bytes().to_vec(),
+            append,
+            create_dirs,
+            crate::atomic_file::Preconditions::default(),
+        )
+        .await?;
         Ok(ProcessResult::success(String::new(), String::new()))
     }
 
@@ -158,9 +158,10 @@ impl FileService {
     ) -> Result<LargeReadResult> {
         let lock = self.lock_for(path);
         let _guard = lock.read().await;
-        let metadata = fs::metadata(path)
+        let mut file = File::open(path)
             .await
             .map_err(|error| anyhow::anyhow!(javascript_stat_error(path, &error)))?;
+        let metadata = file.metadata().await?;
         if !metadata.is_file() {
             bail!("Not a regular file.");
         }
@@ -171,9 +172,6 @@ impl FileService {
         let bytes_to_read =
             usize::try_from(remaining.min(bytes_requested)).unwrap_or(max_bytes.max(1));
 
-        let mut file = File::open(path)
-            .await
-            .with_context(|| format!("open {} for reading", path.display()))?;
         file.seek(SeekFrom::Start(actual_offset))
             .await
             .context("seek large read")?;
@@ -237,24 +235,14 @@ impl FileService {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => (false, 0),
             Err(error) => return Err(error).with_context(|| format!("inspect {}", path.display())),
         };
-        ensure_parent(path, create_dirs).await?;
-
-        let mut options = OpenOptions::new();
-        options.write(true).create(true);
-        if append {
-            options.append(true);
-        } else {
-            options.truncate(true);
-        }
-        let mut file = options
-            .open(path)
-            .await
-            .with_context(|| format!("open {} for exact write", path.display()))?;
-        file.write_all(&payload)
-            .await
-            .context("write exact payload")?;
-        file.flush().await.context("flush exact payload")?;
-        drop(file);
+        crate::atomic_file::write(
+            path.to_path_buf(),
+            payload.clone(),
+            append,
+            create_dirs,
+            crate::atomic_file::Preconditions::default(),
+        )
+        .await?;
 
         let final_metadata = fs::metadata(path)
             .await
@@ -393,14 +381,7 @@ impl FileService {
 
     fn lock_for(&self, path: &Path) -> Arc<RwLock<()>> {
         let key = absolute_lexical_path(path);
-        let mut locks = self
-            .locks
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        locks
-            .entry(key)
-            .or_insert_with(|| Arc::new(RwLock::new(())))
-            .clone()
+        self.locks[crate::atomic_file::stripe(&key)].clone()
     }
 }
 
@@ -494,18 +475,6 @@ fn javascript_open_error(path: &Path, error: &std::io::Error) -> String {
     }
 }
 
-async fn ensure_parent(path: &Path, create_dirs: bool) -> Result<()> {
-    if create_dirs
-        && let Some(parent) = path.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        fs::create_dir_all(parent)
-            .await
-            .with_context(|| format!("create parent directory {}", parent.display()))?;
-    }
-    Ok(())
-}
-
 fn normalize_expected_sha256(value: Option<&str>) -> Result<Option<String>> {
     let Some(raw) = value.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok(None);
@@ -577,6 +546,21 @@ fn is_skippable_fs_error(error: &std::io::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unique_paths_do_not_grow_the_lock_registry() {
+        let files = FileService::new();
+        for index in 0..10000 {
+            let _lock = files.lock_for(Path::new(&format!("fixture-{index}")));
+        }
+        assert_eq!(files.locks.len(), 256);
+        let first = files.lock_for(Path::new("same"));
+        let second = files.lock_for(Path::new("same"));
+        let guard = first.try_write().unwrap();
+        assert!(second.try_write().is_err());
+        drop(guard);
+        assert!(second.try_write().is_ok());
+    }
 
     #[tokio::test]
     async fn large_read_pages_exact_bytes_and_clamps_eof() {

--- a/rust-mcp/src/host_inspect.rs
+++ b/rust-mcp/src/host_inspect.rs
@@ -313,21 +313,22 @@ async fn inspect_powershell_syntax(
     let command = format!(
         "$tokens=$null;$errors=$null;[System.Management.Automation.Language.Parser]::ParseFile('{escaped}',[ref]$tokens,[ref]$errors)|Out-Null;$r=@{{parse_ok=(@($errors).Count -eq 0);error_count=@($errors).Count;errors=@(@($errors)|Select-Object -First 8|ForEach-Object {{ @{{message=$_.Message;line=$_.Extent.StartLineNumber;column=$_.Extent.StartColumnNumber;text=$_.Extent.Text}} }})}};[Console]::Out.Write(($r|ConvertTo-Json -Compress -Depth 6))"
     );
-    match runtime
-        .run_host_shell_only(
-            ShellRequest {
-                command,
-                working_dir: working_dir.to_path_buf(),
-                timeout: Duration::from_secs(15),
-                user: String::new(),
-                max_capture_chars: Some(65_536),
-                output_tx: None,
-                pid_tx: None,
-            },
-            cancellation,
-        )
-        .await
-    {
+    let request = ShellRequest {
+        command,
+        working_dir: working_dir.to_path_buf(),
+        timeout: Duration::from_secs(15),
+        user: String::new(),
+        max_capture_chars: Some(65_536),
+        output_tx: None,
+        pid_tx: None,
+    };
+    #[cfg(windows)]
+    let output = runtime
+        .run_windows_inspection_shell(request, cancellation)
+        .await;
+    #[cfg(not(windows))]
+    let output = runtime.run_host_shell_only(request, cancellation).await;
+    match output {
         Ok(output) => serde_json::from_str(output.stdout.trim()).unwrap_or_else(|error| {
             syntax_failure(&format!("PowerShell parser returned invalid JSON: {error}"))
         }),
@@ -451,6 +452,30 @@ fn push_string(value: &mut Value, field: &str, message: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn powershell_inspection_uses_parser_without_elevation_or_configured_cmd_shell() {
+        let root = tempfile::tempdir().unwrap();
+        let config = crate::config::test_config(root.path());
+        assert_eq!(config.host_shell, "cmd.exe");
+        let runtime = Arc::new(RuntimeExecutor::new(Arc::new(config)));
+        let path = root.path().join("fixture.ps1");
+        fs::write(&path, "Write-Output 'valid'\n").await.unwrap();
+        let valid = inspect_powershell_syntax(
+            runtime.clone(),
+            &path,
+            root.path(),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(valid["parse_ok"], true, "{valid}");
+        fs::write(&path, "function Broken {\n").await.unwrap();
+        let invalid =
+            inspect_powershell_syntax(runtime, &path, root.path(), CancellationToken::new()).await;
+        assert_eq!(invalid["parse_ok"], false, "{invalid}");
+        assert!(invalid["error_count"].as_u64().unwrap() > 0);
+    }
 
     #[test]
     fn detects_bom_binary_magic_and_line_endings() {

--- a/rust-mcp/src/job_control.rs
+++ b/rust-mcp/src/job_control.rs
@@ -129,7 +129,7 @@ pub(crate) async fn list(
         }) {
             continue;
         }
-        let mut status = store.get_status(&id).await?;
+        let status = store.get_status(&id).await?;
         if !status_filter.is_empty()
             && !status_filter
                 .iter()
@@ -141,10 +141,24 @@ pub(crate) async fn list(
             next_cursor = jobs.last().and_then(|v: &Value| v.get("id")).cloned();
             break;
         }
-        if let Some(agent) = request.get("agent") {
-            status["agent"] = agent.clone();
+        let mut summary = json!({});
+        for key in [
+            "id",
+            "status",
+            "createdAtUtc",
+            "startedAtUtc",
+            "completedAtUtc",
+            "exitCode",
+            "runnerAlive",
+        ] {
+            if let Some(value) = status.get(key) {
+                summary[key] = value.clone();
+            }
         }
-        jobs.push(status);
+        if let Some(agent) = request.get("agent") {
+            summary["agent"] = agent.clone();
+        }
+        jobs.push(summary);
     }
     Ok(json!({"jobs": jobs, "next_cursor": next_cursor, "order": "job_id", "limit": limit}))
 }

--- a/rust-mcp/src/job_control.rs
+++ b/rust-mcp/src/job_control.rs
@@ -1,0 +1,215 @@
+//! Durable submission identity, admission and bounded discovery for the Rust runtime.
+use crate::{Config, atomic_file, jobs::JobStore};
+use anyhow::{Context, Result, bail};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    fs::OpenOptions,
+    path::Path,
+    time::{Duration, Instant},
+};
+use tokio::{fs, io::AsyncReadExt};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Submission {
+    pub task_id: String,
+    pub operation_id: String,
+    pub label: String,
+}
+
+pub(crate) fn validate_key(value: &str) -> Result<()> {
+    if value.is_empty()
+        || value.len() > 80
+        || !value
+            .bytes()
+            .all(|c| (c.is_ascii_lowercase() || c.is_ascii_digit()) || matches!(c, b'-' | b'_'))
+    {
+        bail!(
+            "Task/operation IDs must be 1-80 lowercase ASCII letters, digits, hyphens or underscores"
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn terminal(value: &Value) -> bool {
+    matches!(
+        value.get("status").and_then(Value::as_str),
+        Some("succeeded" | "failed" | "cancelled" | "timed_out" | "interrupted")
+    )
+}
+
+pub(crate) async fn gate(root: &Path) -> Result<std::fs::File> {
+    fs::create_dir_all(root).await?;
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(root.join(".submission.lock"))?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(file),
+            Err(error)
+                if error.kind() == std::io::ErrorKind::WouldBlock
+                    || error.raw_os_error().is_some_and(|code| {
+                        Some(code) == fs2::lock_contended_error().raw_os_error()
+                    }) => {}
+            Err(error) => return Err(error.into()),
+        }
+        if Instant::now() >= deadline {
+            bail!("SUBMISSION_BUSY: retry with the same operation ID");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+pub(crate) async fn ids(root: &Path) -> Result<Vec<String>> {
+    let mut reader = match fs::read_dir(root).await {
+        Ok(reader) => reader,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mut ids = Vec::new();
+    while let Some(entry) = reader.next_entry().await? {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with("job-") && entry.file_type().await?.is_dir() {
+            if ids.len() >= 10000 {
+                bail!(
+                    "Job store exceeds the bounded discovery budget; reconcile retention before submitting more work"
+                );
+            }
+            ids.push(name);
+        }
+    }
+    ids.sort();
+    Ok(ids)
+}
+
+pub(crate) async fn admit(store: &JobStore, config: &Config, task: Option<&str>) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    tokio::time::timeout_at(deadline, async {
+        let mut active = 0; let mut task_active = 0;
+        for id in ids(&config.jobs_root).await? {
+            let status = store.get_status(&id).await.context("admission requires readable job state")?;
+            if !terminal(&status) {
+                active += 1;
+                if let Some(task) = task { let request = store.read_request(&id).await?; if request.pointer("/agent/taskId").and_then(Value::as_str) == Some(task) { task_active += 1; } }
+            }
+            if active >= config.job_max_active || task.is_some() && task_active >= config.job_max_per_task { bail!("JOB_CAPACITY: active or queued runner limit reached; retry the same operation after a job completes"); }
+        }
+        Ok(())
+    }).await.context("Job admission inspection exceeded its deadline")?
+}
+
+pub(crate) async fn list(
+    store: &JobStore,
+    task: Option<&str>,
+    status_filter: &[String],
+    cursor: Option<&str>,
+    limit: usize,
+) -> Result<Value> {
+    if let Some(task) = task {
+        validate_key(task)?;
+    }
+    if !(1..=100).contains(&limit) {
+        bail!("limit must be between 1 and 100");
+    }
+    let mut jobs = Vec::new();
+    let mut next_cursor = None;
+    for id in ids(&store.config().root).await? {
+        if cursor.is_some_and(|cursor| id.as_str() <= cursor) {
+            continue;
+        }
+        let request = store.read_request(&id).await?;
+        if task.is_some_and(|task| {
+            request.pointer("/agent/taskId").and_then(Value::as_str) != Some(task)
+        }) {
+            continue;
+        }
+        let mut status = store.get_status(&id).await?;
+        if !status_filter.is_empty()
+            && !status_filter
+                .iter()
+                .any(|filter| status.get("status").and_then(Value::as_str) == Some(filter))
+        {
+            continue;
+        }
+        if jobs.len() == limit {
+            next_cursor = jobs.last().and_then(|v: &Value| v.get("id")).cloned();
+            break;
+        }
+        if let Some(agent) = request.get("agent") {
+            status["agent"] = agent.clone();
+        }
+        jobs.push(status);
+    }
+    Ok(json!({"jobs": jobs, "next_cursor": next_cursor, "order": "job_id", "limit": limit}))
+}
+
+pub(crate) async fn read_receipt(root: &Path, id: &str) -> Result<Option<Value>> {
+    match fs::File::open(root.join(".operations").join(format!("{id}.json"))).await {
+        Ok(file) => {
+            let mut bytes = Vec::new();
+            file.take(65537).read_to_end(&mut bytes).await?;
+            if bytes.len() > 65536 {
+                bail!("Operation receipt exceeds size limit");
+            }
+            Ok(Some(serde_json::from_slice(&bytes)?))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub(crate) async fn write_receipt(root: &Path, id: &str, value: &Value) -> Result<()> {
+    atomic_file::write(
+        root.join(".operations").join(format!("{id}.json")),
+        serde_json::to_vec(value)?,
+        false,
+        true,
+        atomic_file::Preconditions::default(),
+    )
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn check_receipt_capacity(config: &Config) -> Result<()> {
+    let mut reader = match fs::read_dir(config.jobs_root.join(".operations")).await {
+        Ok(reader) => reader,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e.into()),
+    };
+    let mut count = 0;
+    while reader.next_entry().await?.is_some() {
+        count += 1;
+        if count >= config.job_max_operations {
+            bail!(
+                "OPERATION_CAPACITY: durable operation receipts are full; archive the task records explicitly before accepting new operation IDs"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn global_and_task_admission_limits_reject_before_spawning() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = crate::config::test_config(root.path());
+        config.job_max_active = 2;
+        config.job_max_per_task = 1;
+        let store = JobStore::new(crate::job_manager::job_store_config(&config));
+        store.create_job("job-pending-fixture",&json!({"agent":{"taskId":"task-a"}}),&json!({"id":"job-pending-fixture","status":"queued","createdAtUtc":chrono::Utc::now().to_rfc3339()})).await.unwrap();
+        assert!(admit(&store, &config, Some("task-a")).await.is_err());
+        admit(&store, &config, Some("task-b")).await.unwrap();
+        config.job_max_active = 1;
+        assert!(admit(&store, &config, None).await.is_err());
+        let page = list(&store, Some("task-a"), &[], None, 1).await.unwrap();
+        assert_eq!(page["jobs"][0]["id"], "job-pending-fixture");
+    }
+}

--- a/rust-mcp/src/job_control.rs
+++ b/rust-mcp/src/job_control.rs
@@ -117,50 +117,53 @@ pub(crate) async fn list(
     if !(1..=100).contains(&limit) {
         bail!("limit must be between 1 and 100");
     }
-    let mut jobs = Vec::new();
-    let mut next_cursor = None;
-    for id in ids(&store.config().root).await? {
-        if cursor.is_some_and(|cursor| id.as_str() <= cursor) {
-            continue;
-        }
-        let request = store.read_request(&id).await?;
-        if task.is_some_and(|task| {
-            request.pointer("/agent/taskId").and_then(Value::as_str) != Some(task)
-        }) {
-            continue;
-        }
-        let status = store.get_status(&id).await?;
-        if !status_filter.is_empty()
-            && !status_filter
-                .iter()
-                .any(|filter| status.get("status").and_then(Value::as_str) == Some(filter))
-        {
-            continue;
-        }
-        if jobs.len() == limit {
-            next_cursor = jobs.last().and_then(|v: &Value| v.get("id")).cloned();
-            break;
-        }
-        let mut summary = json!({});
-        for key in [
-            "id",
-            "status",
-            "createdAtUtc",
-            "startedAtUtc",
-            "completedAtUtc",
-            "exitCode",
-            "runnerAlive",
-        ] {
-            if let Some(value) = status.get(key) {
-                summary[key] = value.clone();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let mut jobs = Vec::new();
+        let mut next_cursor = None;
+        for id in ids(&store.config().root).await? {
+            if cursor.is_some_and(|cursor| id.as_str() <= cursor) {
+                continue;
             }
+            let request = store.read_request(&id).await?;
+            if task.is_some_and(|task| {
+                request.pointer("/agent/taskId").and_then(Value::as_str) != Some(task)
+            }) {
+                continue;
+            }
+            let status = store.get_status(&id).await?;
+            if !status_filter.is_empty()
+                && !status_filter
+                    .iter()
+                    .any(|filter| status.get("status").and_then(Value::as_str) == Some(filter))
+            {
+                continue;
+            }
+            if jobs.len() == limit {
+                next_cursor = jobs.last().and_then(|v: &Value| v.get("id")).cloned();
+                break;
+            }
+            let mut summary = json!({"id": id});
+            for key in [
+                "status",
+                "createdAtUtc",
+                "startedAtUtc",
+                "completedAtUtc",
+                "exitCode",
+                "runnerAlive",
+            ] {
+                if let Some(value) = status.get(key) {
+                    summary[key] = value.clone();
+                }
+            }
+            if let Some(agent) = request.get("agent") {
+                summary["agent"] = agent.clone();
+            }
+            jobs.push(summary);
         }
-        if let Some(agent) = request.get("agent") {
-            summary["agent"] = agent.clone();
-        }
-        jobs.push(summary);
-    }
-    Ok(json!({"jobs": jobs, "next_cursor": next_cursor, "order": "job_id", "limit": limit}))
+        Ok(json!({"jobs": jobs, "next_cursor": next_cursor, "order": "job_id", "limit": limit}))
+    })
+    .await
+    .context("Job discovery exceeded its five-second deadline")?
 }
 
 pub(crate) async fn read_receipt(root: &Path, id: &str) -> Result<Option<Value>> {
@@ -225,5 +228,26 @@ mod tests {
         assert!(admit(&store, &config, None).await.is_err());
         let page = list(&store, Some("task-a"), &[], None, 1).await.unwrap();
         assert_eq!(page["jobs"][0]["id"], "job-pending-fixture");
+    }
+
+    #[tokio::test]
+    async fn discovery_uses_directory_identity_when_journal_omits_id() {
+        let root = tempfile::tempdir().unwrap();
+        let config = crate::config::test_config(root.path());
+        let store = JobStore::new(crate::job_manager::job_store_config(&config));
+        for id in ["job-directory-a", "job-directory-b"] {
+            store
+                .create_job(id, &json!({}), &json!({"status":"succeeded"}))
+                .await
+                .unwrap();
+        }
+        let first = list(&store, None, &[], None, 1).await.unwrap();
+        assert_eq!(first["jobs"][0]["id"], "job-directory-a");
+        assert_eq!(first["next_cursor"], "job-directory-a");
+        let second = list(&store, None, &[], first["next_cursor"].as_str(), 1)
+            .await
+            .unwrap();
+        assert_eq!(second["jobs"][0]["id"], "job-directory-b");
+        assert!(second["next_cursor"].is_null());
     }
 }

--- a/rust-mcp/src/job_manager.rs
+++ b/rust-mcp/src/job_manager.rs
@@ -171,6 +171,16 @@ impl JobManager {
     }
 
     async fn persist_and_spawn(&self, request: JobRequest) -> Result<JobStartSummary> {
+        let _gate = crate::job_control::gate(&self.config.jobs_root).await?;
+        crate::job_control::admit(&self.store, &self.config, None).await?;
+        self.persist_and_spawn_unlocked(request, None).await
+    }
+
+    async fn persist_and_spawn_unlocked(
+        &self,
+        request: JobRequest,
+        agent: Option<&crate::job_control::Submission>,
+    ) -> Result<JobStartSummary> {
         let initial = json!({
             "id": request.id,
             "status": "queued",
@@ -184,7 +194,10 @@ impl JobManager {
             "resourceClass": request.resource_class.as_str(),
             "runtimeMode": request.runtime_mode,
         });
-        let request_value = serde_json::to_value(&request)?;
+        let mut request_value = serde_json::to_value(&request)?;
+        if let Some(agent) = agent {
+            request_value["agent"] = serde_json::to_value(agent)?;
+        }
         let paths = self
             .store
             .create_job(&request.id, &request_value, &initial)
@@ -220,6 +233,9 @@ impl JobManager {
         })
     }
 }
+
+#[path = "job_manager_agent.rs"]
+mod agent;
 
 #[must_use]
 pub fn job_store_config(config: &Config) -> JobStoreConfig {

--- a/rust-mcp/src/job_manager_agent.rs
+++ b/rust-mcp/src/job_manager_agent.rs
@@ -1,0 +1,92 @@
+use super::{JobManager, JobRequest, Result, StartProgramJob, StartShellJob, json};
+use crate::{
+    atomic_file,
+    job_control::{self, Submission},
+};
+use serde_json::Value;
+
+impl JobManager {
+    pub(crate) async fn submit_program(
+        &self,
+        options: StartProgramJob,
+        agent: Submission,
+    ) -> Result<Value> {
+        self.submit_request(self.program_request(options), agent)
+            .await
+    }
+
+    pub(crate) async fn submit_shell(
+        &self,
+        options: StartShellJob,
+        agent: Submission,
+    ) -> Result<Value> {
+        self.submit_request(self.shell_request(options), agent)
+            .await
+    }
+
+    async fn submit_request(&self, mut request: JobRequest, agent: Submission) -> Result<Value> {
+        job_control::validate_key(&agent.task_id)?;
+        job_control::validate_key(&agent.operation_id)?;
+        if agent.label.len() > 200 {
+            anyhow::bail!("label exceeds 200 bytes");
+        }
+        let key = serde_json::to_vec(&(&agent.task_id, &agent.operation_id))?;
+        request.id = format!("job-op-{}", atomic_file::digest(&key));
+        let mut value = serde_json::to_value(&request)?;
+        value
+            .as_object_mut()
+            .expect("serialized job object")
+            .remove("createdAtUtc");
+        value["agent"] = serde_json::to_value(&agent)?;
+        let fingerprint = atomic_file::digest(&serde_json::to_vec(&canonical(value))?);
+        let _gate = job_control::gate(&self.config.jobs_root).await?;
+        if let Some(receipt) =
+            job_control::read_receipt(&self.config.jobs_root, &request.id).await?
+        {
+            if receipt["fingerprint"] != fingerprint {
+                anyhow::bail!(
+                    "OPERATION_CONFLICT: operation ID already belongs to a different request"
+                );
+            }
+            let status = match self.store.get_status(&request.id).await {
+                Ok(value) => value,
+                Err(error) if self.store.paths(&request.id)?.dir.exists() => {
+                    return Err(error.context(
+                        "JOB_STATE_UNAVAILABLE: retained operation will not be executed again",
+                    ));
+                }
+                Err(_) => {
+                    json!({"id":request.id,"status":if receipt["submitted"]==true {"result_expired"} else {"submission_unknown"},"message":"Operation ID is retained and will not be executed again. Inspect the task before choosing a new operation ID."})
+                }
+            };
+            return Ok(json!({"id":request.id,"replayed":true,"agent":agent,"job":status}));
+        }
+        job_control::check_receipt_capacity(&self.config).await?;
+        job_control::admit(&self.store, &self.config, Some(&agent.task_id)).await?;
+        let mut receipt = json!({"id":request.id,"agent":agent,"fingerprint":fingerprint,"submitted":false,"createdAtUtc":request.created_at_utc});
+        job_control::write_receipt(&self.config.jobs_root, &request.id, &receipt).await?;
+        let id = request.id.clone();
+        let summary = self
+            .persist_and_spawn_unlocked(request, Some(&agent))
+            .await?;
+        receipt["submitted"] = json!(true);
+        job_control::write_receipt(&self.config.jobs_root, &id, &receipt).await?;
+        Ok(json!({"id":id,"replayed":false,"agent":agent,"job":summary}))
+    }
+}
+
+// Object field order must not change operation identity when code is refactored.
+fn canonical(value: Value) -> Value {
+    match value {
+        Value::Object(object) => Value::Object(
+            object
+                .into_iter()
+                .collect::<std::collections::BTreeMap<_, _>>()
+                .into_iter()
+                .map(|(key, value)| (key, canonical(value)))
+                .collect(),
+        ),
+        Value::Array(array) => Value::Array(array.into_iter().map(canonical).collect()),
+        value => value,
+    }
+}

--- a/rust-mcp/src/job_runner.rs
+++ b/rust-mcp/src/job_runner.rs
@@ -216,11 +216,7 @@ async fn prepare_runner(
     let store = JobStore::new(job_store_config(&config));
     validate_request_path(&store, &request, request_path).await?;
     let initial = store.read_status_raw(&request.id).await.ok();
-    let already_cancelled = initial
-        .as_ref()
-        .and_then(|value| value.get("status"))
-        .and_then(Value::as_str)
-        == Some("cancelled")
+    let already_cancelled = initial.as_ref().is_some_and(crate::job_control::terminal)
         || store.cancellation_requested(&request.id).await?;
     if already_cancelled {
         return Ok(None);

--- a/rust-mcp/src/jobs.rs
+++ b/rust-mcp/src/jobs.rs
@@ -1197,6 +1197,19 @@ impl JobStore {
             if status_name(&current) != "cancel_requested"
                 || tokio::time::Instant::now() >= deadline
             {
+                if status_name(&current) == "cancelled" && current["runnerAlive"] == false {
+                    // Keep the legacy acknowledgement snapshot, but only after the
+                    // authoritative status has verified runner/child termination.
+                    cancelled.insert("status".to_owned(), json!("cancelled"));
+                    cancelled.insert("runnerAlive".to_owned(), json!(false));
+                    cancelled.insert(
+                        "completedAtUtc".to_owned(),
+                        current["completedAtUtc"].clone(),
+                    );
+                    cancelled.remove("terminationPending");
+                    cancelled.remove("childAlive");
+                    return Ok(Value::Object(cancelled));
+                }
                 if let Some(age) = status.get("heartbeatAgeMs")
                     && let Some(object) = current.as_object_mut()
                 {

--- a/rust-mcp/src/jobs.rs
+++ b/rust-mcp/src/jobs.rs
@@ -325,12 +325,12 @@ impl JobStore {
             );
         };
         let status = string_field(&object, "status").unwrap_or_default();
-        if is_terminal(status) {
+        if is_terminal(status) && status != "cancelled" {
             decorate_status(&mut object, paths, false, None);
             return Ok(Value::Object(object));
         }
 
-        if marker_exists(&paths.cancel).await? {
+        if status == "cancelled" || marker_exists(&paths.cancel).await? {
             return self.reconcile_cancelled(paths, object).await;
         }
 
@@ -349,6 +349,19 @@ impl JobStore {
             (Some(_), true) => runner_owner_alive(&object).await,
             (None, _) => false,
         };
+        if !heartbeat_stale {
+            if let Some(pid) = heartbeat
+                .value
+                .as_ref()
+                .and_then(|value| value.get("childPid"))
+                .filter(|value| !value.is_null())
+            {
+                object.insert("childPid".to_owned(), pid.clone());
+            }
+        } else if runner_alive {
+            object.insert("heartbeatStale".to_owned(), json!(true));
+            object.insert("monitoringWarning".to_owned(), json!("Runner is alive but its heartbeat is stale; inspect job progress and storage health"));
+        }
         if !runner_alive && heartbeat_stale {
             return self
                 .interrupt_orphan(paths, object, heartbeat.value, heartbeat_age)
@@ -369,12 +382,48 @@ impl JobStore {
         } else {
             false
         };
-        object.insert("status".to_owned(), json!("cancelled"));
+        let heartbeat = read_heartbeat(paths).await?;
+        let child_pid = heartbeat
+            .value
+            .as_ref()
+            .and_then(|v| v.get("childPid"))
+            .and_then(Value::as_u64)
+            .and_then(|v| u32::try_from(v).ok())
+            .or_else(|| u32_field(&object, "childPid"));
+        let instance = heartbeat
+            .value
+            .as_ref()
+            .and_then(|v| v.get("childProcessInstance"))
+            .and_then(|v| {
+                v.as_u64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+            });
+        let child_alive = child_pid
+            .is_some_and(|pid| crate::process_identity::process_matches_instance(pid, instance));
+        let docker_unverified = string_field(&object, "runtimeMode") == Some("docker");
+        let pending = runner_alive || child_alive || docker_unverified;
+        object.insert(
+            "status".to_owned(),
+            json!(if pending {
+                "cancel_requested"
+            } else {
+                "cancelled"
+            }),
+        );
         object.insert("cancelRequested".to_owned(), json!(true));
-        if object.get("completedAtUtc").is_none_or(Value::is_null) {
+        if pending {
+            object.insert("completedAtUtc".to_owned(), Value::Null);
+            object.insert("terminationPending".to_owned(), json!(true));
+            object.insert("childAlive".to_owned(), json!(child_alive));
+            if docker_unverified {
+                object.insert("terminationDetail".to_owned(), json!("Local Docker client termination does not verify the in-container workload stopped"));
+            }
+        } else if object.get("completedAtUtc").is_none_or(Value::is_null) {
             object.insert("completedAtUtc".to_owned(), json!(utc_now()));
         }
-        if !runner_alive {
+        if !pending {
+            object.remove("terminationPending");
+            object.remove("childAlive");
             write_json_atomic(&paths.status, &Value::Object(object.clone())).await?;
         }
         decorate_status(&mut object, paths, runner_alive, None);
@@ -1118,8 +1167,6 @@ impl JobStore {
         }
         let mut cancelled = status.as_object().cloned().unwrap_or_default();
         let completed = utc_now();
-        cancelled.insert("status".to_owned(), json!("cancelled"));
-        cancelled.insert("completedAtUtc".to_owned(), json!(completed.clone()));
         cancelled.insert("cancelRequested".to_owned(), json!(true));
         create_marker_once(&paths.cancel, &format!("{completed}\n")).await?;
         if let Some(pid) = u32_field(&cancelled, "runnerPid").filter(|_| runner_alive)
@@ -1127,9 +1174,23 @@ impl JobStore {
         {
             terminate_job_runner_gracefully(pid, &paths.status).await;
         }
-        cancelled.insert("runnerAlive".to_owned(), json!(false));
-        cancelled.insert("jobDir".to_owned(), json!(path_text(&paths.dir)));
-        Ok(Value::Object(cancelled))
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let mut current = self.get_status(job_id).await?;
+            if status_name(&current) != "cancel_requested"
+                || tokio::time::Instant::now() >= deadline
+            {
+                if let Some(age) = status.get("heartbeatAgeMs")
+                    && let Some(object) = current.as_object_mut()
+                {
+                    object
+                        .entry("heartbeatAgeMs")
+                        .or_insert_with(|| age.clone());
+                }
+                return Ok(current);
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
     }
 }
 
@@ -1576,6 +1637,18 @@ fn path_text(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn cancellation_marker_does_not_claim_a_live_runner_stopped() {
+        let root = tempfile::tempdir().unwrap();
+        let store = store(root.path());
+        let paths=write_status(&store,"job-live-cancellation",json!({"id":"job-live-cancellation","status":"running","runnerPid":std::process::id(),"runnerProcessInstance":crate::process_identity::current_process_instance().map(|v|v.to_string()),"createdAtUtc":utc_now(),"runtimeMode":"host"})).await;
+        fs::write(&paths.cancel, b"requested").await.unwrap();
+        let status = store.get_status("job-live-cancellation").await.unwrap();
+        assert_eq!(status["status"], "cancel_requested");
+        assert_eq!(status["runnerAlive"], true);
+        assert!(status["completedAtUtc"].is_null());
+    }
 
     fn store(root: &Path) -> JobStore {
         JobStore::new(JobStoreConfig {

--- a/rust-mcp/src/jobs.rs
+++ b/rust-mcp/src/jobs.rs
@@ -401,7 +401,19 @@ impl JobStore {
         let child_alive = child_pid
             .is_some_and(|pid| crate::process_identity::process_matches_instance(pid, instance));
         let docker_unverified = string_field(&object, "runtimeMode") == Some("docker");
-        let pending = runner_alive || child_alive || docker_unverified;
+        let pending = runner_alive || child_alive;
+        if !pending && docker_unverified {
+            object.insert("status".to_owned(), json!("interrupted"));
+            object.insert("completedAtUtc".to_owned(), json!(utc_now()));
+            object.insert("cancelRequested".to_owned(), json!(true));
+            object.insert("workloadTerminationVerified".to_owned(), json!(false));
+            object.insert("terminationDetail".to_owned(), json!("Local Docker runner stopped; termination of the workload in the shared container is unverified"));
+            object.remove("terminationPending");
+            object.remove("childAlive");
+            write_json_atomic(&paths.status, &Value::Object(object.clone())).await?;
+            decorate_status(&mut object, paths, false, None);
+            return Ok(Value::Object(object));
+        }
         if !pending && string_field(&object, "status") == Some("cancelled") {
             // Preserve the runner's final journal once termination has been verified.
             decorate_status(&mut object, paths, false, None);
@@ -1667,6 +1679,26 @@ mod tests {
         assert_eq!(status["runnerAlive"], false);
         assert!(status.get("cancelRequested").is_none());
         assert_eq!(store.read_status_raw(id).await.unwrap(), journal);
+    }
+
+    #[tokio::test]
+    async fn stopped_docker_runner_is_terminal_without_claiming_workload_termination() {
+        let root = tempfile::tempdir().unwrap();
+        let store = store(root.path());
+        let id = "job-docker-cancelled";
+        let paths = write_status(
+            &store,
+            id,
+            json!({"id":id,"status":"cancelled","runtimeMode":"docker","completedAtUtc":utc_now()}),
+        )
+        .await;
+        fs::write(&paths.cancel, b"requested").await.unwrap();
+        let status = store.get_status(id).await.unwrap();
+        assert_eq!(status["status"], "interrupted");
+        assert_eq!(status["runnerAlive"], false);
+        assert_eq!(status["workloadTerminationVerified"], false);
+        assert!(!status["completedAtUtc"].is_null());
+        assert_eq!(store.get_status(id).await.unwrap()["status"], "interrupted");
     }
 
     fn store(root: &Path) -> JobStore {

--- a/rust-mcp/src/jobs.rs
+++ b/rust-mcp/src/jobs.rs
@@ -402,6 +402,11 @@ impl JobStore {
             .is_some_and(|pid| crate::process_identity::process_matches_instance(pid, instance));
         let docker_unverified = string_field(&object, "runtimeMode") == Some("docker");
         let pending = runner_alive || child_alive || docker_unverified;
+        if !pending && string_field(&object, "status") == Some("cancelled") {
+            // Preserve the runner's final journal once termination has been verified.
+            decorate_status(&mut object, paths, false, None);
+            return Ok(Value::Object(object));
+        }
         object.insert(
             "status".to_owned(),
             json!(if pending {
@@ -1648,6 +1653,20 @@ mod tests {
         assert_eq!(status["status"], "cancel_requested");
         assert_eq!(status["runnerAlive"], true);
         assert!(status["completedAtUtc"].is_null());
+    }
+
+    #[tokio::test]
+    async fn verified_cancelled_runner_journal_is_preserved() {
+        let root = tempfile::tempdir().unwrap();
+        let store = store(root.path());
+        let id = "job-cancelled-final";
+        let journal = json!({"id":id,"status":"cancelled","runtimeMode":"host","completedAtUtc":utc_now(),"error":"Command cancelled by the MCP client.","logs":{"truncated":false}});
+        let paths = write_status(&store, id, journal.clone()).await;
+        fs::write(&paths.cancel, b"requested").await.unwrap();
+        let status = store.get_status(id).await.unwrap();
+        assert_eq!(status["runnerAlive"], false);
+        assert!(status.get("cancelRequested").is_none());
+        assert_eq!(store.read_status_raw(id).await.unwrap(), journal);
     }
 
     fn store(root: &Path) -> JobStore {

--- a/rust-mcp/src/lib.rs
+++ b/rust-mcp/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod allocator_metrics;
+mod atomic_file;
 pub mod background;
 pub mod capture;
 pub mod config;
@@ -11,6 +12,7 @@ pub mod github_auth;
 pub mod hex;
 pub mod host_inspect;
 mod incident_task;
+mod job_control;
 pub mod job_logs;
 pub mod job_manager;
 pub mod job_runner;
@@ -29,6 +31,7 @@ pub mod runtime;
 pub mod schema_parity;
 pub mod search;
 pub mod server;
+mod task_store;
 pub mod usage;
 
 pub use config::{AuthMode, Config, Platform, RuntimeMode};

--- a/rust-mcp/src/main.rs
+++ b/rust-mcp/src/main.rs
@@ -27,6 +27,13 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    if std::env::args().any(|arg| arg == "--build-info") {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&devbox_mcp::provenance::snapshot())?
+        );
+        return Ok(());
+    }
     let config = Arc::new(Config::load()?);
     if let Some(request_path) = job_runner_request()? {
         return devbox_mcp::job_runner::run_job_request(config, &request_path).await;

--- a/rust-mcp/src/oauth.rs
+++ b/rust-mcp/src/oauth.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     path::PathBuf,
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result};
@@ -31,6 +31,39 @@ const REFRESH_TOKEN_TTL_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
 const AUTHORIZATION_CODE_TTL_MS: u64 = 10 * 60 * 1_000;
 const CLIENT_SECRET_TTL_SECONDS: u64 = 30 * 24 * 60 * 60;
 const JWKS_CACHE_TTL_MS: u64 = 5 * 60 * 1_000;
+const JWKS_TIMEOUT: Duration = Duration::from_secs(10);
+const JWKS_MAX_BYTES: usize = 256 * 1024;
+
+async fn fetch_bounded_jwks(
+    client: &reqwest::Client,
+    url: &str,
+    timeout: Duration,
+) -> Result<JwkSet> {
+    tokio::time::timeout(timeout, async {
+        let mut response = client
+            .get(url)
+            .timeout(timeout)
+            .send()
+            .await?
+            .error_for_status()?;
+        if response
+            .content_length()
+            .is_some_and(|size| size > JWKS_MAX_BYTES as u64)
+        {
+            anyhow::bail!("JWKS response exceeds the byte limit");
+        }
+        let mut bytes = Vec::new();
+        while let Some(chunk) = response.chunk().await? {
+            if bytes.len().saturating_add(chunk.len()) > JWKS_MAX_BYTES {
+                anyhow::bail!("JWKS response exceeds the byte limit");
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        serde_json::from_slice(&bytes).context("parse bounded JWKS")
+    })
+    .await
+    .context("JWKS request deadline exceeded")?
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -159,6 +192,7 @@ pub struct OAuthService {
     cloudflare_jwks_url: Option<String>,
     http: reqwest::Client,
     jwks_cache: Arc<Mutex<Option<CachedJwks>>>,
+    jwks_refresh: Arc<Mutex<Option<Instant>>>,
     state: Arc<Mutex<OAuthState>>,
 }
 
@@ -375,6 +409,7 @@ impl OAuthService {
             }),
             http: reqwest::Client::new(),
             jwks_cache: Arc::new(Mutex::new(None)),
+            jwks_refresh: Arc::new(Mutex::new(None)),
             state: Arc::new(Mutex::new(OAuthState::default())),
         })
     }
@@ -531,6 +566,8 @@ impl OAuthService {
                     .with_safe_redirect_uri(&redirect_uri)
             })?;
         }
+        // External identity verification must never hold the token/state lock.
+        drop(state);
         let identity = if self.mode == AuthMode::CloudflareAccess {
             Some(
                 self.verify_cloudflare_access_identity(cloudflare_assertion, cloudflare_email)
@@ -540,6 +577,12 @@ impl OAuthService {
         } else {
             None
         };
+        let mut state = self.state.lock().await;
+        if state.clients.get(&request.client_id) != Some(&client) {
+            return Err(OAuthFailure::invalid_client(
+                "Client changed during authorization",
+            ));
+        }
         let code = Uuid::new_v4().to_string();
         state.authorization_codes.insert(
             code.clone(),
@@ -799,6 +842,18 @@ impl OAuthService {
         if let Some(key) = self.cached_decoding_key(kid).await? {
             return Ok(key);
         }
+        let mut refresh = tokio::time::timeout(JWKS_TIMEOUT, self.jwks_refresh.lock())
+            .await
+            .map_err(|_| OAuthFailure::server("Cloudflare key refresh wait timed out"))?;
+        if let Some(key) = self.cached_decoding_key(kid).await? {
+            return Ok(key);
+        }
+        if refresh.is_some_and(|last| last.elapsed() < Duration::from_secs(5)) {
+            return Err(OAuthFailure::server(
+                "Cloudflare key refresh is cooling down; retry shortly",
+            ));
+        }
+        *refresh = Some(Instant::now());
         self.refresh_jwks().await?;
         self.cached_decoding_key(kid).await?.ok_or_else(|| {
             OAuthFailure::server("Cloudflare Access JWT verification failed: unknown kid")
@@ -833,18 +888,7 @@ impl OAuthService {
             .cloudflare_jwks_url
             .as_deref()
             .ok_or_else(|| OAuthFailure::server("Cloudflare Access JWKS URL is not configured"))?;
-        let set = self
-            .http
-            .get(jwks_url)
-            .send()
-            .await
-            .and_then(reqwest::Response::error_for_status)
-            .map_err(|error| {
-                OAuthFailure::server(format!(
-                    "Cloudflare Access JWT verification failed: {error}"
-                ))
-            })?
-            .json::<JwkSet>()
+        let set = fetch_bounded_jwks(&self.http, jwks_url, JWKS_TIMEOUT)
             .await
             .map_err(|error| {
                 OAuthFailure::server(format!(
@@ -1397,6 +1441,116 @@ fn unix_seconds() -> u64 {
 
 fn internal_failure(error: impl std::fmt::Display) -> OAuthFailure {
     OAuthFailure::server(error.to_string())
+}
+
+#[cfg(test)]
+mod reliability_tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn jwks_headers_and_body_are_bounded() {
+        for headers in ["", "HTTP/1.1 200 OK\r\nContent-Length: 20\r\n\r\n"] {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            let task = tokio::spawn(async move {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut buffer = [0; 4096];
+                assert!(socket.read(&mut buffer).await.unwrap() > 0);
+                socket.write_all(headers.as_bytes()).await.unwrap();
+                std::future::pending::<()>().await;
+            });
+            let started = Instant::now();
+            assert!(
+                fetch_bounded_jwks(
+                    &reqwest::Client::new(),
+                    &format!("http://{address}"),
+                    Duration::from_millis(150)
+                )
+                .await
+                .is_err()
+            );
+            assert!(started.elapsed() < Duration::from_secs(2));
+            task.abort();
+            let _ = task.await;
+        }
+    }
+
+    #[tokio::test]
+    async fn stalled_jwks_does_not_block_existing_tokens_or_registration() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = crate::config::test_config(root.path());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (sent, received) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buffer = [0; 4096];
+            assert!(socket.read(&mut buffer).await.unwrap() > 0);
+            let _ = sent.send(());
+            std::future::pending::<()>().await;
+        });
+        config.auth_mode = AuthMode::CloudflareAccess;
+        config.public_base_url = Some("http://localhost:8100".into());
+        config.cloudflare_access_team_domain = Some(format!("http://{address}"));
+        config.cloudflare_access_jwks_url = Some(format!("http://{address}"));
+        config.cloudflare_access_aud = "fixture".into();
+        let service = Arc::new(OAuthService::new(&config).unwrap());
+        let metadata = json!({"redirect_uris":["http://localhost/callback"],"token_endpoint_auth_method":"none"});
+        let client = service.register_client(metadata.clone()).await.unwrap();
+        service.state.lock().await.access_tokens.insert(
+            "existing".into(),
+            TokenRecord {
+                client_id: client["client_id"].as_str().unwrap().into(),
+                scopes: vec!["mcp:tools".into()],
+                resource: None,
+                identity: None,
+                expires_at: unix_millis() + 30000,
+            },
+        );
+        let worker = service.clone();
+        let authorization = tokio::spawn(async move {
+            let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"RS256","kid":"fixture"}"#);
+            worker
+                .authorize(
+                    AuthorizationRequest {
+                        client_id: client["client_id"].as_str().unwrap().into(),
+                        redirect_uri: Some("http://localhost/callback".into()),
+                        response_type: "code".into(),
+                        code_challenge: "fixture".into(),
+                        code_challenge_method: "S256".into(),
+                        scope: None,
+                        state: None,
+                        resource: None,
+                    },
+                    Some(&format!("{header}.e30.AA")),
+                    None,
+                )
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(3), received)
+            .await
+            .unwrap()
+            .unwrap();
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            service.verify_access_token("existing"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            service.register_client(metadata),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        authorization.abort();
+        task.abort();
+        let _ = authorization.await;
+        let _ = task.await;
+    }
 }
 
 #[cfg(test)]

--- a/rust-mcp/src/provenance.rs
+++ b/rust-mcp/src/provenance.rs
@@ -19,6 +19,8 @@ fn build_snapshot() -> Value {
     json!({
         "gitSha": env!("DEVBOX_BUILD_GIT_SHA"),
         "gitRef": env!("DEVBOX_BUILD_GIT_REF"),
+        "sourceTree": env!("DEVBOX_BUILD_SOURCE_TREE"),
+        "sourceDirty": match env!("DEVBOX_BUILD_SOURCE_DIRTY") { "true" => Some(true), "false" => Some(false), _ => None },
         "buildUnixSeconds": env!("DEVBOX_BUILD_UNIX_SECONDS"),
         "rustc": env!("DEVBOX_BUILD_RUSTC"),
         "binarySha256": binary_sha256,

--- a/rust-mcp/src/runtime.rs
+++ b/rust-mcp/src/runtime.rs
@@ -58,6 +58,7 @@ pub enum RuntimeExecError {
     },
     WindowsElevationRequired,
     WindowsAdminProbe(String),
+    ShellCommandTooLong,
     Process(ProcessError),
 }
 
@@ -79,6 +80,7 @@ impl std::fmt::Display for RuntimeExecError {
                 "Windows host PowerShell requires the Devbox MCP process to already be elevated. This MCP process is medium-integrity, so host_exec refused to call Start-Process -Verb RunAs (that would spam UAC). Guardian treats unelevated MCP as unhealthy and restarts it via the Highest scheduled-task path. Retry after repair.",
             ),
             Self::WindowsAdminProbe(message) => formatter.write_str(message),
+            Self::ShellCommandTooLong => formatter.write_str("CMD inline commands are limited to 8000 UTF-16 units; save a .cmd script and run that file instead."),
             Self::Process(error) => std::fmt::Display::fmt(error, formatter),
         }
     }
@@ -652,6 +654,22 @@ mod tests {
             .unwrap();
         assert!(output.stdout.to_ascii_lowercase().contains("cmd.exe"));
         assert!(runtime.windows_admin_state.get().is_none());
+        let error = runtime
+            .run_shell(
+                ShellRequest {
+                    command: "x".repeat(9000),
+                    working_dir: root.path().to_path_buf(),
+                    timeout: Duration::from_secs(5),
+                    user: String::new(),
+                    max_capture_chars: Some(1024),
+                    output_tx: None,
+                    pid_tx: None,
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, RuntimeExecError::ShellCommandTooLong));
     }
 
     #[test]

--- a/rust-mcp/src/runtime.rs
+++ b/rust-mcp/src/runtime.rs
@@ -427,7 +427,16 @@ impl RuntimeExecutor {
         cancellation: CancellationToken,
     ) -> Result<ProcessOutput, RuntimeExecError> {
         match self.config.runtime_mode {
-            RuntimeMode::Host => self.run_host_shell(request, cancellation).await,
+            RuntimeMode::Host => {
+                #[cfg(windows)]
+                {
+                    self.run_windows_runtime_shell(request, cancellation).await
+                }
+                #[cfg(not(windows))]
+                {
+                    self.run_host_shell(request, cancellation).await
+                }
+            }
             RuntimeMode::Docker => self.run_docker_shell(request, cancellation).await,
         }
     }
@@ -592,7 +601,6 @@ fn resolve_windows_program_path(program: &str) -> Option<PathBuf> {
     None
 }
 
-#[cfg(any(not(windows), test))]
 fn host_shell_args(shell: &str, command: &str, is_windows: bool) -> Vec<String> {
     let name = normalize_program(shell);
     if is_windows && matches!(name.as_str(), "powershell" | "pwsh") {
@@ -621,6 +629,30 @@ fn host_shell_args(shell: &str, command: &str, is_windows: bool) -> Vec<String> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn devbox_shell_honors_cmd_override_without_an_admin_probe() {
+        let root = tempfile::tempdir().unwrap();
+        let runtime = RuntimeExecutor::new(test_config(root.path()));
+        let output = runtime
+            .run_shell(
+                ShellRequest {
+                    command: "echo %COMSPEC%".to_owned(),
+                    working_dir: root.path().to_path_buf(),
+                    timeout: Duration::from_secs(5),
+                    user: String::new(),
+                    max_capture_chars: Some(4096),
+                    output_tx: None,
+                    pid_tx: None,
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert!(output.stdout.to_ascii_lowercase().contains("cmd.exe"));
+        assert!(runtime.windows_admin_state.get().is_none());
+    }
 
     #[test]
     fn program_normalization_matches_javascript_behavior() {

--- a/rust-mcp/src/runtime/windows_host_shell.rs
+++ b/rust-mcp/src/runtime/windows_host_shell.rs
@@ -28,6 +28,30 @@ struct PowerShellSpawnRequest {
 }
 
 impl RuntimeExecutor {
+    /// Internal parser probes inherit the server token and never request elevation.
+    pub(crate) async fn run_windows_inspection_shell(
+        &self,
+        request: ShellRequest,
+        cancellation: CancellationToken,
+    ) -> Result<ProcessOutput, RuntimeExecError> {
+        if !self.config.host_exec_enabled {
+            return Err(RuntimeExecError::HostExecDisabled);
+        }
+        self.spawn_windows_powershell(
+            PowerShellSpawnRequest {
+                args: windows_shell::encoded_command_args(&request.command),
+                cwd: request.working_dir,
+                timeout: request.timeout,
+                max_capture_chars: request.max_capture_chars,
+                output_tx: request.output_tx,
+                pid_tx: request.pid_tx,
+            },
+            cancellation,
+        )
+        .await
+        .map(clean_output)
+    }
+
     pub(super) async fn run_windows_runtime_shell(
         &self,
         request: ShellRequest,

--- a/rust-mcp/src/runtime/windows_host_shell.rs
+++ b/rust-mcp/src/runtime/windows_host_shell.rs
@@ -70,6 +70,11 @@ impl RuntimeExecutor {
         let mut script = None;
         let started = Instant::now();
         for (index, shell) in candidates.iter().enumerate() {
+            if super::normalize_program(shell) == "cmd"
+                && request.command.encode_utf16().count() > 8000
+            {
+                return Err(RuntimeExecError::ShellCommandTooLong);
+            }
             let powershell = matches!(
                 super::normalize_program(shell).as_str(),
                 "pwsh" | "powershell"

--- a/rust-mcp/src/runtime/windows_host_shell.rs
+++ b/rust-mcp/src/runtime/windows_host_shell.rs
@@ -28,6 +28,88 @@ struct PowerShellSpawnRequest {
 }
 
 impl RuntimeExecutor {
+    pub(super) async fn run_windows_runtime_shell(
+        &self,
+        request: ShellRequest,
+        cancellation: CancellationToken,
+    ) -> Result<ProcessOutput, RuntimeExecError> {
+        if !self.config.host_exec_enabled {
+            return Err(RuntimeExecError::HostExecDisabled);
+        }
+        let mut candidates = vec![self.config.host_shell.clone()];
+        if self.config.host_shell == self.config.power_shell_exe
+            && !self.config.power_shell_fallback_exe.is_empty()
+            && self.config.power_shell_fallback_exe != self.config.host_shell
+        {
+            candidates.push(self.config.power_shell_fallback_exe.clone());
+        }
+        let mut script = None;
+        let started = Instant::now();
+        for (index, shell) in candidates.iter().enumerate() {
+            let powershell = matches!(
+                super::normalize_program(shell).as_str(),
+                "pwsh" | "powershell"
+            );
+            let args = if powershell && windows_shell::should_use_script_file(&request.command) {
+                if script.is_none() {
+                    let temporary = tempfile::Builder::new()
+                        .suffix(".ps1")
+                        .tempfile()
+                        .map_err(|e| RuntimeExecError::WindowsAdminProbe(e.to_string()))?;
+                    tokio::fs::write(temporary.path(), &request.command)
+                        .await
+                        .map_err(|e| RuntimeExecError::WindowsAdminProbe(e.to_string()))?;
+                    script = Some(temporary);
+                }
+                vec![
+                    "-NoLogo".into(),
+                    "-NoProfile".into(),
+                    "-NonInteractive".into(),
+                    "-ExecutionPolicy".into(),
+                    "Bypass".into(),
+                    "-File".into(),
+                    script
+                        .as_ref()
+                        .expect("script staged")
+                        .path()
+                        .to_string_lossy()
+                        .into_owned(),
+                ]
+            } else {
+                super::host_shell_args(shell, &request.command, true)
+            };
+            let result = spawn_process(
+                shell,
+                &args,
+                ProcessOptions {
+                    cwd: Some(request.working_dir.clone()),
+                    timeout: Some(
+                        request
+                            .timeout
+                            .saturating_sub(started.elapsed())
+                            .max(Duration::from_millis(1)),
+                    ),
+                    max_capture_chars: request.max_capture_chars,
+                    output_tx: request.output_tx.clone(),
+                    pid_tx: request.pid_tx.clone(),
+                    ..ProcessOptions::default()
+                },
+                cancellation.child_token(),
+            )
+            .await;
+            match result {
+                Ok(value) => return Ok(value),
+                Err(error)
+                    if index + 1 < candidates.len()
+                        && error.exit_code.is_none()
+                        && !error.timed_out
+                        && !error.aborted => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        unreachable!("nonempty shell candidates return their final result")
+    }
+
     pub(super) async fn windows_admin_state(
         &self,
         cancellation: CancellationToken,

--- a/rust-mcp/src/server.rs
+++ b/rust-mcp/src/server.rs
@@ -61,6 +61,9 @@ use crate::{
     usage::{ToolUsageDropGuard, ToolUsageInvocation, UsageService},
 };
 
+#[path = "agent_tools.rs"]
+mod agent_tools;
+
 #[derive(Debug, Clone)]
 pub struct DevboxMcp {
     config: Arc<Config>,
@@ -145,7 +148,7 @@ impl DevboxMcp {
             files: Arc::new(FileService::new()),
             docker_files: Arc::new(DockerFileBackend::new()),
             scheduler,
-            tool_router: Self::tool_router(),
+            tool_router: Self::tool_router() + agent_tools::router(),
         }
     }
 
@@ -752,14 +755,30 @@ impl DevboxMcp {
 
     fn configured_tool(&self, mut tool: rmcp::model::Tool) -> rmcp::model::Tool {
         let mut schema = (*tool.input_schema).clone();
-        crate::schema_parity::configure_tool_input_schema(
-            tool.name.as_ref(),
-            &mut schema,
-            &self.config,
-        );
+        if crate::contract::AGENT_TOOL_NAMES.contains(&tool.name.as_ref()) {
+            agent_tools::configure_schema(&mut schema, &self.config);
+        } else {
+            crate::schema_parity::configure_tool_input_schema(
+                tool.name.as_ref(),
+                &mut schema,
+                &self.config,
+            );
+        }
         tool.input_schema = Arc::new(schema);
         crate::schema_parity::configure_tool_output_schema(&mut tool);
         crate::schema_parity::configure_tool_metadata(&mut tool, &self.config);
+        if crate::contract::AGENT_TOOL_NAMES.contains(&tool.name.as_ref()) {
+            let read = matches!(
+                required_tool_scope(tool.name.as_ref()),
+                Some("mcp:devbox:read")
+            );
+            let mut annotations = rmcp::model::ToolAnnotations::default();
+            annotations.read_only_hint = Some(read);
+            annotations.destructive_hint = Some(!read);
+            annotations.idempotent_hint = Some(true);
+            annotations.open_world_hint = Some(tool.name.as_ref() == "devbox_job_submit");
+            tool.annotations = Some(annotations);
+        }
         tool
     }
 
@@ -822,6 +841,7 @@ impl DevboxMcp {
         );
         data.insert("jobQuota".to_owned(), job_quota.unwrap_or(Value::Null));
         data.insert("execution".to_owned(), json!(execution));
+        data.insert("capabilities".to_owned(), self.capability_manifest());
         let performance = self.performance.snapshot();
         data.insert("performance".to_owned(), performance);
         let background_snapshot = self.background.snapshot();
@@ -2359,8 +2379,19 @@ impl DevboxMcp {
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for DevboxMcp {
+    async fn on_initialized(&self, context: rmcp::service::NotificationContext<RoleServer>) {
+        let _ = tokio::time::timeout(
+            Duration::from_secs(1),
+            context.peer.notify_tool_list_changed(),
+        )
+        .await;
+    }
+
     fn get_info(&self) -> ServerInfo {
-        let mut capabilities = ServerCapabilities::builder().enable_tools().build();
+        let mut capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_tool_list_changed()
+            .build();
         capabilities.logging = Some(serde_json::Map::default());
         ServerInfo::new(capabilities).with_server_info(
             Implementation::new(self.config.server_name(), env!("CARGO_PKG_VERSION"))
@@ -2444,7 +2475,12 @@ impl ServerHandler for DevboxMcp {
 
 fn required_tool_scope(tool: &str) -> Option<&'static str> {
     match tool {
-        "devbox_status"
+        "devbox_capabilities"
+        | "devbox_file_state"
+        | "devbox_job_list"
+        | "devbox_task_get"
+        | "devbox_task_list"
+        | "devbox_status"
         | "devbox_github_auth_status"
         | "devbox_job_logs"
         | "devbox_job_status"
@@ -2454,7 +2490,10 @@ fn required_tool_scope(tool: &str) -> Option<&'static str> {
         | "devbox_search_files"
         | "devbox_wait"
         | "devbox_wait_for_file" => Some("mcp:devbox:read"),
-        "devbox_exec"
+        "devbox_write_file_atomic"
+        | "devbox_job_submit"
+        | "devbox_task_put"
+        | "devbox_exec"
         | "devbox_exec_readonly"
         | "devbox_exec_start"
         | "devbox_job_cancel"
@@ -3177,8 +3216,8 @@ async fn readyz(State(state): State<HttpState>) -> Response {
         let scheduler = cached_execution_value(&state.handler.execution_snapshot)
             .await
             .is_some();
-        let tool_contract =
-            state.handler.tool_router.list_all().len() == crate::contract::TARGET_TOOL_NAMES.len();
+        let tool_contract = state.handler.tool_router.list_all().len()
+            == crate::contract::TARGET_TOOL_NAMES.len() + crate::contract::AGENT_TOOL_NAMES.len();
         let background = state.handler.background.snapshot();
         let store_task = &background["execution-store-probe"];
         let store_task_fresh = store_task.get("running").and_then(Value::as_bool) == Some(true)
@@ -3496,9 +3535,14 @@ fn render_oversized_posix_capture_pid(
 }
 
 fn render_windows_capture_pid_binding_error(pid: u64) -> CallToolResult {
-    let summary = format!(
+    let mut summary = format!(
         "\u{1b}[31;1mcapture.ps1: \u{1b}[31;1mCannot process argument transformation on parameter 'TargetPid'. Cannot convert value \"{pid}\" to type \"System.Int32\". Error: \"Value was either too large or too small for an Int32.\"\u{1b}[0m"
     );
+    if std::env::var_os("NO_COLOR").is_some()
+        || std::env::var("TERM").is_ok_and(|term| term == "dumb")
+    {
+        summary = summary.replace("\u{1b}[31;1m", "").replace("\u{1b}[0m", "");
+    }
     ToolEnvelope::process_error(
         summary.clone(),
         None,

--- a/rust-mcp/src/task_store.rs
+++ b/rust-mcp/src/task_store.rs
@@ -1,0 +1,163 @@
+//! Versioned task checkpoints. State is data; it never grants execution permission.
+use crate::{
+    atomic_file::{self, Preconditions},
+    job_control::validate_key,
+};
+use anyhow::{Result, bail};
+use serde_json::{Value, json};
+use std::path::Path;
+use tokio::{fs, io::AsyncReadExt};
+
+pub(crate) const MAX_STATE_BYTES: usize = 65536;
+
+pub(crate) async fn get(root: &Path, id: &str) -> Result<Value> {
+    validate_key(id)?;
+    match fs::File::open(root.join(format!("{id}.json"))).await {
+        Ok(file) => {
+            let mut bytes = Vec::new();
+            file.take((MAX_STATE_BYTES + 2049) as u64)
+                .read_to_end(&mut bytes)
+                .await?;
+            if bytes.len() > MAX_STATE_BYTES + 2048 {
+                bail!("Task record exceeds size limit");
+            }
+            let record: Value = serde_json::from_slice(&bytes)?;
+            Ok(json!({"exists":true,"record":record,"sha256":atomic_file::digest(&bytes)}))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(json!({"exists":false,"task_id":id,"revision":0}))
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(crate) async fn put(root: &Path, id: &str, revision: u64, state: Value) -> Result<Value> {
+    validate_key(id)?;
+    if revision >= 9_007_199_254_740_991 {
+        bail!("Task revision exceeds the interoperable integer range");
+    }
+    if serde_json::to_vec(&state)?.len() > MAX_STATE_BYTES {
+        bail!("Task state exceeds 65536 bytes; store large artifacts separately");
+    }
+    let _gate = crate::job_control::gate(root).await?;
+    let current = get(root, id).await?;
+    let current_revision = current
+        .pointer("/record/revision")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if current_revision == revision + 1 && current.pointer("/record/state") == Some(&state) {
+        return Ok(json!({"replayed":true,"record":current["record"],"sha256":current["sha256"]}));
+    }
+    if current_revision != revision {
+        bail!("TASK_CONFLICT: expected_revision is stale");
+    }
+    if current["exists"] != true && task_ids(root).await?.len() >= 10000 {
+        bail!("TASK_CAPACITY: archive completed task records before creating more");
+    }
+    let record = json!({"schema_version":1,"task_id":id,"revision":revision+1,"updated_at":chrono::Utc::now().to_rfc3339(),"state":state});
+    let expected = current["sha256"].as_str().unwrap_or("missing").to_owned();
+    let receipt = atomic_file::write(
+        root.join(format!("{id}.json")),
+        serde_json::to_vec(&record)?,
+        false,
+        true,
+        Preconditions {
+            sha256: Some(expected),
+            offset: None,
+        },
+    )
+    .await?;
+    Ok(json!({"replayed":receipt.replayed,"record":record,"sha256":receipt.current.sha256}))
+}
+
+async fn task_ids(root: &Path) -> Result<Vec<String>> {
+    let mut reader = match fs::read_dir(root).await {
+        Ok(reader) => reader,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mut ids = Vec::new();
+    while let Some(entry) = reader.next_entry().await? {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if let Some(id) = name.strip_suffix(".json")
+            && validate_key(id).is_ok()
+        {
+            if ids.len() >= 10000 {
+                bail!("Task index exceeds its scan budget");
+            }
+            ids.push(id.to_owned());
+        }
+    }
+    ids.sort();
+    Ok(ids)
+}
+
+pub(crate) async fn list(root: &Path, cursor: Option<&str>, limit: usize) -> Result<Value> {
+    if !(1..=100).contains(&limit) {
+        bail!("limit must be between 1 and 100");
+    }
+    let ids = task_ids(root).await?;
+    let ids = ids
+        .into_iter()
+        .filter(|id| cursor.is_none_or(|cursor| id.as_str() > cursor))
+        .collect::<Vec<_>>();
+    let next = if ids.len() > limit {
+        Some(ids[limit - 1].clone())
+    } else {
+        None
+    };
+    let mut records = Vec::new();
+    for id in ids.into_iter().take(limit) {
+        let value = get(root, &id).await?;
+        if value["exists"] == true {
+            records.push(json!({"task_id":id,"revision":value["record"]["revision"],"updated_at":value["record"]["updated_at"]}));
+        }
+    }
+    Ok(json!({"tasks":records,"next_cursor":next}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn task_revision_retries_and_conflicts_are_durable() {
+        let root = tempfile::tempdir().unwrap();
+        let first = put(
+            root.path(),
+            "task-a",
+            0,
+            json!({"step":"build","job_id":"job-existing"}),
+        )
+        .await
+        .unwrap();
+        assert_eq!(first["record"]["revision"], 1);
+        assert_eq!(
+            put(
+                root.path(),
+                "task-a",
+                0,
+                json!({"step":"build","job_id":"job-existing"})
+            )
+            .await
+            .unwrap()["replayed"],
+            true
+        );
+        assert!(
+            put(root.path(), "task-a", 0, json!({"step":"overwrite"}))
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            get(root.path(), "task-a").await.unwrap()["record"]["state"]["job_id"],
+            "job-existing"
+        );
+        assert_eq!(
+            list(root.path(), None, 1).await.unwrap()["tasks"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(get(root.path(), "../escape").await.is_err());
+    }
+}

--- a/scripts/Start-ChatGptDevboxMcp.ps1
+++ b/scripts/Start-ChatGptDevboxMcp.ps1
@@ -1014,6 +1014,24 @@ function Start-CloudflaredQuickTunnel {
     throw "Cloudflare quick tunnel did not publish a URL. Logs:`n$logs"
 }
 
+function Get-RustSourceIdentity {
+    param([Parameter(Mandatory = $true)][string]$ProjectRoot)
+    $gitSha = ([string](& git -C $ProjectRoot rev-parse HEAD 2>$null | Select-Object -First 1)).Trim()
+    $sourceTree = ([string](& git -C $ProjectRoot rev-parse 'HEAD^{tree}' 2>$null | Select-Object -First 1)).Trim()
+    $trackedDirty = ((& git -C $ProjectRoot status --porcelain --untracked-files=no 2>$null | Out-String).Trim()).Length -gt 0
+    $untrackedRust = ((& git -C $ProjectRoot ls-files --others --exclude-standard -- rust-mcp 2>$null | Out-String).Trim()).Length -gt 0
+    if ($trackedDirty -or $untrackedRust -or $gitSha -notmatch '^[0-9a-f]{40}$' -or $sourceTree -notmatch '^[0-9a-f]{40}$') {
+        throw 'Production Rust preflight requires committed, clean tracked source and no untracked Rust build inputs. The existing MCP was not stopped.'
+    }
+    return [pscustomobject]@{ GitSha = $gitSha; SourceTree = $sourceTree; SourceDirty = $false }
+}
+
+function Test-RustSourceIdentity {
+    param($BuildInfo, [string]$GitSha, [string]$SourceTree)
+    if (-not $BuildInfo -or -not $BuildInfo.PSObject.Properties['SourceDirty'] -or -not $BuildInfo.PSObject.Properties['SourceTree'] -or -not $BuildInfo.PSObject.Properties['GitSha']) { return $false }
+    return ($BuildInfo.SourceDirty -is [bool] -and -not $BuildInfo.SourceDirty -and $BuildInfo.GitSha -eq $GitSha -and $BuildInfo.SourceTree -eq $SourceTree)
+}
+
 function Assert-McpReplacementReady {
     param(
         [Parameter(Mandatory = $true)][string]$Implementation,
@@ -1034,31 +1052,34 @@ function Assert-McpReplacementReady {
         $currentManifestPath = Join-Path $versionedBinDir 'current-rust.json'
         Ensure-Directory -Path $versionedBinDir
 
-        $gitSha = (& git -C $ProjectRoot rev-parse HEAD 2>$null | Select-Object -First 1).Trim()
-        if ([string]::IsNullOrWhiteSpace($gitSha)) {
-            $gitSha = 'unknown'
-        }
-        $trackedDirty = ((& git -C $ProjectRoot status --porcelain --untracked-files=no 2>$null | Out-String).Trim()).Length -gt 0
+        $source = Get-RustSourceIdentity -ProjectRoot $ProjectRoot
+        $gitSha = $source.GitSha
+        $sourceTree = $source.SourceTree
 
         # Fast boot path: only reuse a candidate that previously passed the complete
         # local/public startup gate and matches the current committed source tree.
-        if (-not $trackedDirty -and (Test-Path $currentManifestPath)) {
+        if (Test-Path $currentManifestPath) {
             try {
                 $current = Get-Content $currentManifestPath -Raw | ConvertFrom-Json
-                if ($current.GitSha -eq $gitSha -and $current.FilePath -and (Test-Path ([string]$current.FilePath))) {
+                $candidateUnderRoot = $current.FilePath -and ([IO.Path]::GetFullPath([string]$current.FilePath)).StartsWith(([IO.Path]::GetFullPath($versionedBinDir).TrimEnd('\') + '\'), [StringComparison]::OrdinalIgnoreCase)
+                if ((Test-RustSourceIdentity -BuildInfo $current -GitSha $gitSha -SourceTree $sourceTree) -and $candidateUnderRoot -and (Test-Path ([string]$current.FilePath))) {
                     $candidateHash = (Get-FileHash -LiteralPath ([string]$current.FilePath) -Algorithm SHA256).Hash
                     if ($candidateHash -eq [string]$current.Sha256) {
                         $previousErrorActionPreference = $ErrorActionPreference
                         try {
                             $ErrorActionPreference = 'Continue'
                             $parityOutput = & ([string]$current.FilePath) '--parity-report' 2>&1 | Out-String
-                            if ($LASTEXITCODE -eq 0) {
+                            $parityPassed = $LASTEXITCODE -eq 0
+                            $buildInfo = & ([string]$current.FilePath) '--build-info' | ConvertFrom-Json
+                            if ($parityPassed -and $LASTEXITCODE -eq 0 -and (Test-RustSourceIdentity -BuildInfo $buildInfo -GitSha $gitSha -SourceTree $sourceTree)) {
                                 return [pscustomobject]@{
                                     Implementation = 'rust'
                                     FilePath = [string]$current.FilePath
                                     ArgumentList = @()
                                     Generation = [string]$current.Generation
                                     GitSha = $gitSha
+                                    SourceTree = $sourceTree
+                                    SourceDirty = $false
                                     Sha256 = $candidateHash
                                     CandidateManifestPath = $currentManifestPath
                                     Reused = $true
@@ -1106,6 +1127,10 @@ function Assert-McpReplacementReady {
             if ($LASTEXITCODE -ne 0) {
                 throw "Rust MCP binary preflight failed before the existing MCP was stopped. Output:`n$parityOutput"
             }
+            $buildInfo = & $binaryPath '--build-info' | ConvertFrom-Json
+            if ($LASTEXITCODE -ne 0 -or -not (Test-RustSourceIdentity -BuildInfo $buildInfo -GitSha $gitSha -SourceTree $sourceTree)) {
+                throw 'Rust binary source provenance did not match the clean committed checkout. Existing MCP was not stopped.'
+            }
         } finally {
             $ErrorActionPreference = $previousErrorActionPreference
             Pop-Location
@@ -1117,6 +1142,8 @@ function Assert-McpReplacementReady {
             ArgumentList = @()
             Generation = $generation
             GitSha = $gitSha
+            SourceTree = $sourceTree
+            SourceDirty = $false
             Sha256 = $hash
             CandidateManifestPath = $currentManifestPath
             Reused = $false
@@ -1777,6 +1804,8 @@ if ($mcpImplementation -eq 'rust' -and $launchSpec.CandidateManifestPath) {
     }
     Write-JsonStateFile -Path $manifestPath -Value @{
         GitSha = [string]$launchSpec.GitSha
+        SourceTree = [string]$launchSpec.SourceTree
+        SourceDirty = [bool]$launchSpec.SourceDirty
         Sha256 = [string]$launchSpec.Sha256
         Generation = [string]$launchSpec.Generation
         FilePath = [string]$launchSpec.FilePath

--- a/scripts/check-runtime-contract.mjs
+++ b/scripts/check-runtime-contract.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+const root=new URL('../',import.meta.url);
+const read=p=>readFile(new URL(p,root),'utf8');
+const toolchain=(await read('rust-toolchain.toml')).match(/channel\s*=\s*"([^"]+)"/)[1];
+const bootstrap=await read('bootstrap/src/main.rs');
+assert.equal(bootstrap.match(/const PINNED_RUST_TOOLCHAIN: &str = "([^"]+)"/)[1],toolchain,'Installer must provision the repository toolchain');
+const msrv=(await read('rust-mcp/Cargo.toml')).match(/rust-version\s*=\s*"([^"]+)"/)[1];
+assert.equal(bootstrap.match(/const MINIMUM_RUST_VERSION: \(u32, u32, u32\) = \((\d+), (\d+), (\d+)\)/).slice(1).map(Number).slice(0,2).join('.'),msrv);
+const workflow=await read('.github/workflows/rust-mcp.yml');
+assert(workflow.includes(`rustup toolchain install ${toolchain}`));
+assert(workflow.includes(`Rust MCP MSRV (${msrv}.0)`));
+console.log(JSON.stringify({ok:true,toolchain,serverMsrv:msrv,nodeCertified:24}));

--- a/scripts/ci/platform-runtime-e2e.mjs
+++ b/scripts/ci/platform-runtime-e2e.mjs
@@ -36,7 +36,7 @@ const waitForHealth = async (baseUrl, timeoutMs = 20000) => {
   let lastError = null;
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(healthUrl);
+      const response = await fetch(healthUrl, { signal: AbortSignal.timeout(Math.max(1, Math.min(1000, deadline - Date.now()))) });
       if (response.ok) return healthUrl;
       lastError = new Error(`HTTP ${response.status}`);
     } catch (error) {

--- a/scripts/ci/test-windows-startup-contract.ps1
+++ b/scripts/ci/test-windows-startup-contract.ps1
@@ -138,4 +138,47 @@ if (Test-Path $legacy) {
     if ($LASTEXITCODE -ne 0) { throw "Windows PowerShell 5.1 parse validation failed with exit code $LASTEXITCODE." }
 }
 
-Write-Host 'Windows Devbox startup lifecycle contract checks passed.'
+$sourceAst = [System.Management.Automation.Language.Parser]::ParseFile($startPath, [ref]$null, [ref]$null)
+foreach ($name in @('Get-RustSourceIdentity', 'Test-RustSourceIdentity')) {
+    $function = $sourceAst.Find({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name }, $true)
+    if (-not $function) { throw "Missing source provenance helper $name" }
+    . ([scriptblock]::Create($function.Extent.Text))
+}
+$sourceFixture = Join-Path ([IO.Path]::GetTempPath()) ('devbox-source-contract-' + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path (Join-Path $sourceFixture 'rust-mcp\src') -Force | Out-Null
+try {
+    git -C $sourceFixture init --quiet
+    git -C $sourceFixture config user.email 'fixture@example.test'
+    git -C $sourceFixture config user.name 'Devbox fixture'
+    $sourceFile = Join-Path $sourceFixture 'rust-mcp\src\main.rs'
+    [IO.File]::WriteAllText($sourceFile, 'fn main() {}')
+    git -C $sourceFixture add .
+    git -C $sourceFixture -c commit.gpgsign=false commit --quiet -m fixture
+    if ($LASTEXITCODE -ne 0) { throw 'Could not prepare provenance fixture repository' }
+    $clean = Get-RustSourceIdentity -ProjectRoot $sourceFixture
+    if (-not (Test-RustSourceIdentity -BuildInfo $clean -GitSha $clean.GitSha -SourceTree $clean.SourceTree)) { throw 'Clean provenance was not accepted' }
+    [IO.File]::AppendAllText($sourceFile, '// dirty input')
+    $refused = $false
+    try { Get-RustSourceIdentity -ProjectRoot $sourceFixture | Out-Null } catch { $refused = $_.Exception.Message -match 'clean tracked source' }
+    if (-not $refused) { throw 'Dirty source was not refused' }
+    git -C $sourceFixture restore -- 'rust-mcp/src/main.rs'
+    $restored = Get-RustSourceIdentity -ProjectRoot $sourceFixture
+    if ($restored.GitSha -ne $clean.GitSha) { throw 'Fixture HEAD unexpectedly changed' }
+    foreach ($candidate in @(
+        [pscustomobject]@{ GitSha=$clean.GitSha; SourceTree=$clean.SourceTree; SourceDirty=$true },
+        [pscustomobject]@{ GitSha=$clean.GitSha; SourceTree=$clean.SourceTree; SourceDirty='false' },
+        [pscustomobject]@{ GitSha=$clean.GitSha },
+        [pscustomobject]@{ GitSha=$clean.GitSha; SourceTree=('0'*40); SourceDirty=$false }
+    )) { if (Test-RustSourceIdentity -BuildInfo $candidate -GitSha $restored.GitSha -SourceTree $restored.SourceTree) { throw 'Untrusted candidate provenance was accepted after restoring the same HEAD' } }
+    [IO.File]::WriteAllText((Join-Path $sourceFixture 'rust-mcp\src\untracked.rs'), '// hidden build input')
+    $refused = $false
+    try { Get-RustSourceIdentity -ProjectRoot $sourceFixture | Out-Null } catch { $refused = $_.Exception.Message -match 'untracked Rust build inputs' }
+    if (-not $refused) { throw 'Untracked Rust source was not refused' }
+} finally {
+    $resolvedFixture = [IO.Path]::GetFullPath($sourceFixture)
+    $tempPrefix = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\') + '\'
+    if (-not $resolvedFixture.StartsWith($tempPrefix, [StringComparison]::OrdinalIgnoreCase) -or [IO.Path]::GetFileName($resolvedFixture) -notlike 'devbox-source-contract-*') { throw 'Unsafe provenance fixture cleanup target' }
+    Remove-Item -LiteralPath $resolvedFixture -Recurse -Force
+}
+
+Write-Host 'Windows Devbox startup lifecycle and source provenance contract checks passed.'

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -61,8 +61,18 @@ export const waitForServerReady = async ({
     }
 
     try {
-      const response = await fetch(healthUrl);
-      if (response.ok) {
+      const response = await fetch(healthUrl, { signal: AbortSignal.timeout(Math.max(1, Math.min(1000, deadline - Date.now()))) });
+      const reader = response.body?.getReader();
+      let text = "";
+      try {
+        while (reader) {
+          const chunk = await reader.read();
+          if (chunk.done) break;
+          text += new TextDecoder().decode(chunk.value);
+          if (text.length > 16) throw new Error("Unexpected health response body");
+        }
+      } finally { await reader?.cancel().catch(() => {}); }
+      if (response.ok && text.trim() === "ok") {
         return { healthUrl, status: response.status };
       }
       lastError = new Error(`health endpoint returned HTTP ${response.status}`);
@@ -70,7 +80,7 @@ export const waitForServerReady = async ({
       lastError = error;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    await new Promise((resolve) => setTimeout(resolve, Math.max(0, Math.min(pollIntervalMs, deadline - Date.now()))));
   }
 
   const detail = lastError instanceof Error && lastError.message ? ` Last error: ${lastError.message}` : "";

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -75,7 +75,9 @@ export const waitForServerReady = async ({
       if (response.ok && text.trim() === "ok") {
         return { healthUrl, status: response.status };
       }
-      lastError = new Error(`health endpoint returned HTTP ${response.status}`);
+      lastError = new Error(response.ok
+        ? `health endpoint returned HTTP ${response.status} with an unexpected body`
+        : `health endpoint returned HTTP ${response.status}`);
     } catch (error) {
       lastError = error;
     }

--- a/src/screen-capture.js
+++ b/src/screen-capture.js
@@ -63,8 +63,10 @@ const withCapturePolicy = async ({ signal, timeoutMs }, operation) =>
         lastError = error;
         if (attempt >= maxAttempts || !isTransientCaptureFailure(error)) throw error;
         const afterAttemptRemainingMs = deadlineMs - Date.now();
-        if (afterAttemptRemainingMs <= 0) throw error;
-        await abortableSleep(Math.min(retryBackoffMs, afterAttemptRemainingMs), signal);
+        // A timer may wake slightly before its requested deadline. Do not start
+        // another attempt when the remaining budget cannot fit the retry backoff.
+        if (afterAttemptRemainingMs <= retryBackoffMs) throw error;
+        await abortableSleep(retryBackoffMs, signal);
       }
     }
 

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -7,6 +7,18 @@ import { createServer } from "node:http";
 
 import { buildServerUrl, getLauncherPaths, getServerStatus, parseLauncherArgs, startServerProcess, stopServerProcess, waitForServerReady } from "../src/launcher.js";
 
+test("launcher deadline bounds stalled response headers and bodies", async () => {
+  for (const headers of [false, true]) {
+    const server = createServer((_request, response) => { if (headers) { response.writeHead(200); response.flushHeaders(); } });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const started = Date.now();
+    try {
+      await assert.rejects(waitForServerReady({ url: `http://127.0.0.1:${server.address().port}`, timeoutMs: 200, pollIntervalMs: 20 }), /Timed out/);
+      assert.ok(Date.now() - started < 1500, "health network read escaped the overall deadline");
+    } finally { server.closeAllConnections(); await new Promise(resolve => server.close(resolve)); }
+  }
+});
+
 test("parseLauncherArgs defaults to background start and supports explicit commands", () => {
   assert.deepEqual(parseLauncherArgs([]), { command: "start", background: true });
   assert.deepEqual(parseLauncherArgs(["start"]), { command: "start", background: true });

--- a/test/mcp-http.test.js
+++ b/test/mcp-http.test.js
@@ -152,7 +152,7 @@ const connectClient = async (t, port) => {
 };
 
 const assertJpegToolResult = (result) => {
-  assert.equal(result.isError, undefined);
+  assert.equal(result.isError, undefined, `Capture failed: ${JSON.stringify(result)}`);
   assert.equal(result.structuredContent?.ok, true);
   assert.equal(result.structuredContent?.data?.mime_type, "image/jpeg");
   assert.match(result.structuredContent?.data?.sha256 ?? "", /^[a-f0-9]{64}$/);


### PR DESCRIPTION
Devbox could block authenticated requests behind a stalled key server, lose checkpoints during direct writes, and duplicate detached work after a lost submission response. This change adds bounded OAuth key refresh, atomic host file replacement with conditional retry semantics, durable operation receipts, job discovery, revisioned task checkpoints, and admission limits before runner creation. Cancellation remains pending until owned processes are verified gone.

The Rust service now publishes a versioned 45-tool capability manifest while preserving the legacy 37-tool contract. Ordinary Windows Devbox commands honor the configured shell; explicit administrative host execution retains its existing policy. Managed production promotion rejects dirty or unproven source and verifies the executable's SHA, source tree and clean-build flag before replacement. Startup HTTP probes enforce deadlines across both headers and bodies. Runtime documentation and bootstrap Rust versions now match the certified profile.

Validation: 184 Windows Rust tests, strict Clippy, Windows startup and ownership contracts, JavaScript unit/MCP regression suites, 43-call local observable result parity, HTTP/OAuth/disconnect smokes, and native durable-agent recovery scenarios. CI additionally checks Windows/macOS/Linux behavior, MSRV, dependency audit, bootstrap binaries and platform deployment. The new native smoke covers concurrent duplicate submission, retained receipts, admission limits, checkpoint CAS, reconnect recovery, verified cancellation, bounded nested output and repeated Windows cold capture.

Durable submissions are host-runtime only. Docker cancellation stays pending while local processes live; after they stop it becomes terminal interrupted with workloadTerminationVerified=false, without claiming the shared-container workload stopped. Task records store client-owned plans and approvals; they do not grant authority or automatically replay uncertain operations. Production remains managed by Guardian with Rust as the execution service.


Review follow-up: job discovery has a five-second deadline and uses directory IDs for pagination; Unix lock directories/files are private and account-owned; oversized CMD commands fail clearly; cancellation tests poll for convergence; Windows workflow drift checks fail on either script. Atomic append retains complete-file staging as a documented integrity/performance tradeoff. Ordinary PowerShell keeps the ordinary configured-shell contract, and a client changed during OAuth authorization receives a direct invalid-client error.
